### PR TITLE
Migrate to libfabric 1.12.1

### DIFF
--- a/include/derecho/rdmc/detail/lf_helper.hpp
+++ b/include/derecho/rdmc/detail/lf_helper.hpp
@@ -299,7 +299,7 @@ bool lf_initialize(const std::map<uint32_t, std::pair<ip_addr_t, uint16_t>>& ip_
                    uint32_t node_rank);
 bool lf_add_connection(uint32_t new_id, const std::pair<ip_addr_t, uint16_t>& new_ip_addr_and_port);
 bool lf_remove_connection(uint32_t node_id);
-bool lf_destroy();
+void lf_destroy();
 
 std::map<uint32_t, remote_memory_region> lf_exchange_memory_regions(
         const std::vector<uint32_t>& members, uint32_t node_rank,

--- a/scripts/prerequisites/install-libfabric.sh
+++ b/scripts/prerequisites/install-libfabric.sh
@@ -13,7 +13,8 @@ cd ${WORKPATH}
 git clone https://github.com/ofiwg/libfabric.git
 cd libfabric
 #git checkout fcf0f2ec3c7109e06e09d3650564df8d2dfa12b6
-git checkout tags/v1.7.0
+#git checkout tags/v1.7.0
+git checkout tags/v1.12.1
 libtoolize
 ./autogen.sh
 ./configure --prefix=${INSTALL_PREFIX} --disable-mlx

--- a/scripts/prerequisites/install-libfabric.sh
+++ b/scripts/prerequisites/install-libfabric.sh
@@ -17,6 +17,6 @@ cd libfabric
 git checkout tags/v1.12.1
 libtoolize
 ./autogen.sh
-./configure --prefix=${INSTALL_PREFIX} --disable-mlx
+./configure --prefix=${INSTALL_PREFIX} --disable-memhooks-monitor
 make -j `lscpu | grep "^CPU(" | awk '{print $2}'`
 make install

--- a/src/rdmc/lf_helper.cpp
+++ b/src/rdmc/lf_helper.cpp
@@ -379,7 +379,10 @@ bool endpoint::post_send(const memory_region& mr, size_t offset, size_t size,
     msg_iov.iov_len = size;
 
     msg.msg_iov = &msg_iov;
-    msg.desc = (void**)&mr.mr->key;
+    // in v1.12.1, this API spec changed.
+    // msg.desc = (void**)&mr.mr->key;
+    void *desc = fi_mr_desc(mr.mr.get());
+    msg.desc = &desc;
     msg.iov_count = 1;
     msg.addr = 0;
     msg.context = (void*)(wr_id | ((uint64_t)*type.tag << type.shift_bits) | ((uint64_t)RDMA_OP_SEND) << OP_BITS_SHIFT);
@@ -400,7 +403,10 @@ bool endpoint::post_recv(const memory_region& mr, size_t offset, size_t size,
     msg_iov.iov_len = size;
 
     msg.msg_iov = &msg_iov;
-    msg.desc = (void**)&mr.mr->key;
+    // in v1.12.1, this API spec changed.
+    // msg.desc = (void**)&mr.mr->key;
+    void *desc = fi_mr_desc(mr.mr.get());
+    msg.desc = &desc;
     msg.iov_count = 1;
     msg.addr = 0;
     msg.context = (void*)(wr_id | ((uint64_t)*type.tag << type.shift_bits) | ((uint64_t)RDMA_OP_RECV) << OP_BITS_SHIFT);
@@ -461,7 +467,10 @@ bool endpoint::post_write(const memory_region& mr, size_t offset, size_t size,
     rma_iov.key = remote_mr.rkey;
 
     msg.msg_iov = &msg_iov;
-    msg.desc = (void**)&mr.mr->key;
+    // in v1.12.1, this API spec changed.
+    // msg.desc = (void**)&mr.mr->key;
+    void *desc = fi_mr_desc(mr.mr.get());
+    msg.desc = &desc;
     msg.iov_count = 1;
     msg.addr = 0;
     msg.rma_iov = &rma_iov;

--- a/src/rdmc/rdmc.cpp
+++ b/src/rdmc/rdmc.cpp
@@ -95,7 +95,14 @@ void destroy_group(uint16_t group_number) {
     LOG_EVENT(group_number, -1, -1, "destroy_group");
     groups.erase(group_number);
 }
-void shutdown() { shutdown_flag = true; }
+void shutdown() { 
+    shutdown_flag = true; 
+#ifdef USE_VERBS_API
+    ::rdma::impl::verbs_destroy();
+#else
+    ::rdma::impl::lf_destroy();
+#endif
+}
 bool send(uint16_t group_number, shared_ptr<memory_region> mr, size_t offset,
           size_t length) {
     if(shutdown_flag) return false;

--- a/src/sst/lf.cpp
+++ b/src/sst/lf.cpp
@@ -395,7 +395,10 @@ int _resources::post_remote_send(
         msg_iov.iov_len = size;
 
         msg.msg_iov = &msg_iov;
-        msg.desc = (void**)&this->mr_lrkey;
+        // in v1.12.1, the API spec changed.
+        // msg.desc = (void**)&this->mr_lrkey;
+        void *desc = fi_mr_desc(this->read_mr);
+        msg.desc = &desc;
         msg.iov_count = 1;
         msg.addr = 0;
         msg.context = (void*)ctxt;
@@ -417,7 +420,10 @@ int _resources::post_remote_send(
         rma_iov.key = this->mr_rwkey;
 
         msg.msg_iov = &msg_iov;
-        msg.desc = (void**)&this->mr_lrkey;
+        // in v1.12.1, this API changed.
+        // msg.desc = (void**)&this->mr_lrkey;
+        void *desc = fi_mr_desc(this->read_mr);
+        msg.desc = &desc;
         msg.iov_count = 1;
         msg.addr = 0;  // not used for a connection endpoint
         msg.rma_iov = &rma_iov;
@@ -565,7 +571,10 @@ int resources_two_sided::post_receive(lf_sender_ctxt* ctxt, const long long int 
     msg_iov.iov_len = size;
 
     msg.msg_iov = &msg_iov;
-    msg.desc = (void**)&this->mr_lwkey;
+    // v1.12.1 changed API spec
+    // msg.desc = (void**)&this->mr_lwkey;
+    void *desc = fi_mr_desc(this->write_mr);
+    msg.desc = &desc;
     msg.iov_count = 1;
     msg.addr = 0;  // not used
     msg.context = (void*)ctxt;


### PR DESCRIPTION
The libfabric 1.7.0 is too old. This branch adopts the latest libfabric v1.12.1. The new libfabric is incorporated with the following new useful features for derecho.
1) The new "tcp" provider replacing deprecated "sockets" provider. It *alleviates* the sequential consistency issue. Cascade is now working with it.
2) The awkward "desc" argument for `fi_write/fi_writemsg` and similar APIs in `fi_rma` module, which has been used to pass memory region keys, is replaced by a solid entity called "descriptor". To get the descriptor, just call `fi_mr_desc()` on a memory region fid.
3) the new v1.12.1 release seems to support GPU Direct, which will be required in Cascade data path enhancement.

@etremel I'm considering including this feature in release r2.2.