### PR TITLE
graceful leave for objstore

### DIFF
--- a/objectstore/ObjectStore.cpp
+++ b/objectstore/ObjectStore.cpp
@@ -921,7 +921,10 @@ public:
         }
     }
 
-    virtual void leave() {
+    virtual void leave(bool grace) {
+        if(grace) {
+            group.barrier_sync();
+        }
         group.leave();
     }
 

--- a/objectstore/ObjectStore.hpp
+++ b/objectstore/ObjectStore.hpp
@@ -59,8 +59,9 @@ public:
     virtual derecho::rpc::QueryResults<const Object> aio_get(const OID& oid, const version_t& ver = INVALID_VERSION, const bool& force_client = false) = 0;
     virtual derecho::rpc::QueryResults<const Object> aio_get(const OID& oid, const uint64_t& ts_us) = 0;
 
-
-    virtual void leave() = 0;  // leave gracefully
+    // leave
+    // @PARAM grace - leave gracefully if true (wait for other nodes), false otherwise. Default to true.
+    virtual void leave(bool grace = true) = 0;
     virtual const ObjectWatcher& getObjectWatcher() = 0;
 
     // get singleton

--- a/objectstore/performance.cpp
+++ b/objectstore/performance.cpp
@@ -91,6 +91,5 @@ int main(int argc, char** argv) {
     std::cout << "throughput:" << thp_mBps << "MB/s." << std::endl;
     std::cout << "throughput:" << thp_ops << "op/s." << std::endl;
     std::cout << std::flush;
-    while(true) {
-    }
+    oss.leave();
 }


### PR DESCRIPTION
`leave(bool grace = true)` now supports graceful leave.