### PR TITLE
Replaced p2p_connections_mutex with fine-grained locking

### DIFF
--- a/include/derecho/conf/conf.hpp
+++ b/include/derecho/conf/conf.hpp
@@ -35,6 +35,7 @@ private:
 #define CONF_DERECHO_RESTART_TIMEOUT_MS "DERECHO/restart_timeout_ms"
 #define CONF_DERECHO_ENABLE_BACKUP_RESTART_LEADERS "DERECHO/enable_backup_restart_leaders"
 #define CONF_DERECHO_DISABLE_PARTITIONING_SAFETY "DERECHO/disable_partitioning_safety"
+#define CONF_DERECHO_MAX_NODE_ID "DERECHO/max_node_id"
 
 #define CONF_DERECHO_MAX_P2P_REQUEST_PAYLOAD_SIZE "DERECHO/max_p2p_request_payload_size"
 #define CONF_DERECHO_MAX_P2P_REPLY_PAYLOAD_SIZE "DERECHO/max_p2p_reply_payload_size"
@@ -83,6 +84,7 @@ private:
 	        {CONF_DERECHO_MAX_P2P_REQUEST_PAYLOAD_SIZE, "10240"},
 	        {CONF_DERECHO_MAX_P2P_REPLY_PAYLOAD_SIZE, "10240"},
 	        {CONF_DERECHO_P2P_WINDOW_SIZE, "16"},
+            {CONF_DERECHO_MAX_NODE_ID, "1024"},
             // [SUBGROUP/<subgroupname>]
             {CONF_SUBGROUP_DEFAULT_MAX_PAYLOAD_SIZE, "10240"},
             {CONF_SUBGROUP_DEFAULT_MAX_REPLY_PAYLOAD_SIZE, "10240"},

--- a/include/derecho/core/detail/external_group_impl.hpp
+++ b/include/derecho/core/detail/external_group_impl.hpp
@@ -383,7 +383,7 @@ void ExternalGroup<ReplicatedTypes...>::p2p_receive_loop() {
 
     uint64_t max_payload_size = getConfUInt64(CONF_SUBGROUP_DEFAULT_MAX_PAYLOAD_SIZE);
 
-    request_worker_thread = std::thread(&ExternalGroup<ReplicatedTypes...>::fifo_worker, this);
+    request_worker_thread = std::thread(&ExternalGroup<ReplicatedTypes...>::p2p_request_worker, this);
 
     struct timespec last_time, cur_time;
     clock_gettime(CLOCK_REALTIME, &last_time);

--- a/include/derecho/core/detail/p2p_connection_manager.hpp
+++ b/include/derecho/core/detail/p2p_connection_manager.hpp
@@ -36,14 +36,25 @@ class P2PConnectionManager {
     const node_id_t my_node_id;
 
     RequestParams request_params;
-    // one element per member for P2P
-    std::map<node_id_t, std::unique_ptr<P2PConnection>> p2p_connections;
+    /**
+     * Contains one entry per possible Node ID; the vector index is the node ID.
+     * Each entry is a pair consisting of a mutex protecting that entry and a
+     * possibly-null pointer to a P2PConnection to the node ID indicated by the
+     * index. You must lock the mutex before accessing the pointer.
+     */
+    std::vector<std::pair<std::mutex, std::unique_ptr<P2PConnection>>> p2p_connections;
+    /**
+     * Contains one Boolean value for each entry in p2p_connections that serves
+     * as a hint for whether that entry is non-null. This can be used to check
+     * whether a connection exists without locking its mutex, but it can be
+     * wrong due to race conditions.
+     */
+    std::vector<bool> active_p2p_connections;
 
     uint64_t p2p_buf_size;
     std::atomic<bool> thread_shutdown{false};
     std::thread timeout_thread;
-    
-    node_id_t last_node_id;
+
     void check_failures_loop();
     failure_upcall_t failure_upcall;
     std::mutex connections_mutex;
@@ -56,7 +67,7 @@ public:
     bool contains_node(const node_id_t node_id);
     void shutdown_failures_thread();
     uint64_t get_max_p2p_reply_size();
-    void update_incoming_seq_num();
+    void update_incoming_seq_num(node_id_t node_id);
     std::optional<std::pair<node_id_t, char*>> probe_all();
     char* get_sendbuffer_ptr(node_id_t node_id, REQUEST_TYPE type);
     void send(node_id_t node_id);

--- a/include/derecho/core/detail/p2p_connection_manager.hpp
+++ b/include/derecho/core/detail/p2p_connection_manager.hpp
@@ -44,12 +44,16 @@ class P2PConnectionManager {
      */
     std::vector<std::pair<std::mutex, std::unique_ptr<P2PConnection>>> p2p_connections;
     /**
-     * Contains one Boolean value for each entry in p2p_connections that serves
-     * as a hint for whether that entry is non-null. This can be used to check
-     * whether a connection exists without locking its mutex, but it can be
-     * wrong due to race conditions.
+     * An array containing one Boolean value for each entry in p2p_connections
+     * that serves as a hint for whether that entry is non-null. The values are
+     * declared as char rather than bool to ensure they are each stored in
+     * exactly one byte. This can be used to check whether a connection exists
+     * without locking its mutex, but the hint can be wrong due to race
+     * conditions. Threads that write to this array should lock the
+     * corresponding mutex in p2p_connections before updating it to avoid lost
+     * updates from write conflicts.
      */
-    std::vector<bool> active_p2p_connections;
+    char* active_p2p_connections;
 
     uint64_t p2p_buf_size;
     std::atomic<bool> thread_shutdown{false};

--- a/include/derecho/core/detail/rpc_manager.hpp
+++ b/include/derecho/core/detail/rpc_manager.hpp
@@ -95,11 +95,7 @@ class RPCManager {
     /** Contains an RDMA connection to each member of the group. */
     std::unique_ptr<sst::P2PConnectionManager> connections;
 
-    /**
-     * This provides mutual exclusion between the P2P listening thread
-     * and the view-change thread, guarding the P2P connections pointer.
-     */
-    std::mutex p2p_connections_mutex;
+
     /** This mutex guards both toFulfillQueue and fulfilledList. */
     std::mutex pending_results_mutex;
     /** This condition variable is to resolve a race condition in using ToFulfillQueue and fulfilledList */

--- a/include/derecho/core/external_group.hpp
+++ b/include/derecho/core/external_group.hpp
@@ -65,28 +65,28 @@ private:
 
     /** ======================== copy/paste from rpc_manager ======================== **/
     std::atomic<bool> thread_shutdown{false};
-    std::thread rpc_thread;
+    std::thread rpc_listener_thread;
     /** p2p send and queries are queued in fifo worker */
-    std::thread fifo_worker_thread;
-    struct fifo_req {
+    std::thread request_worker_thread;
+    struct p2p_req {
         node_id_t sender_id;
         char* msg_buf;
         uint32_t buffer_size;
-        fifo_req() : sender_id(0),
+        p2p_req() : sender_id(0),
                      msg_buf(nullptr),
                      buffer_size(0) {}
-        fifo_req(node_id_t _sender_id,
+        p2p_req(node_id_t _sender_id,
                  char* _msg_buf,
                  uint32_t _buffer_size) : sender_id(_sender_id),
                                           msg_buf(_msg_buf),
                                           buffer_size(_buffer_size) {}
     };
-    std::queue<fifo_req> fifo_queue;
-    std::mutex fifo_queue_mutex;
-    std::condition_variable fifo_queue_cv;
+    std::queue<p2p_req> p2p_request_queue;
+    std::mutex request_queue_mutex;
+    std::condition_variable request_queue_cv;
     mutils::RemoteDeserialization_v rdv;
     void p2p_receive_loop();
-    void fifo_worker();
+    void p2p_request_worker();
     void p2p_message_handler(node_id_t sender_id, char* msg_buf, uint32_t buffer_size);
     std::exception_ptr receive_message(const rpc::Opcode& indx, const node_id_t& received_from,
                                        char const* const buf, std::size_t payload_size,

--- a/include/derecho/core/external_group.hpp
+++ b/include/derecho/core/external_group.hpp
@@ -43,7 +43,6 @@ private:
     std::unique_ptr<View> prev_view;
     std::unique_ptr<View> curr_view;
     std::unique_ptr<sst::P2PConnectionManager> p2p_connections;
-    std::mutex p2p_connections_mutex;
     std::unique_ptr<std::map<rpc::Opcode, rpc::receive_fun_t>> receivers;
     std::map<subgroup_id_t, std::list<rpc::PendingBase_ref>> fulfilled_pending_results;
     std::map<subgroup_id_t, uint64_t> max_payload_sizes;
@@ -55,7 +54,7 @@ private:
     /**
      * requests a new view from group member nid
      * if nid is -1, then request a view from CONF_DERECHO_LEADER_IP
-     * defined in derecho.cfg 
+     * defined in derecho.cfg
      */
     bool get_view(const node_id_t nid);
     void clean_up();

--- a/src/conf/conf.cpp
+++ b/src/conf/conf.cpp
@@ -2,6 +2,7 @@
 #include <cstdlib>
 #include <sys/stat.h>
 #include <unistd.h>
+#include <stdexcept>
 #ifndef NDEBUG
 #include <spdlog/sinks/stdout_color_sinks.h>
 #endif  //NDEBUG
@@ -50,6 +51,7 @@ struct option Conf::long_options[] = {
 	    MAKE_LONG_OPT_ENTRY(CONF_DERECHO_MAX_P2P_REQUEST_PAYLOAD_SIZE),
 	    MAKE_LONG_OPT_ENTRY(CONF_DERECHO_MAX_P2P_REPLY_PAYLOAD_SIZE),
 	    MAKE_LONG_OPT_ENTRY(CONF_DERECHO_P2P_WINDOW_SIZE),
+        MAKE_LONG_OPT_ENTRY(CONF_DERECHO_MAX_NODE_ID),
         // [SUBGROUP/<subgroup name>]
         MAKE_LONG_OPT_ENTRY(CONF_SUBGROUP_DEFAULT_RDMC_SEND_ALGORITHM),
         MAKE_LONG_OPT_ENTRY(CONF_SUBGROUP_DEFAULT_MAX_PAYLOAD_SIZE),
@@ -101,6 +103,11 @@ void Conf::initialize(int argc, char* argv[], const char* conf_file) {
 
         // 3 - set the flag to initialized
         Conf::singleton_initialized_flag.store(CONF_INITIALIZED, std::memory_order_acq_rel);
+
+
+        if(getConfUInt32(CONF_DERECHO_LOCAL_ID) >= getConfUInt32(CONF_DERECHO_MAX_NODE_ID)) {
+            throw std::logic_error("Configuration error: Local node ID must be less than max node ID");
+        }
     }
 }
 

--- a/src/conf/derecho-sample.cfg
+++ b/src/conf/derecho-sample.cfg
@@ -23,6 +23,13 @@ sst_port = 37683
 rdmc_port = 31675
 # externel tcp port listening to external clients
 external_port = 32645
+# Maximum possible node ID value
+# Node IDs are 32-bit integers, but all Derecho systems will have
+# many fewer nodes than this. Derecho will pre-allocate space for a
+# P2P connection for each possible node ID, each of which is about
+# 48 bytes, so keeping the maximum node ID value as low as possible
+# saves memory.
+max_node_id = 1024
 # this is the frequency of the failure detector thread for MulticastGroup and P2PConnectionManager.
 # It is best to leave this to 1 ms for RDMA. If it is too high,
 # you run the risk of overflowing the queue of outstanding sends.

--- a/src/core/git_version.cpp
+++ b/src/core/git_version.cpp
@@ -13,8 +13,8 @@ namespace derecho {
 const int MAJOR_VERSION = 2;
 const int MINOR_VERSION = 1;
 const int PATCH_VERSION = 0;
-const int COMMITS_AHEAD_OF_VERSION = 96;
+const int COMMITS_AHEAD_OF_VERSION = 97;
 const char* VERSION_STRING = "2.1.0";
-const char* VERSION_STRING_PLUS_COMMITS = "2.1.0+96";
+const char* VERSION_STRING_PLUS_COMMITS = "2.1.0+97";
 
 }

--- a/src/core/git_version.cpp
+++ b/src/core/git_version.cpp
@@ -13,8 +13,8 @@ namespace derecho {
 const int MAJOR_VERSION = 2;
 const int MINOR_VERSION = 1;
 const int PATCH_VERSION = 0;
-const int COMMITS_AHEAD_OF_VERSION = 92;
+const int COMMITS_AHEAD_OF_VERSION = 93;
 const char* VERSION_STRING = "2.1.0";
-const char* VERSION_STRING_PLUS_COMMITS = "2.1.0+92";
+const char* VERSION_STRING_PLUS_COMMITS = "2.1.0+93";
 
 }

--- a/src/core/git_version.cpp
+++ b/src/core/git_version.cpp
@@ -13,8 +13,8 @@ namespace derecho {
 const int MAJOR_VERSION = 2;
 const int MINOR_VERSION = 1;
 const int PATCH_VERSION = 0;
-const int COMMITS_AHEAD_OF_VERSION = 95;
+const int COMMITS_AHEAD_OF_VERSION = 96;
 const char* VERSION_STRING = "2.1.0";
-const char* VERSION_STRING_PLUS_COMMITS = "2.1.0+95";
+const char* VERSION_STRING_PLUS_COMMITS = "2.1.0+96";
 
 }

--- a/src/core/git_version.cpp
+++ b/src/core/git_version.cpp
@@ -13,8 +13,8 @@ namespace derecho {
 const int MAJOR_VERSION = 2;
 const int MINOR_VERSION = 1;
 const int PATCH_VERSION = 0;
-const int COMMITS_AHEAD_OF_VERSION = 93;
+const int COMMITS_AHEAD_OF_VERSION = 95;
 const char* VERSION_STRING = "2.1.0";
-const char* VERSION_STRING_PLUS_COMMITS = "2.1.0+93";
+const char* VERSION_STRING_PLUS_COMMITS = "2.1.0+95";
 
 }

--- a/src/core/p2p_connection_manager.cpp
+++ b/src/core/p2p_connection_manager.cpp
@@ -35,6 +35,7 @@ P2PConnectionManager::P2PConnectionManager(const P2PParams params)
     p2p_buf_size += sizeof(bool);
 
     p2p_connections[my_node_id].second = std::make_unique<P2PConnection>(my_node_id, my_node_id, p2p_buf_size, request_params);
+    active_p2p_connections[my_node_id] = true;
 
     // external client doesn't need failure checking
     if(!params.is_external) {

--- a/src/core/rpc_manager.cpp
+++ b/src/core/rpc_manager.cpp
@@ -213,11 +213,8 @@ void RPCManager::p2p_message_handler(node_id_t sender_id, char* msg_buf, uint32_
 
 //This is always called while holding a write lock on view_manager.view_mutex
 void RPCManager::new_view_callback(const View& new_view) {
-    {
-        std::lock_guard<std::mutex> connections_lock(p2p_connections_mutex);
-        connections->remove_connections(new_view.departed);
-        connections->add_connections(new_view.members);
-    }
+    connections->remove_connections(new_view.departed);
+    connections->add_connections(new_view.members);
     dbg_default_debug("Created new connections among the new view members");
     std::lock_guard<std::mutex> lock(pending_results_mutex);
     for(auto& fulfilled_pending_results_pair : fulfilled_pending_results) {
@@ -247,7 +244,6 @@ void RPCManager::new_view_callback(const View& new_view) {
 }
 
 void RPCManager::add_connections(const std::vector<uint32_t>& node_ids) {
-    std::lock_guard<std::mutex> connections_lock(p2p_connections_mutex);
     connections->add_connections(node_ids);
 }
 
@@ -262,8 +258,8 @@ volatile char* RPCManager::get_sendbuffer_ptr(uint32_t dest_id, sst::REQUEST_TYP
     volatile char* buf;
     int curr_vid = -1;
     do {
-        //ViewManager's view_mutex also prevents connections from being reassigned (because
-        //that happens in new_view_callback), so we don't need p2p_connections_mutex
+        //ViewManager's view_mutex also prevents connections from being removed (because
+        //that happens in new_view_callback)
         SharedLockedReference<View> view_and_lock = view_manager.get_current_view();
         //Check to see if the view changed between iterations of the loop, and re-get the rank
         if(curr_vid != view_and_lock.get().vid) {
@@ -281,8 +277,8 @@ volatile char* RPCManager::get_sendbuffer_ptr(uint32_t dest_id, sst::REQUEST_TYP
 
 void RPCManager::finish_p2p_send(node_id_t dest_id, subgroup_id_t dest_subgroup_id, PendingBase& pending_results_handle) {
     try {
-        //ViewManager's view_mutex also prevents connections from being reassigned (because
-        //that happens in new_view_callback), so we don't need p2p_connections_mutex
+        //ViewManager's view_mutex also prevents connections from being removed (because
+        //that happens in new_view_callback)
         SharedLockedReference<View> view_and_lock = view_manager.get_current_view();
         connections->send(dest_id);
     } catch(std::out_of_range& map_error) {
@@ -361,26 +357,33 @@ void RPCManager::p2p_receive_loop() {
 
     // loop event
     while(!thread_shutdown) {
-        std::unique_lock<std::mutex> connections_lock(p2p_connections_mutex);
-        auto optional_reply_pair = connections->probe_all();
-        if(optional_reply_pair) {
-            auto reply_pair = optional_reply_pair.value();
-            if(reply_pair.first != INVALID_NODE_ID) {
-                p2p_message_handler(reply_pair.first, (char*)reply_pair.second, max_payload_size);
-                connections->update_incoming_seq_num();
+        bool message_received = false;
+        // This scope contains a lock on the View, which prevents view changes during
+        // delivery of a P2P message (otherwise, a View change could occur between a
+        // successful probe_all() and the call to p2p_message_handler)
+        {
+            SharedLockedReference<View> locked_view = view_manager.get_current_view();
+            auto optional_reply_pair = connections->probe_all();
+            if(optional_reply_pair) {
+                message_received = true;
+                auto reply_pair = optional_reply_pair.value();
+                if(reply_pair.first != INVALID_NODE_ID) {
+                    p2p_message_handler(reply_pair.first, (char*)reply_pair.second, max_payload_size);
+                    connections->update_incoming_seq_num(reply_pair.first);
+                }
+                // update last time
+                clock_gettime(CLOCK_REALTIME, &last_time);
             }
-            // update last time
-            clock_gettime(CLOCK_REALTIME, &last_time);
-        } else {
+        }
+        //Release the View lock before going to sleep if no messages were received
+        if(!message_received) {
             clock_gettime(CLOCK_REALTIME, &cur_time);
             // check if the system has been inactive for enough time to induce sleep
             double time_elapsed_in_ms = (cur_time.tv_sec - last_time.tv_sec) * 1e3
                                         + (cur_time.tv_nsec - last_time.tv_nsec) / 1e6;
             if(time_elapsed_in_ms > 1) {
-                connections_lock.unlock();
                 using namespace std::chrono_literals;
                 std::this_thread::sleep_for(1ms);
-                connections_lock.lock();
             }
         }
     }


### PR DESCRIPTION
As discussed in the issue report for #195, the "one big lock" on P2PConnectionsManager within RPCManager was vulnerable to deadlocks. One solution is to make the P2P connections a fixed-size array with a separate lock for each P2P connection, so that unrelated add and remove operations don't block each other. I've implemented that solution and tested it to ensure P2P requests still work in normal operation. When merged, this should fix #195.