### PR TITLE
Fix bugs identified in issue #205

### DIFF
--- a/include/derecho/core/detail/external_group_impl.hpp
+++ b/include/derecho/core/detail/external_group_impl.hpp
@@ -14,7 +14,7 @@ template <typename T, typename ExternalGroupType>
 template <rpc::FunctionTag tag, typename... Args>
 auto ExternalClientCaller<T, ExternalGroupType>::p2p_send(node_id_t dest_node, Args&&... args) {
     if(!group.p2p_connections->contains_node(dest_node)) {
-        dbg_default_info("p2p connection to {} is not establised yet, establishing right now.", dest_node);
+        dbg_default_info("p2p connection to {} is not established yet, establishing right now.", dest_node);
         int rank = group.curr_view->rank_of(dest_node);
         if(rank == -1) {
             throw invalid_node_exception("Cannot send a p2p request to node "
@@ -61,14 +61,14 @@ auto ExternalClientCaller<T, ExternalGroupType>::p2p_send(node_id_t dest_node, A
             },
             std::forward<Args>(args)...);
     group.finish_p2p_send(dest_node, subgroup_id, return_pair.pending);
-    return std::move(return_pair.results);
+    return std::move(*return_pair.results);
 }
 
 template <typename... ReplicatedTypes>
 ExternalGroup<ReplicatedTypes...>::ExternalGroup(std::vector<DeserializationContext*> deserialization_contexts)
         : my_id(getConfUInt32(CONF_DERECHO_LOCAL_ID)),
           receivers(new std::decay_t<decltype(*receivers)>()) {
-    for(auto dc:deserialization_contexts) {
+    for(auto dc : deserialization_contexts) {
         rdv.push_back(dc);
     }
 #ifdef USE_VERBS_API
@@ -150,7 +150,7 @@ bool ExternalGroup<ReplicatedTypes...>::get_view(const node_id_t nid) {
         prev_view = std::move(curr_view);
         curr_view = mutils::from_bytes<View>(nullptr, buffer);
     } catch(tcp::connection_failure&) {
-        dbg_default_error("Failed to connect to group member {} when reqeusting new view.", nid);
+        dbg_default_error("Failed to connect to group member {} when requesting new view.", nid);
         dbg_default_flush();
         return false;
     } catch(tcp::socket_error&) {
@@ -176,10 +176,8 @@ void ExternalGroup<ReplicatedTypes...>::clean_up() {
         //the subgroup, and call set_exception_for_removed_node for the departed nodes
         for(auto pending_results_iter = fulfilled_pending_results_pair.second.begin();
             pending_results_iter != fulfilled_pending_results_pair.second.end();) {
-            //Garbage-collect PendingResults references that are obsolete
-            if(pending_results_iter->get().all_responded()) {
-                pending_results_iter = fulfilled_pending_results_pair.second.erase(pending_results_iter);
-            } else {
+            std::shared_ptr<AbstractPendingResults> live_pending_results = pending_results_iter->lock();
+            if(live_pending_results && !live_pending_results->all_responded()) {
                 for(uint32_t shard_num = 0;
                     shard_num < curr_view->subgroup_shard_views[subgroup_id].size();
                     ++shard_num) {
@@ -187,10 +185,13 @@ void ExternalGroup<ReplicatedTypes...>::clean_up() {
                         //This will do nothing if removed_id was never in the
                         //shard this PendingResult corresponds to
                         dbg_default_debug("Setting exception for removed node {} on PendingResults for subgroup {}, shard {}", removed_id, subgroup_id, shard_num);
-                        pending_results_iter->get().set_exception_for_removed_node(removed_id);
+                        live_pending_results->set_exception_for_removed_node(removed_id);
                     }
                 }
                 pending_results_iter++;
+            } else {
+                //Garbage-collect PendingResults pointers that are obsolete
+                pending_results_iter = fulfilled_pending_results_pair.second.erase(pending_results_iter);
             }
         }
     }
@@ -252,14 +253,17 @@ volatile char* ExternalGroup<ReplicatedTypes...>::get_sendbuffer_ptr(uint32_t de
 }
 
 template <typename... ReplicatedTypes>
-void ExternalGroup<ReplicatedTypes...>::finish_p2p_send(node_id_t dest_id, subgroup_id_t dest_subgroup_id, rpc::PendingBase& pending_results_handle) {
+void ExternalGroup<ReplicatedTypes...>::finish_p2p_send(node_id_t dest_id, subgroup_id_t dest_subgroup_id, std::weak_ptr<rpc::AbstractPendingResults> pending_results_handle) {
     try {
         p2p_connections->send(dest_id);
     } catch(std::out_of_range& map_error) {
         throw node_removed_from_group_exception(dest_id);
     }
-    pending_results_handle.fulfill_map({dest_id});
-    fulfilled_pending_results[dest_subgroup_id].push_back(pending_results_handle);
+    std::shared_ptr<AbstractPendingResults> pending_results = pending_results_handle.lock();
+    if(pending_results) {
+        pending_results->fulfill_map({dest_id});
+        fulfilled_pending_results[dest_subgroup_id].push_back(pending_results_handle);
+    }
 }
 
 template <typename... ReplicatedTypes>
@@ -427,34 +431,34 @@ uint32_t ExternalGroup<ReplicatedTypes...>::get_index_of_type(const std::type_in
     //return index_of_type<SubgroupType, ReplicatedTypes...>;
 }
 
-template <typename...ReplicatedTypes>
+template <typename... ReplicatedTypes>
 template <typename SubgroupType>
 uint32_t ExternalGroup<ReplicatedTypes...>::get_index_of_type() const {
     return get_index_of_type(typeid(SubgroupType));
 }
 
-template <typename...ReplicatedTypes>
+template <typename... ReplicatedTypes>
 template <typename SubgroupType>
 uint32_t ExternalGroup<ReplicatedTypes...>::get_number_of_subgroups() const {
     uint32_t type_idx = this->template get_index_of_type<SubgroupType>();
-    if (curr_view->subgroup_ids_by_type_id.find(type_idx) != curr_view->subgroup_ids_by_type_id.end()){
+    if(curr_view->subgroup_ids_by_type_id.find(type_idx) != curr_view->subgroup_ids_by_type_id.end()) {
         return curr_view->subgroup_ids_by_type_id.at(type_idx).size();
     }
     return 0;
 }
 
-template <typename...ReplicatedTypes>
+template <typename... ReplicatedTypes>
 uint32_t ExternalGroup<ReplicatedTypes...>::get_number_of_shards(uint32_t subgroup_id) const {
-    if (subgroup_id < curr_view->subgroup_shard_views.size()) {
+    if(subgroup_id < curr_view->subgroup_shard_views.size()) {
         return curr_view->subgroup_shard_views[subgroup_id].size();
     }
     return 0;
 }
 
-template <typename...ReplicatedTypes>
+template <typename... ReplicatedTypes>
 template <typename SubgroupType>
 uint32_t ExternalGroup<ReplicatedTypes...>::get_number_of_shards(uint32_t subgroup_index) const {
-    if (subgroup_index < this->template get_number_of_subgroups<SubgroupType>()) {
+    if(subgroup_index < this->template get_number_of_subgroups<SubgroupType>()) {
         return get_number_of_shards(curr_view->subgroup_ids_by_type_id.at(this->template get_index_of_type<SubgroupType>())[subgroup_index]);
     }
     return 0;

--- a/include/derecho/core/detail/replicated_impl.hpp
+++ b/include/derecho/core/detail/replicated_impl.hpp
@@ -155,8 +155,6 @@ auto Replicated<T>::ordered_send(Args&&... args) {
                     ->multicast_group->send(subgroup_id, payload_size_for_multicast_send, serializer, true);
         });
         group_rpc_manager.finish_rpc_send(subgroup_id, pending_ptr);
-        //Warning: Even though the move-constructor will clean up all the state in *results_ptr, this
-        //still leaks the memory allocated on the heap by new QueryResults<Ret>() in the serializer lambda
         return std::move(*results_ptr);
     } else {
         throw empty_reference_exception{"Attempted to use an empty Replicated<T>"};

--- a/include/derecho/core/detail/replicated_impl.hpp
+++ b/include/derecho/core/detail/replicated_impl.hpp
@@ -115,7 +115,7 @@ auto Replicated<T>::p2p_send(node_id_t dest_node, Args&&... args) const {
                 },
                 std::forward<Args>(args)...);
         group_rpc_manager.finish_p2p_send(dest_node, subgroup_id, return_pair.pending);
-        return std::move(return_pair.results);
+        return std::move(*return_pair.results);
     } else {
         throw empty_reference_exception{"Attempted to use an empty Replicated<T>"};
     }
@@ -130,8 +130,8 @@ auto Replicated<T>::ordered_send(Args&&... args) {
         using Ret = typename std::remove_pointer<decltype(wrapped_this->template getReturnType<rpc::to_internal_tag<false>(tag)>(
                 std::forward<Args>(args)...))>::type;
         //These pointers help "return" the PendingResults/QueryResults out of the lambda
-        rpc::QueryResults<Ret>* results_ptr;
-        rpc::PendingResults<Ret>* pending_ptr;
+        std::unique_ptr<rpc::QueryResults<Ret>> results_ptr;
+        std::weak_ptr<rpc::PendingResults<Ret>> pending_ptr;
         auto serializer = [&](char* buffer) {
             //By the time this lambda runs, the current thread will be holding a read lock on view_mutex
             const std::size_t max_payload_size = group_rpc_manager.view_manager.get_max_payload_sizes().at(subgroup_id);
@@ -145,8 +145,8 @@ auto Replicated<T>::ordered_send(Args&&... args) {
                         }
                     },
                     std::forward<Args>(args)...);
-            results_ptr = new rpc::QueryResults<Ret>(std::move(send_return_struct.results));
-            pending_ptr = &send_return_struct.pending;
+            results_ptr = std::move(send_return_struct.results);
+            pending_ptr = send_return_struct.pending;
         };
 
         std::shared_lock<std::shared_timed_mutex> view_read_lock(group_rpc_manager.view_manager.view_mutex);
@@ -154,7 +154,7 @@ auto Replicated<T>::ordered_send(Args&&... args) {
             return group_rpc_manager.view_manager.curr_view
                     ->multicast_group->send(subgroup_id, payload_size_for_multicast_send, serializer, true);
         });
-        group_rpc_manager.finish_rpc_send(subgroup_id, *pending_ptr);
+        group_rpc_manager.finish_rpc_send(subgroup_id, pending_ptr);
         //Warning: Even though the move-constructor will clean up all the state in *results_ptr, this
         //still leaks the memory allocated on the heap by new QueryResults<Ret>() in the serializer lambda
         return std::move(*results_ptr);
@@ -312,7 +312,7 @@ auto ExternalCaller<T>::p2p_send(node_id_t dest_node, Args&&... args) {
                 },
                 std::forward<Args>(args)...);
         group_rpc_manager.finish_p2p_send(dest_node, subgroup_id, return_pair.pending);
-        return std::move(return_pair.results);
+        return std::move(*return_pair.results);
     } else {
         throw empty_reference_exception{"Attempted to use an empty Replicated<T>"};
     }

--- a/include/derecho/core/external_group.hpp
+++ b/include/derecho/core/external_group.hpp
@@ -44,7 +44,7 @@ private:
     std::unique_ptr<View> curr_view;
     std::unique_ptr<sst::P2PConnectionManager> p2p_connections;
     std::unique_ptr<std::map<rpc::Opcode, rpc::receive_fun_t>> receivers;
-    std::map<subgroup_id_t, std::list<rpc::PendingBase_ref>> fulfilled_pending_results;
+    std::map<subgroup_id_t, std::list<std::weak_ptr<AbstractPendingResults>>> fulfilled_pending_results;
     std::map<subgroup_id_t, uint64_t> max_payload_sizes;
 
     template <typename T>
@@ -59,7 +59,7 @@ private:
     bool get_view(const node_id_t nid);
     void clean_up();
     volatile char* get_sendbuffer_ptr(uint32_t dest_id, sst::REQUEST_TYPE type);
-    void finish_p2p_send(node_id_t dest_id, subgroup_id_t dest_subgroup_id, rpc::PendingBase& pending_results_handle);
+    void finish_p2p_send(node_id_t dest_id, subgroup_id_t dest_subgroup_id, std::weak_ptr<AbstractPendingResults> pending_results_handle);
     uint32_t get_index_of_type(const std::type_info& ti) const;
 
 

--- a/src/core/git_version.cpp
+++ b/src/core/git_version.cpp
@@ -13,8 +13,8 @@ namespace derecho {
 const int MAJOR_VERSION = 2;
 const int MINOR_VERSION = 2;
 const int PATCH_VERSION = 0;
-const int COMMITS_AHEAD_OF_VERSION = 3;
+const int COMMITS_AHEAD_OF_VERSION = 4;
 const char* VERSION_STRING = "2.2.0";
-const char* VERSION_STRING_PLUS_COMMITS = "2.2.0+3";
+const char* VERSION_STRING_PLUS_COMMITS = "2.2.0+4";
 
 }

--- a/src/core/git_version.cpp
+++ b/src/core/git_version.cpp
@@ -13,8 +13,8 @@ namespace derecho {
 const int MAJOR_VERSION = 2;
 const int MINOR_VERSION = 2;
 const int PATCH_VERSION = 0;
-const int COMMITS_AHEAD_OF_VERSION = 2;
+const int COMMITS_AHEAD_OF_VERSION = 3;
 const char* VERSION_STRING = "2.2.0";
-const char* VERSION_STRING_PLUS_COMMITS = "2.2.0+2";
+const char* VERSION_STRING_PLUS_COMMITS = "2.2.0+3";
 
 }

--- a/src/core/git_version.cpp
+++ b/src/core/git_version.cpp
@@ -13,8 +13,8 @@ namespace derecho {
 const int MAJOR_VERSION = 2;
 const int MINOR_VERSION = 2;
 const int PATCH_VERSION = 0;
-const int COMMITS_AHEAD_OF_VERSION = 0;
+const int COMMITS_AHEAD_OF_VERSION = 1;
 const char* VERSION_STRING = "2.2.0";
-const char* VERSION_STRING_PLUS_COMMITS = "2.2.0+0";
+const char* VERSION_STRING_PLUS_COMMITS = "2.2.0+1";
 
 }

--- a/src/core/git_version.cpp
+++ b/src/core/git_version.cpp
@@ -13,8 +13,8 @@ namespace derecho {
 const int MAJOR_VERSION = 2;
 const int MINOR_VERSION = 2;
 const int PATCH_VERSION = 0;
-const int COMMITS_AHEAD_OF_VERSION = 1;
+const int COMMITS_AHEAD_OF_VERSION = 2;
 const char* VERSION_STRING = "2.2.0";
-const char* VERSION_STRING_PLUS_COMMITS = "2.2.0+1";
+const char* VERSION_STRING_PLUS_COMMITS = "2.2.0+2";
 
 }

--- a/src/core/rpc_manager.cpp
+++ b/src/core/rpc_manager.cpp
@@ -64,11 +64,17 @@ void RPCManager::destroy_remote_invocable_class(uint32_t instance_id) {
     //would already have been deleted.
     std::lock_guard<std::mutex> lock(pending_results_mutex);
     while(!pending_results_to_fulfill[instance_id].empty()) {
-        pending_results_to_fulfill[instance_id].front().get().set_exception_for_caller_removed();
+        std::shared_ptr<AbstractPendingResults> pending_results = pending_results_to_fulfill[instance_id].front().lock();
+        if(pending_results) {
+            pending_results->set_exception_for_caller_removed();
+        }
         pending_results_to_fulfill[instance_id].pop();
     }
     for(auto& pending_results_pair : results_awaiting_local_persistence[instance_id]) {
-        pending_results_pair.second.get().set_exception_for_caller_removed();
+        std::shared_ptr<AbstractPendingResults> pending_results = pending_results_pair.second.lock();
+        if(pending_results) {
+            pending_results->set_exception_for_caller_removed();
+        }
     }
     results_awaiting_local_persistence[instance_id].clear();
 }
@@ -155,17 +161,22 @@ void RPCManager::rpc_message_handler(subgroup_id_t subgroup_id, node_id_t sender
             // thread that called the orderedSend signal us
             // although the race condition is infinitely rare
             pending_results_cv.wait(lock, [&]() { return !pending_results_to_fulfill[subgroup_id].empty(); });
-            //We now know the membership of "all nodes in my shard of the subgroup" in the current view
-            pending_results_to_fulfill[subgroup_id].front().get().fulfill_map(
+            std::shared_ptr<AbstractPendingResults> pending_results = pending_results_to_fulfill[subgroup_id].front().lock();
+            if(pending_results) {
+                //We now know the membership of "all nodes in my shard of the subgroup" in the current view
+                pending_results->fulfill_map(
                     view_manager.unsafe_get_current_view().subgroup_shard_views.at(subgroup_id).at(my_shard).members);
-            pending_results_to_fulfill[subgroup_id].front().get().set_persistent_version(version, timestamp);
-            //Move the fulfilled PendingResults to either the "completed" list or the "awaiting persistence" list
-            if(view_manager.subgroup_is_persistent(subgroup_id)) {
-                results_awaiting_local_persistence[subgroup_id].emplace(version,
-                                                                        pending_results_to_fulfill[subgroup_id].front());
-            } else {
-                completed_pending_results[subgroup_id].emplace_back(pending_results_to_fulfill[subgroup_id].front());
+                pending_results->set_persistent_version(version, timestamp);
+                //Move the fulfilled PendingResults to either the "completed" list or the "awaiting persistence" list
+                //(but move the weak_ptr, not the shared_ptr)
+                if(view_manager.subgroup_is_persistent(subgroup_id)) {
+                    results_awaiting_local_persistence[subgroup_id].emplace(version,
+                                                                            pending_results_to_fulfill[subgroup_id].front());
+                } else {
+                    completed_pending_results[subgroup_id].emplace_back(pending_results_to_fulfill[subgroup_id].front());
+                }
             }
+            //Regardless of whether the weak_ptr was valid, delete the entry because we're done with it
             pending_results_to_fulfill[subgroup_id].pop();
         }  //release pending_results_mutex
         if(reply_size > 0) {
@@ -232,19 +243,25 @@ void RPCManager::new_view_callback(const View& new_view) {
         //the subgroup, and call set_exception_for_removed_node for the departed nodes
         for(auto pending_results_iter = fulfilled_pending_results_pair.second.begin();
             pending_results_iter != fulfilled_pending_results_pair.second.end();) {
-            if(!pending_results_iter->second.get().all_responded()) {
-                for(uint32_t shard_num = 0;
-                    shard_num < new_view.subgroup_shard_views[subgroup_id].size();
-                    ++shard_num) {
-                    for(auto removed_id : new_view.subgroup_shard_views[subgroup_id][shard_num].departed) {
-                        //This will do nothing if removed_id was never in the
-                        //shard this PendingResult corresponds to
-                        dbg_default_debug("Setting exception for removed node {} on PendingResults for subgroup {}, shard {}", removed_id, subgroup_id, shard_num);
-                        pending_results_iter->second.get().set_exception_for_removed_node(removed_id);
+            std::shared_ptr<AbstractPendingResults> live_pending_results = pending_results_iter->second.lock();
+            if(live_pending_results) {
+                if(!live_pending_results->all_responded()) {
+                    for(uint32_t shard_num = 0;
+                        shard_num < new_view.subgroup_shard_views[subgroup_id].size();
+                        ++shard_num) {
+                        for(auto removed_id : new_view.subgroup_shard_views[subgroup_id][shard_num].departed) {
+                            //This will do nothing if removed_id was never in the
+                            //shard this PendingResult corresponds to
+                            dbg_default_debug("Setting exception for removed node {} on PendingResults for subgroup {}, shard {}", removed_id, subgroup_id, shard_num);
+                            live_pending_results->set_exception_for_removed_node(removed_id);
+                        }
                     }
                 }
+                pending_results_iter++;
+            } else {
+                //The PendingResults is gone, so don't bother keeping this entry
+                pending_results_iter = fulfilled_pending_results_pair.second.erase(pending_results_iter);
             }
-            pending_results_iter++;
         }
     }
     //Do the same departed-node check on PendingResults in the awaiting_global_persistence map
@@ -252,17 +269,22 @@ void RPCManager::new_view_callback(const View& new_view) {
         const subgroup_id_t subgroup_id = fulfilled_pending_results_pair.first;
         for(auto pending_results_iter = fulfilled_pending_results_pair.second.begin();
             pending_results_iter != fulfilled_pending_results_pair.second.end();) {
-            if(!pending_results_iter->second.get().all_responded()) {
-                for(uint32_t shard_num = 0;
-                    shard_num < new_view.subgroup_shard_views[subgroup_id].size();
-                    ++shard_num) {
-                    for(auto removed_id : new_view.subgroup_shard_views[subgroup_id][shard_num].departed) {
-                        dbg_default_debug("Setting exception for removed node {} on PendingResults for subgroup {}, shard {}", removed_id, subgroup_id, shard_num);
-                        pending_results_iter->second.get().set_exception_for_removed_node(removed_id);
+            std::shared_ptr<AbstractPendingResults> live_pending_results = pending_results_iter->second.lock();
+            if(live_pending_results) {
+                if(!live_pending_results->all_responded()) {
+                    for(uint32_t shard_num = 0;
+                        shard_num < new_view.subgroup_shard_views[subgroup_id].size();
+                        ++shard_num) {
+                        for(auto removed_id : new_view.subgroup_shard_views[subgroup_id][shard_num].departed) {
+                            dbg_default_debug("Setting exception for removed node {} on PendingResults for subgroup {}, shard {}", removed_id, subgroup_id, shard_num);
+                            live_pending_results->set_exception_for_removed_node(removed_id);
+                        }
                     }
                 }
+                pending_results_iter++;
+            } else {
+                pending_results_iter = fulfilled_pending_results_pair.second.erase(pending_results_iter);
             }
-            pending_results_iter++;
         }
     }
 
@@ -274,9 +296,8 @@ void RPCManager::new_view_callback(const View& new_view) {
         const subgroup_id_t subgroup_id = fulfilled_pending_results_pair.first;
         for(auto pending_results_iter = fulfilled_pending_results_pair.second.begin();
             pending_results_iter != fulfilled_pending_results_pair.second.end();) {
-            if(pending_results_iter->get().all_responded()) {
-                pending_results_iter = fulfilled_pending_results_pair.second.erase(pending_results_iter);
-            } else {
+            std::shared_ptr<AbstractPendingResults> live_pending_results = pending_results_iter->lock();
+            if(live_pending_results && !live_pending_results->all_responded()) {
                 for(uint32_t shard_num = 0;
                     shard_num < new_view.subgroup_shard_views[subgroup_id].size();
                     ++shard_num) {
@@ -284,10 +305,13 @@ void RPCManager::new_view_callback(const View& new_view) {
                         //This will do nothing if removed_id was never in the
                         //shard this PendingResult corresponds to
                         dbg_default_debug("Setting exception for removed node {} on PendingResults for subgroup {}, shard {}", removed_id, subgroup_id, shard_num);
-                        pending_results_iter->get().set_exception_for_removed_node(removed_id);
+                        live_pending_results->set_exception_for_removed_node(removed_id);
                     }
                 }
                 pending_results_iter++;
+            } else {
+                //The PendingResults is gone, or it exists but all_responded() is true
+                pending_results_iter = fulfilled_pending_results_pair.second.erase(pending_results_iter);
             }
         }
     }
@@ -301,9 +325,12 @@ void RPCManager::notify_persistence_finished(subgroup_id_t subgroup_id, persiste
     for(auto pending_results_iter = results_awaiting_local_persistence[subgroup_id].begin();
         pending_results_iter != results_awaiting_local_persistence[subgroup_id].upper_bound(version);) {
         dbg_default_trace("RPCManager: Setting local persistence on version {}", pending_results_iter->first);
-        pending_results_iter->second.get().set_local_persistence();
-        //Move the PendingResults reference to results_awaiting_global_persistence, with the same key
-        results_awaiting_global_persistence[subgroup_id].emplace(*pending_results_iter);
+        std::shared_ptr<AbstractPendingResults> live_pending_results = pending_results_iter->second.lock();
+        if(live_pending_results) {
+            live_pending_results->set_local_persistence();
+            //If the PendingResults still exists, move the pointer to results_awaiting_global_persistence
+            results_awaiting_global_persistence[subgroup_id].emplace(*pending_results_iter);
+        }
         pending_results_iter = results_awaiting_local_persistence[subgroup_id].erase(pending_results_iter);
     }
 }
@@ -316,13 +343,16 @@ void RPCManager::notify_global_persistence_finished(subgroup_id_t subgroup_id, p
     for(auto pending_results_iter = results_awaiting_global_persistence[subgroup_id].begin();
         pending_results_iter != results_awaiting_global_persistence[subgroup_id].upper_bound(version);) {
         dbg_default_trace("RPCManager: Setting global persistence on version {}", pending_results_iter->first);
-        pending_results_iter->second.get().set_global_persistence();
-        //Move the PendingResults reference to results_awaiting_signature if the subgroup needs signatures,
-        //or completed_pending_results if it does not
-        if(view_manager.subgroup_is_signed(subgroup_id)) {
-            results_awaiting_signature[subgroup_id].emplace(*pending_results_iter);
-        } else {
-            completed_pending_results[subgroup_id].emplace_back(pending_results_iter->second);
+        std::shared_ptr<AbstractPendingResults> live_pending_results = pending_results_iter->second.lock();
+        if(live_pending_results) {
+            live_pending_results->set_global_persistence();
+            //If the PendingResults still exists, move the pointer to results_awaiting_signature if the
+            //subgroup needs signatures, or completed_pending_results if it does not
+            if(view_manager.subgroup_is_signed(subgroup_id)) {
+                results_awaiting_signature[subgroup_id].emplace(*pending_results_iter);
+            } else {
+                completed_pending_results[subgroup_id].emplace_back(pending_results_iter->second);
+            }
         }
         pending_results_iter = results_awaiting_global_persistence[subgroup_id].erase(pending_results_iter);
     }
@@ -334,9 +364,12 @@ void RPCManager::notify_verification_finished(subgroup_id_t subgroup_id, persist
     for(auto pending_results_iter = results_awaiting_signature[subgroup_id].begin();
         pending_results_iter != results_awaiting_signature[subgroup_id].upper_bound(version);) {
         dbg_default_trace("RPCManager: Setting signature verification on version {}", pending_results_iter->first);
-        pending_results_iter->second.get().set_signature_verified();
-        //Move the PendingResults reference to completed_pending_results
-        completed_pending_results[subgroup_id].emplace_back(pending_results_iter->second);
+        std::shared_ptr<AbstractPendingResults> live_pending_results = pending_results_iter->second.lock();
+        if(live_pending_results) {
+            live_pending_results->set_signature_verified();
+            //Move the PendingResults pointer to completed_pending_results
+            completed_pending_results[subgroup_id].emplace_back(pending_results_iter->second);
+        }
         pending_results_iter = results_awaiting_signature[subgroup_id].erase(pending_results_iter);
     }
 }
@@ -345,7 +378,7 @@ void RPCManager::add_connections(const std::vector<uint32_t>& node_ids) {
     connections->add_connections(node_ids);
 }
 
-bool RPCManager::finish_rpc_send(subgroup_id_t subgroup_id, PendingBase& pending_results_handle) {
+bool RPCManager::finish_rpc_send(subgroup_id_t subgroup_id, std::weak_ptr<AbstractPendingResults> pending_results_handle) {
     std::lock_guard<std::mutex> lock(pending_results_mutex);
     pending_results_to_fulfill[subgroup_id].push(pending_results_handle);
     pending_results_cv.notify_all();
@@ -373,7 +406,7 @@ volatile char* RPCManager::get_sendbuffer_ptr(uint32_t dest_id, sst::REQUEST_TYP
     return buf;
 }
 
-void RPCManager::finish_p2p_send(node_id_t dest_id, subgroup_id_t dest_subgroup_id, PendingBase& pending_results_handle) {
+void RPCManager::finish_p2p_send(node_id_t dest_id, subgroup_id_t dest_subgroup_id, std::weak_ptr<AbstractPendingResults> pending_results_handle) {
     try {
         //ViewManager's view_mutex also prevents connections from being removed (because
         //that happens in new_view_callback)
@@ -382,11 +415,14 @@ void RPCManager::finish_p2p_send(node_id_t dest_id, subgroup_id_t dest_subgroup_
     } catch(std::out_of_range& map_error) {
         throw node_removed_from_group_exception(dest_id);
     }
-    pending_results_handle.fulfill_map({dest_id});
-    std::lock_guard<std::mutex> lock(pending_results_mutex);
-    // These PendingResults don't need to have ReplyMaps fulfilled, and they
-    // won't ever get version numbers or persistence notifications (since P2P sends are read-only)
-    completed_pending_results[dest_subgroup_id].push_back(pending_results_handle);
+    std::shared_ptr<AbstractPendingResults> pending_results = pending_results_handle.lock();
+    if(pending_results) {
+        pending_results->fulfill_map({dest_id});
+        std::lock_guard<std::mutex> lock(pending_results_mutex);
+        // These PendingResults don't need to have ReplyMaps fulfilled, and they
+        // won't ever get version numbers or persistence notifications (since P2P sends are read-only)
+        completed_pending_results[dest_subgroup_id].push_back(pending_results_handle);
+    }
 }
 
 void RPCManager::p2p_request_worker() {

--- a/src/core/rpc_manager.cpp
+++ b/src/core/rpc_manager.cpp
@@ -256,6 +256,10 @@ void RPCManager::new_view_callback(const View& new_view) {
                             live_pending_results->set_exception_for_removed_node(removed_id);
                         }
                     }
+                    //This PendingResults will not receive any more replies, so RemoteInvoker doesn't need to
+                    //access it through its heap-allocated shared_ptr. Delete that pointer here to avoid leaking
+                    //the PendingResults, since RemoteInvoker can only delete it by receiving a valid reply.
+                    live_pending_results->delete_self_ptr();
                 }
                 pending_results_iter++;
             } else {
@@ -280,6 +284,7 @@ void RPCManager::new_view_callback(const View& new_view) {
                             live_pending_results->set_exception_for_removed_node(removed_id);
                         }
                     }
+                    live_pending_results->delete_self_ptr();
                 }
                 pending_results_iter++;
             } else {
@@ -308,6 +313,7 @@ void RPCManager::new_view_callback(const View& new_view) {
                         live_pending_results->set_exception_for_removed_node(removed_id);
                     }
                 }
+                live_pending_results->delete_self_ptr();
                 pending_results_iter++;
             } else {
                 //The PendingResults is gone, or it exists but all_responded() is true


### PR DESCRIPTION
As discussed in the issue, I rewrote the way RemoteInvoker manages PendingResults objects so that they are dynamically created and deleted instead of being stored in a fixed-size array (which was the cause of the bug). An invocation ID is now the memory address of a `shared_ptr<PendingResults>` on the sending node rather than an array index, which the `receive_response` method can use to retrieve the correct PendingResults for an incoming response. The PendingResults is deleted when both all responses are received and the user-level thread has deleted its corresponding QueryResults object.

I have tested my changes with `persistent_bw_test` and confirmed that the original `future_error` problem identified in #205 no longer happens (and also no new errors appear). Weijia plans to test the performance of this version to ensure it doesn't introduce any performance issues, then we can merge it.