### PR TITLE
Fix bugs in view change logic

### DIFF
--- a/include/derecho/core/detail/group_impl.hpp
+++ b/include/derecho/core/detail/group_impl.hpp
@@ -400,6 +400,7 @@ void Group<ReplicatedTypes...>::receive_objects(const std::set<std::pair<subgrou
             leader_socket.get().read(buffer_size);
             std::unique_ptr<char[]> buffer = std::make_unique<char[]>(buffer_size);
             leader_socket.get().read(buffer.get(), buffer_size);
+            dbg_default_trace("Deserializing Replicated Object from buffer of size {}", buffer_size);
             subgroup_object->receive_object(buffer.get());
         } catch(tcp::socket_error& e) {
             //Convert socket exceptions to a more readable error message, since this will cause a crash

--- a/include/derecho/core/detail/multicast_group.hpp
+++ b/include/derecho/core/detail/multicast_group.hpp
@@ -317,7 +317,10 @@ private:
     /** next_message is the message that will be sent when send is called the next time.
      * It is std::nullopt when there is no message to send. */
     std::vector<std::optional<RDMCMessage>> next_sends;
-    std::map<uint32_t, bool> pending_sst_sends;
+    /** For each subgroup, indicates whether an SST Multicast send is currently in progress
+     * (i.e. a thread is inside the send() method). This prevents multiple application threads
+     * from calling send() simultaneously and causing a race condition. */
+    std::map<uint32_t, bool> smc_send_in_progress;
     std::vector<uint32_t> committed_sst_index;
     std::vector<uint32_t> num_nulls_queued;
     std::vector<int32_t> first_null_index;
@@ -549,7 +552,6 @@ public:
 	The user function that generates the message is supplied to send */
     bool send(subgroup_id_t subgroup_num, long long unsigned int payload_size,
               const std::function<void(char* buf)>& msg_generator, bool cooked_send);
-    bool check_pending_sst_sends(subgroup_id_t subgroup_num);
 
     const uint64_t compute_global_stability_frontier(subgroup_id_t subgroup_num);
 

--- a/include/derecho/core/detail/rpc_manager.hpp
+++ b/include/derecho/core/detail/rpc_manager.hpp
@@ -21,6 +21,7 @@
 #include "rpc_utils.hpp"
 #include <derecho/mutils-serialization/SerializationSupport.hpp>
 #include <derecho/utils/logger.hpp>
+#include <derecho/persistent/Persistent.hpp>
 
 namespace derecho {
 
@@ -189,8 +190,9 @@ class RPCManager {
      */
     void p2p_message_handler(node_id_t sender_id, char* msg_buf);
 
-    /** Reports to the view manager that the given node has failed if it's internal member.
-     * Otherwise clean up p2p_connections and external sockets in lf.cpp
+    /**
+     * Reports to the view manager that the given node has failed if it's an
+     * internal member, or removes its global SST connection if it's an external member.
      */
     void report_failure(const node_id_t who);
 

--- a/include/derecho/core/detail/rpc_utils.hpp
+++ b/include/derecho/core/detail/rpc_utils.hpp
@@ -725,6 +725,14 @@ private:
      */
     std::shared_ptr<PendingResults<Ret>>* self_heap_ptr;
 
+    /**
+     * A mutex that can be used to control access to this object "as a whole,"
+     * in order to make a sequence of method invocations atomic. This is
+     * necessary to make receive_response thread-safe, since the sequence
+     * "set_value()/set_exception() then all_responded()" needs to be atomic.
+     */
+    std::mutex this_object_mutex;
+
 public:
     PendingResults()
             : reply_promises_are_ready(promise_for_reply_promises.get_future()),
@@ -821,14 +829,16 @@ public:
      */
     void set_exception_for_removed_node(const node_id_t& removed_nid) {
         assert(map_fulfilled);
+        if(reply_promises.size() == 0) {
+            reply_promises = std::move(reply_promises_are_ready.get());
+        }
         std::lock_guard<std::mutex> lock(responded_nodes_mutex);
         if(dest_nodes.find(removed_nid) != dest_nodes.end()
            && responded_nodes.find(removed_nid) == responded_nodes.end()) {
             //Mark the node as "responded" for the purposes of the other methods
             responded_nodes.insert(removed_nid);
-            set_exception(removed_nid,
-                          std::make_exception_ptr(
-                                  node_removed_from_group_exception{removed_nid}));
+            reply_promises.at(removed_nid).set_exception(
+                std::make_exception_ptr(node_removed_from_group_exception{removed_nid}));
         }
     }
 
@@ -911,6 +921,15 @@ public:
      */
     void set_signature_verified() {
         signature_verified_promise.set_value();
+    }
+
+    /**
+     * @return A reference to the "object mutex" stored in this PendingResults.
+     * Callers should lock this mutex before performing a sequence of multiple
+     * method calls to prevent threads from interleaving between them.
+     */
+    std::mutex& object_mutex() {
+        return this_object_mutex;
     }
 };
 

--- a/include/derecho/core/detail/view_manager.hpp
+++ b/include/derecho/core/detail/view_manager.hpp
@@ -450,11 +450,30 @@ private:
                                       uint num_shard_senders);
 
     /* -- Static helper methods that implement chunks of view-management functionality -- */
-    static bool suspected_not_equal(const DerechoSST& gmsSST, const std::vector<bool>& old);
+    /** Copies the local node's suspected array from the SST to an ordinary vector. */
     static void copy_suspected(const DerechoSST& gmsSST, std::vector<bool>& old);
+    /**
+     * Returns true if any row in the SST has a suspected array that has new
+     * "true" entries compared to the vector argument, which should contain a
+     * copy of the local node's suspected array.
+     */
+    static bool suspected_not_equal(const DerechoSST& gmsSST, const std::vector<bool>& old);
+    /** Returns true if the local node's changes list contains the given node ID */
     static bool changes_contains(const DerechoSST& gmsSST, const node_id_t q);
+    /**
+     * Returns true if the pending changes currently proposed by the leader
+     * include a change with the end-of-view marker set to true. The leader's
+     * rank is passed as a parameter to avoid re-computing it inside the method.
+     */
     static bool changes_includes_end_of_view(const DerechoSST& gmsSST, const int rank_of_leader);
+    /**
+     * Returns true if the set of changes committed by the leader, but not yet
+     * installed, includes a change with the end-of-view marker set to true.
+     */
+    static bool end_of_view_committed(const DerechoSST& gmsSST, const int rank_of_leader);
+    /** Returns the minimum value of num_acked across all non-failed members */
     static int min_acked(const DerechoSST& gmsSST, const std::vector<char>& failed);
+    /** Returns true if all non-failed nodes suspect all nodes lower in rank than the current leader */
     static bool previous_leaders_suspected(const DerechoSST& gmsSST, const View& curr_view);
 
     /**

--- a/src/applications/tests/unit_tests/view_change_test.cpp
+++ b/src/applications/tests/unit_tests/view_change_test.cpp
@@ -26,7 +26,7 @@ public:
 
     //Returns true so that replicas will send an acknowledgement when the update is complete
     bool update(int new_state) {
-        dbg_default_debug("Received RPC update {}", new_state);
+        dbg_default_trace("Received RPC update {}", new_state);
         state = new_state;
         return true;
     }
@@ -80,7 +80,7 @@ int main(int argc, char** argv) {
     const uint32_t max_shard_size = std::stoi(argv[dashdash_pos + 2]);
     const uint32_t num_updates = std::stoi(argv[dashdash_pos + 3]);
     const bool use_persistence = (std::string(argv[dashdash_pos + 4]) == "on");
-    if((argc - dashdash_pos) > num_required_args) {
+    if(dashdash_pos + 5 < argc) {
         pthread_setname_np(pthread_self(), argv[dashdash_pos + 5]);
     } else {
         pthread_setname_np(pthread_self(), default_proc_name);

--- a/src/applications/tests/unit_tests/view_change_test.cpp
+++ b/src/applications/tests/unit_tests/view_change_test.cpp
@@ -160,6 +160,9 @@ void persistent_test(uint32_t num_shards, uint32_t max_shard_size, uint32_t num_
         } catch(derecho::derecho_exception& ex) {
             dbg_default_warn("Exception occurred while awaiting reply to update #{}. What(): {}", counter, ex.what());
         }
+        if(counter % 1000 == 0) {
+            std::cout << "Done with " << counter << " updates" << std::endl;
+        }
     }
     //Maybe this will ensure all the log messages finish printing before the stdout line
     dbg_default_flush();

--- a/src/applications/tests/unit_tests/view_change_test.cpp
+++ b/src/applications/tests/unit_tests/view_change_test.cpp
@@ -102,9 +102,12 @@ void nonpersistent_test(uint32_t num_shards, uint32_t max_shard_size) {
             try {
                 //Wait for the first entry in the reply map to get its results
                 //This will confirm that the update was delivered to all replicas
-                bool success = update_results.get().begin()->second.get();
+                update_results.get().begin()->second.get();
             } catch(derecho::derecho_exception& ex) {
                 dbg_default_warn("Exception occurred while awaiting reply to update #{}. What(): {}", counter, ex.what());
+            }
+            if(counter % 1000 == 0) {
+                std::cout << "Done with " << counter << " updates" << std::endl;
             }
         }
         //Maybe this will ensure all the log messages finish printing before the stdout line

--- a/src/applications/tests/unit_tests/view_change_test.cpp
+++ b/src/applications/tests/unit_tests/view_change_test.cpp
@@ -58,20 +58,33 @@ public:
 void persistent_test(uint32_t num_shards, uint32_t max_shard_size, uint32_t num_updates);
 void nonpersistent_test(uint32_t num_shards, uint32_t max_shard_size, uint32_t num_updates);
 
-int main(int argc, char** argv) {
-    pthread_setname_np(pthread_self(), "view_change_test");
+constexpr const char default_proc_name[] = "view_change_test";
+constexpr int num_required_args = 4;
 
-    int num_args = 4;
-    if(argc < (num_args + 1) || (argc > (num_args + 1) && strcmp("--", argv[argc - (num_args + 1)]))) {
+int main(int argc, char** argv) {
+    int dashdash_pos = argc - 1;
+    while(dashdash_pos > 0) {
+        if(strcmp(argv[dashdash_pos], "--") == 0) {
+            break;
+        }
+        dashdash_pos--;
+    }
+
+    if((argc - dashdash_pos) < num_required_args) {
         std::cout << "Invalid command line arguments." << std::endl;
-        std::cout << "USAGE:" << argv[0] << "[ derecho-config-list -- ] <num_shards> <max_shard_size> <num_updates> <persistence_on/off>" << std::endl;
+        std::cout << "USAGE:" << argv[0] << "[ derecho-config-list -- ] <num_shards> <max_shard_size> <num_updates> <persistence_on/off> [proc_name]" << std::endl;
         return -1;
     }
 
-    const uint32_t num_shards = std::stoi(argv[argc - num_args]);
-    const uint32_t max_shard_size = std::stoi(argv[argc - num_args + 1]);
-    const uint32_t num_updates = std::stoi(argv[argc - num_args + 2]);
-    const bool use_persistence = (std::string(argv[argc - num_args + 3]) == "on");
+    const uint32_t num_shards = std::stoi(argv[dashdash_pos + 1]);
+    const uint32_t max_shard_size = std::stoi(argv[dashdash_pos + 2]);
+    const uint32_t num_updates = std::stoi(argv[dashdash_pos + 3]);
+    const bool use_persistence = (std::string(argv[dashdash_pos + 4]) == "on");
+    if((argc - dashdash_pos) > num_required_args) {
+        pthread_setname_np(pthread_self(), argv[dashdash_pos + 5]);
+    } else {
+        pthread_setname_np(pthread_self(), default_proc_name);
+    }
 
     derecho::Conf::initialize(argc, argv);
 

--- a/src/applications/tests/unit_tests/view_change_test.cpp
+++ b/src/applications/tests/unit_tests/view_change_test.cpp
@@ -26,6 +26,7 @@ public:
 
     //Returns true so that replicas will send an acknowledgement when the update is complete
     bool update(int new_state) {
+        dbg_default_debug("Received RPC update {}", new_state);
         state = new_state;
         return true;
     }
@@ -54,35 +55,34 @@ public:
     REGISTER_RPC_FUNCTIONS(PersistentTestObject, P2P_TARGETS(read_state), ORDERED_TARGETS(update));
 };
 
-constexpr int updates_per_loop = 100000;
-
-void persistent_test(uint32_t num_shards, uint32_t max_shard_size);
-void nonpersistent_test(uint32_t num_shards, uint32_t max_shard_size);
+void persistent_test(uint32_t num_shards, uint32_t max_shard_size, uint32_t num_updates);
+void nonpersistent_test(uint32_t num_shards, uint32_t max_shard_size, uint32_t num_updates);
 
 int main(int argc, char** argv) {
     pthread_setname_np(pthread_self(), "view_change_test");
 
-    int num_args = 3;
+    int num_args = 4;
     if(argc < (num_args + 1) || (argc > (num_args + 1) && strcmp("--", argv[argc - (num_args + 1)]))) {
         std::cout << "Invalid command line arguments." << std::endl;
-        std::cout << "USAGE:" << argv[0] << "[ derecho-config-list -- ] <num_shards> <max_shard_size> <persistence_mode>" << std::endl;
+        std::cout << "USAGE:" << argv[0] << "[ derecho-config-list -- ] <num_shards> <max_shard_size> <num_updates> <persistence_on/off>" << std::endl;
         return -1;
     }
 
     const uint32_t num_shards = std::stoi(argv[argc - num_args]);
     const uint32_t max_shard_size = std::stoi(argv[argc - num_args + 1]);
-    const bool use_persistence = (std::string(argv[argc - num_args + 2]) == "on");
+    const uint32_t num_updates = std::stoi(argv[argc - num_args + 2]);
+    const bool use_persistence = (std::string(argv[argc - num_args + 3]) == "on");
 
     derecho::Conf::initialize(argc, argv);
 
     if(use_persistence) {
-        persistent_test(num_shards, max_shard_size);
+        persistent_test(num_shards, max_shard_size, num_updates);
     } else {
-        nonpersistent_test(num_shards, max_shard_size);
+        nonpersistent_test(num_shards, max_shard_size, num_updates);
     }
 }
 
-void nonpersistent_test(uint32_t num_shards, uint32_t max_shard_size) {
+void nonpersistent_test(uint32_t num_shards, uint32_t max_shard_size, uint32_t num_updates) {
     derecho::SubgroupInfo layout(derecho::DefaultSubgroupAllocator(
             {{std::type_index(typeid(TestObject)),
               derecho::one_subgroup_policy(derecho::flexible_even_shards(num_shards, 1, max_shard_size))}}));
@@ -93,38 +93,34 @@ void nonpersistent_test(uint32_t num_shards, uint32_t max_shard_size) {
 
     derecho::Group<TestObject> group(layout, test_object_factory);
 
-    bool test_done = false;
-    while(!test_done) {
-        std::cout << "Sending " << updates_per_loop << " multicast updates" << std::endl;
-        derecho::Replicated<TestObject>& replica_group = group.get_subgroup<TestObject>();
-        for(int counter = 0; counter < updates_per_loop; ++counter) {
-            derecho::rpc::QueryResults<bool> update_results = replica_group.ordered_send<RPC_NAME(update)>(counter);
-            try {
-                //Wait for the first entry in the reply map to get its results
-                //This will confirm that the update was delivered to all replicas
-                update_results.get().begin()->second.get();
-            } catch(derecho::derecho_exception& ex) {
-                dbg_default_warn("Exception occurred while awaiting reply to update #{}. What(): {}", counter, ex.what());
+    std::cout << "Sending " << num_updates << " multicast updates" << std::endl;
+    derecho::Replicated<TestObject>& replica_group = group.get_subgroup<TestObject>();
+    for(uint32_t counter = 0; counter < num_updates ; ++counter) {
+        derecho::rpc::QueryResults<bool> update_results = replica_group.ordered_send<RPC_NAME(update)>(counter);
+        try {
+            using namespace std::chrono_literals;
+            //Wait for the first entry in the reply map to get its results
+            //This will confirm that the update was delivered to all replicas
+            decltype(update_results)::ReplyMap* reply_map = update_results.wait(5s);
+            if(!reply_map) {
+                dbg_default_warn("Failed to get a ReplyMap for update {} after 5 seconds!", counter);
+            } else {
+                reply_map->begin()->second.get();
             }
-            if(counter % 1000 == 0) {
-                std::cout << "Done with " << counter << " updates" << std::endl;
-            }
+        } catch(derecho::derecho_exception& ex) {
+            dbg_default_warn("Exception occurred while awaiting reply to update #{}. What(): {}", counter, ex.what());
         }
-        //Maybe this will ensure all the log messages finish printing before the stdout line
-        dbg_default_flush();
-        std::cout << "Done sending updates. Send " << updates_per_loop << " more? [y/N] ";
-        std::string response;
-        std::cin >> response;
-        if(response == "y" || response == "Y") {
-            test_done = false;
-        } else {
-            test_done = true;
+        if(counter % 1000 == 0) {
+            std::cout << "Done with " << counter << " updates" << std::endl;
         }
     }
+    //Maybe this will ensure all the log messages finish printing before the stdout line
+    dbg_default_flush();
+    std::cout << "Done sending all updates." << std::endl;
     group.leave();
 }
 
-void persistent_test(uint32_t num_shards, uint32_t max_shard_size) {
+void persistent_test(uint32_t num_shards, uint32_t max_shard_size, uint32_t num_updates) {
     derecho::SubgroupInfo layout(derecho::DefaultSubgroupAllocator(
             {{std::type_index(typeid(PersistentTestObject)),
               derecho::one_subgroup_policy(derecho::flexible_even_shards(num_shards, 1, max_shard_size))}}));
@@ -135,30 +131,20 @@ void persistent_test(uint32_t num_shards, uint32_t max_shard_size) {
 
     derecho::Group<PersistentTestObject> group(layout, test_object_factory);
 
-    bool test_done = false;
-    while(!test_done) {
-        std::cout << "Sending " << updates_per_loop << " multicast updates" << std::endl;
-        derecho::Replicated<PersistentTestObject>& replica_group = group.get_subgroup<PersistentTestObject>();
-        for(int counter = 0; counter < updates_per_loop; ++counter) {
-            derecho::rpc::QueryResults<bool> update_results = replica_group.ordered_send<RPC_NAME(update)>("Update number " + std::to_string(counter));
-            try {
-                //Wait for the first entry in the reply map to get its results
-                //This will confirm that the update was delivered to all replicas
-                bool success = update_results.get().begin()->second.get();
-            } catch(derecho::derecho_exception& ex) {
-                dbg_default_warn("Exception occurred while awaiting reply to update #{}. What(): {}", counter, ex.what());
-            }
-        }
-        //Maybe this will ensure all the log messages finish printing before the stdout line
-        dbg_default_flush();
-        std::cout << "Done sending updates. Send " << updates_per_loop << " more? [y/N] ";
-        std::string response;
-        std::cin >> response;
-        if(response == "y" || response == "Y") {
-            test_done = false;
-        } else {
-            test_done = true;
+    std::cout << "Sending " << num_updates << " multicast updates" << std::endl;
+    derecho::Replicated<PersistentTestObject>& replica_group = group.get_subgroup<PersistentTestObject>();
+    for(uint32_t counter = 0; counter < num_updates; ++counter) {
+        derecho::rpc::QueryResults<bool> update_results = replica_group.ordered_send<RPC_NAME(update)>("Update number " + std::to_string(counter));
+        try {
+            //Wait for the first entry in the reply map to get its results
+            //This will confirm that the update was delivered to all replicas
+            update_results.get().begin()->second.get();
+        } catch(derecho::derecho_exception& ex) {
+            dbg_default_warn("Exception occurred while awaiting reply to update #{}. What(): {}", counter, ex.what());
         }
     }
+    //Maybe this will ensure all the log messages finish printing before the stdout line
+    dbg_default_flush();
+    std::cout << "Done sending all updates." << std::endl;
     group.leave();
 }

--- a/src/core/git_version.cpp
+++ b/src/core/git_version.cpp
@@ -13,8 +13,8 @@ namespace derecho {
 const int MAJOR_VERSION = 2;
 const int MINOR_VERSION = 2;
 const int PATCH_VERSION = 1;
-const int COMMITS_AHEAD_OF_VERSION = 3;
+const int COMMITS_AHEAD_OF_VERSION = 12;
 const char* VERSION_STRING = "2.2.1";
-const char* VERSION_STRING_PLUS_COMMITS = "2.2.1+3";
+const char* VERSION_STRING_PLUS_COMMITS = "2.2.1+12";
 
 }

--- a/src/core/git_version.cpp
+++ b/src/core/git_version.cpp
@@ -13,8 +13,8 @@ namespace derecho {
 const int MAJOR_VERSION = 2;
 const int MINOR_VERSION = 2;
 const int PATCH_VERSION = 1;
-const int COMMITS_AHEAD_OF_VERSION = 13;
+const int COMMITS_AHEAD_OF_VERSION = 14;
 const char* VERSION_STRING = "2.2.1";
-const char* VERSION_STRING_PLUS_COMMITS = "2.2.1+13";
+const char* VERSION_STRING_PLUS_COMMITS = "2.2.1+14";
 
 }

--- a/src/core/git_version.cpp
+++ b/src/core/git_version.cpp
@@ -13,8 +13,8 @@ namespace derecho {
 const int MAJOR_VERSION = 2;
 const int MINOR_VERSION = 2;
 const int PATCH_VERSION = 1;
-const int COMMITS_AHEAD_OF_VERSION = 0;
+const int COMMITS_AHEAD_OF_VERSION = 2;
 const char* VERSION_STRING = "2.2.1";
-const char* VERSION_STRING_PLUS_COMMITS = "2.2.1+0";
+const char* VERSION_STRING_PLUS_COMMITS = "2.2.1+2";
 
 }

--- a/src/core/git_version.cpp
+++ b/src/core/git_version.cpp
@@ -13,8 +13,8 @@ namespace derecho {
 const int MAJOR_VERSION = 2;
 const int MINOR_VERSION = 2;
 const int PATCH_VERSION = 1;
-const int COMMITS_AHEAD_OF_VERSION = 15;
+const int COMMITS_AHEAD_OF_VERSION = 16;
 const char* VERSION_STRING = "2.2.1";
-const char* VERSION_STRING_PLUS_COMMITS = "2.2.1+15";
+const char* VERSION_STRING_PLUS_COMMITS = "2.2.1+16";
 
 }

--- a/src/core/git_version.cpp
+++ b/src/core/git_version.cpp
@@ -13,8 +13,8 @@ namespace derecho {
 const int MAJOR_VERSION = 2;
 const int MINOR_VERSION = 2;
 const int PATCH_VERSION = 1;
-const int COMMITS_AHEAD_OF_VERSION = 14;
+const int COMMITS_AHEAD_OF_VERSION = 15;
 const char* VERSION_STRING = "2.2.1";
-const char* VERSION_STRING_PLUS_COMMITS = "2.2.1+14";
+const char* VERSION_STRING_PLUS_COMMITS = "2.2.1+15";
 
 }

--- a/src/core/git_version.cpp
+++ b/src/core/git_version.cpp
@@ -13,8 +13,8 @@ namespace derecho {
 const int MAJOR_VERSION = 2;
 const int MINOR_VERSION = 2;
 const int PATCH_VERSION = 1;
-const int COMMITS_AHEAD_OF_VERSION = 12;
+const int COMMITS_AHEAD_OF_VERSION = 13;
 const char* VERSION_STRING = "2.2.1";
-const char* VERSION_STRING_PLUS_COMMITS = "2.2.1+12";
+const char* VERSION_STRING_PLUS_COMMITS = "2.2.1+13";
 
 }

--- a/src/core/p2p_connection_manager.cpp
+++ b/src/core/p2p_connection_manager.cpp
@@ -245,8 +245,17 @@ void P2PConnectionManager::check_failures_loop() {
                 std::lock_guard<std::mutex> connection_lock(p2p_connections[nid].first);
                 if(p2p_connections[nid].second) {
                     p2p_connections[nid].second->get_res()->report_failure();
+                    p2p_connections[nid].second = nullptr;
+                    active_p2p_connections[nid] = false;
                 }
             }
+            /* Note: Since we release connection_lock before calling failure_upcall, there is a slight
+             * possibility that the failed node will rejoin (and get added back to p2p_connections)
+             * before this thread can reach failure_upcall. However, that would require this thread to
+             * remain stalled for the duration of 2 view changes, 1 to remove the failed node and 1 to
+             * add it back, and this seems unlikely. Holding connection_lock while calling the upcall
+             * leads to a deadlock with the current design since the upcall needs to acquire view_mutex.
+             */
             if(failure_upcall) {
                 failure_upcall(nid);
             }

--- a/src/core/rpc_manager.cpp
+++ b/src/core/rpc_manager.cpp
@@ -154,7 +154,7 @@ void RPCManager::rpc_message_handler(subgroup_id_t subgroup_id, node_id_t sender
         //This is a self-receive of an RPC message I sent, so I have a reply-map that needs fulfilling
         const uint32_t my_shard = view_manager.unsafe_get_current_view().my_subgroups.at(subgroup_id);
         {
-            whendebug(int32_t msg_seq_num = persistent::unpack_version<int32_t>(version).second);
+            whenlog(int32_t msg_seq_num = persistent::unpack_version<int32_t>(version).second);
             dbg_default_trace("RPCManager got a self-receive for message {}", msg_seq_num);
             std::unique_lock<std::mutex> lock(pending_results_mutex);
             // because of a race condition, pending_results_to_fulfill can genuinely be empty

--- a/src/core/view_manager.cpp
+++ b/src/core/view_manager.cpp
@@ -1182,8 +1182,7 @@ void ViewManager::terminate_epoch(DerechoSST& gmsSST) {
         }
         // wait for all pending sst sends to finish
         dbg_default_debug("Waiting for pending SST sends to finish");
-        while(curr_view->multicast_group->check_pending_sst_sends(subgroup_id)) {
-        }
+        curr_view->multicast_group->sst_send_trigger(subgroup_id, curr_subgroup_settings, num_shard_members, gmsSST);
         gmsSST.put_with_completion();
         gmsSST.sync_with_members(
                 curr_view->multicast_group->get_shard_sst_indices(subgroup_id));


### PR DESCRIPTION
I've implemented several fixes for the bugs identified in #213, and after repeated testing with the new view_change_test.cpp, the view change logic seems stable now. These fixes include (pulled from my commit messages):

* Some nodes were moving to the next view as soon as they detected the first change in a batch of 3 changes, and thus only updated their num_acked and num_committed by 1, even though the view they then installed included all 3 changes in the batch. This caused them to immediately detect a new "unacknowledged" change in the next view, which was actually one they already installed. The problem was with the leader_committed_changes predicate, which should be checking to make sure sure the leader has finished proposing all the changes in a batch before returning true -- the call to changes_includes_end_of_view was supposed to do this, but it only checks to see if the "end-of-view" change is in the changes list, not whether this node has actually acknowledged it yet. I fixed this by making leader_committed_changes call a new function called end_of_view_committed instead.
* The terminate_epoch method in ViewManager needed to call sst_send_trigger, not check_pending_sst_sends, to ensure that any in-progress SMC sends were actually sent before ending the view.
* RPCManager's failure_upcall, which is called by P2PConnectionManager, should not call P2PConnectionManager's remove_connection while holding the View mutex. Instead, P2PConnectionManager can simply remove the failed connection itself before calling the upcall.
* RemoteInvoker should not have a single receive_response_mutex shared by all calls to receive_response, because this means that responses to different invocations of the same function will all be competing for the same mutex even though they are accessing different PendingResults objects. The mutex is intended to protect access to the same PendingResults object from different threads, so there should be one mutex per PendingResults object.