### PR TITLE
New APIs needed for CascadeChain

### DIFF
--- a/include/derecho/core/detail/group_impl.hpp
+++ b/include/derecho/core/detail/group_impl.hpp
@@ -9,9 +9,9 @@
 #include <spdlog/sinks/stdout_color_sinks.h>
 
 #include "../group.hpp"
-#include <derecho/utils/container_template_functions.hpp>
 #include "derecho_internal.hpp"
 #include "make_kind_map.hpp"
+#include <derecho/utils/container_template_functions.hpp>
 #include <derecho/utils/logger.hpp>
 
 namespace derecho {
@@ -48,6 +48,14 @@ std::size_t _Group::get_number_of_shards(uint32_t subgroup_index) {
         throw derecho_exception("Error: this top-level group contains no subgroups for the selected type.");
 }
 
+template <typename SubgroupType>
+uint32_t _Group::get_num_subgroups() {
+    if(auto gptr = dynamic_cast<GroupProjection<SubgroupType>*>(this)) {
+        return gptr->get_num_subgroups();
+    } else
+        throw derecho_exception("Error: this top-level group contains no subgroups for the selected type.");
+}
+
 template <typename ReplicatedType>
 Replicated<ReplicatedType>&
 GroupProjection<ReplicatedType>::get_subgroup(uint32_t subgroup_num) {
@@ -76,6 +84,11 @@ template <typename ReplicatedType>
 std::size_t
 GroupProjection<ReplicatedType>::get_number_of_shards(uint32_t subgroup_index) {
     return get_view_manager().get_number_of_shards_in_subgroup(get_index_of_type(typeid(ReplicatedType)), subgroup_index);
+}
+
+template <typename ReplicatedType>
+uint32_t GroupProjection<ReplicatedType>::get_num_subgroups() {
+    return get_view_manager().get_num_subgroups(get_index_of_type(typeid(ReplicatedType)));
 }
 
 template <typename... ReplicatedTypes>
@@ -341,6 +354,7 @@ void Group<ReplicatedTypes...>::set_up_components() {
 template <typename... ReplicatedTypes>
 template <typename SubgroupType>
 Replicated<SubgroupType>& Group<ReplicatedTypes...>::get_subgroup(uint32_t subgroup_index) {
+    static_assert(contains<SubgroupType, ReplicatedTypes...>::value, "get_subgroup was called with a template parameter that does not match any subgroup type");
     if(!view_manager.get_current_view().get().is_adequately_provisioned) {
         throw subgroup_provisioning_exception("View is inadequately provisioned because subgroup provisioning failed!");
     }
@@ -354,10 +368,24 @@ Replicated<SubgroupType>& Group<ReplicatedTypes...>::get_subgroup(uint32_t subgr
 template <typename... ReplicatedTypes>
 template <typename SubgroupType>
 ExternalCaller<SubgroupType>& Group<ReplicatedTypes...>::get_nonmember_subgroup(uint32_t subgroup_index) {
+    static_assert(contains<SubgroupType, ReplicatedTypes...>::value, "get_nonmember_subgroup was called with a template parameter that does not match any subgroup type");
     try {
         return external_callers.template get<SubgroupType>().at(subgroup_index);
     } catch(std::out_of_range& ex) {
         throw invalid_subgroup_exception("No ExternalCaller exists for the requested subgroup; this node may be a member of the subgroup");
+    }
+}
+
+template <typename... ReplicatedTypes>
+template <typename SubgroupType>
+uint32_t Group<ReplicatedTypes...>::get_num_subgroups() {
+    static_assert(contains<SubgroupType, ReplicatedTypes...>::value, "get_num_subgroups was called with a template parameter that did not match any subgroup type");
+    //No need to ask view_manager. This avoids locking the view_mutex.
+    try {
+        return replicated_objects.template get<SubgroupType>().size();
+    } catch(std::out_of_range& ex) {
+        //The SubgroupType must either be in replicated_objects or external_callers
+        return external_callers.template get<SubgroupType>().size();
     }
 }
 
@@ -439,6 +467,12 @@ template <typename... ReplicatedTypes>
 template <typename SubgroupType>
 int32_t Group<ReplicatedTypes...>::get_my_shard(uint32_t subgroup_index) {
     return view_manager.get_my_shard(index_of_type<SubgroupType, ReplicatedTypes...>, subgroup_index);
+}
+
+template <typename... ReplicatedTypes>
+template <typename SubgroupType>
+std::vector<uint32_t> Group<ReplicatedTypes...>::get_my_subgroup_indexes() {
+    return view_manager.get_my_subgroup_indexes(index_of_type<SubgroupType, ReplicatedTypes...>);
 }
 
 template <typename... ReplicatedTypes>

--- a/include/derecho/core/detail/view_manager.hpp
+++ b/include/derecho/core/detail/view_manager.hpp
@@ -816,21 +816,36 @@ public:
 
     /** Causes this node to cleanly leave the group by setting itself to "failed." */
     void leave();
+
     /** Returns a vector listing the nodes that are currently members of the group. */
     std::vector<node_id_t> get_members();
+
     /** Returns the order of this node in the sequence of members of the group */
     int32_t get_my_rank();
+
     /** Returns a vector of vectors listing the members of a single subgroup
      * (identified by type and index), organized by shard number. */
     std::vector<std::vector<node_id_t>> get_subgroup_members(subgroup_type_id_t subgroup_type, uint32_t subgroup_index);
+
     /** Returns the number of shards in a subgroup, identified by its type and index. */
     std::size_t get_number_of_shards_in_subgroup(subgroup_type_id_t subgroup_type, uint32_t subgroup_index);
+
+    /** Returns the number of subgroups (valid indexes) for a subgroup type */
+    uint32_t get_num_subgroups(subgroup_type_id_t subgroup_type);
+
     /**
      * If this node is a member of the given subgroup (identified by its type
      * and index), returns the number of the shard this node belongs to.
      * Otherwise, returns -1.
      */
     int32_t get_my_shard(subgroup_type_id_t subgroup_type, uint32_t subgroup_index);
+
+    /**
+     * Returns the subgroup index(es) that this node is a member of for the
+     * specified subgroup type. If this node is not a member of any subgroups
+     * of that type, returns an empty vector.
+     */
+    std::vector<uint32_t> get_my_subgroup_indexes(subgroup_type_id_t subgroup_type);
 
     /**
      * Determines whether a subgroup (identified by its ID) uses persistence.

--- a/include/derecho/persistent/Persistent.hpp
+++ b/include/derecho/persistent/Persistent.hpp
@@ -293,24 +293,34 @@ protected:
     static thread_local int64_t earliest_version_to_serialize;
 };
 
+/* ---------------------------- DeltaSupport Interface ---------------------------- */
 // If the type T in persistent<T> is a big object and the operations are small
-// updates, for example, an object store or a file system, then T would better
-// implement the IDeltaSupport interface. This interface allows persistent<T>
-// only store the delta in the log, avoiding huge duplicated data wasting
-// storage space as well as I/O bandwidth.
+// updates, for example, an object store or a file system, then T should prefer
+// to implement the IDeltaSupport interface. This interface allows persistent<T>
+// to only store the delta of each update in the log, rather than an entire copy
+// of each new version, which avoids wasteful duplication of a huge amount of data.
 //
-// The idea is that T is responsible of keeping track of the updates in the form
-// of a byte array - the DELTA, as long as the update should be persisted. Each
-// time Persistent<T> trying to make a version, it collects the DELTA and write
-// it to the log. On reloading data from persistent storage, the DELTAs in the
-// log entries are applied in order. TODO: use checkpointing to accelerate it!
+// The idea is that T is responsible for keeping track of the data that should be
+// persisted for each update in the form of a byte array called the DELTA. Each
+// time Persistent<T> tries to make a version, it collects the DELTA from T and
+// writes it to the log. Upon reloading data from persistent storage, the DELTAs in
+// the log entries are applied in order. TODO: use checkpointing to accelerate it!
 //
-// There are three method included in this interface:
-// - 'finalizeCurrentDelta'     This method is called when Persistent<T> trying to
-//   make a version. Once done, the delta needs to be cleared.
-// - 'applyDelta' This method is called on object construction from the disk
-// - 'create' This static method is used to create an empty object from deserialization
+// There are three methods included in this interface:
+// - 'finalizeCurrentDelta'     This method is called when Persistent<T> wants to
+//   make a version. Its argument is a DeltaFinalizer function; T should invoke this
+//   function to give Persistent<T> the Delta data.
+// - 'applyDelta' This method is called on object construction from the disk. Its argument
+//   is a single Delta data buffer that should be applied.
+// - 'create' This static method is used to create an empty object from a deserialization
 //   manager.
+
+/**
+ * Type of a function that receives a Delta data buffer from an object with Delta support,
+ * for the purpose of writing the Delta to a persistent log.
+ * @param arg1 a pointer to the buffer
+ * @param arg2 the buffer's size
+ */
 using DeltaFinalizer = std::function<void(char const* const, std::size_t)>;
 
 template <typename DeltaObjectType>
@@ -625,7 +635,8 @@ public:
      * @throws PERSIST_EXP_INV_INDEX, when the index 'idx' does not exists.
      */
     template <typename DeltaType>
-    std::enable_if_t<std::is_base_of<IDeltaSupport<ObjectType>, ObjectType>::value, std::unique_ptr<DeltaType>> getDeltaByIndex(
+    std::enable_if_t<std::is_base_of<IDeltaSupport<ObjectType>, ObjectType>::value, std::unique_ptr<DeltaType>>
+    getDeltaByIndex(
             int64_t idx,
             mutils::DeserializationManager* dm = nullptr) const;
 
@@ -674,6 +685,36 @@ public:
     template <typename DeltaType>
     std::enable_if_t<std::is_base_of<IDeltaSupport<ObjectType>, ObjectType>::value, std::unique_ptr<DeltaType>>
     getDelta(const version_t ver,
+             mutils::DeserializationManager* dm = nullptr) const;
+
+    /**
+     * getDeltaSignature(const version_t,const Func&,unsigned char*,version_t&,mutils::DeserializationManager*)
+     *
+     * Gets the signature associated with the delta at the given version, but only if it matches
+     * the provided predicate. The user-provided search predicate should be a function that is called
+     * with a delta as input, and returns true if that delta contains the desired data.
+     *
+     * @tparam DeltaType        User-specified DeltaType
+     * @tparam DummyObjectType  A copy of the class's ObjectType template parameter, which is necessary for
+     *                          std::enable_if_t to work on this function -- std::enable_if_t is only supposed
+     *                          to work on templates of the function, not templates of the class. See
+     *                          https://stackoverflow.com/questions/13401716/
+     *
+     * @param ver               Version to retrieve a signature for
+     * @param search_predicate  User-provided function that determines if a DeltaType& is the desired one
+     * @param signature         A byte buffer that will be filled with the signature on the Delta at this version
+     * @param prev_ver          A variable which will be updated to equal the previous version whose signature is
+     *                          included in this version's signature, or INVALID_VERSION if the Delta at this version
+     *                          fails the search predicate
+     *
+     * @return True if a signature was placed in the signature buffer, false if there was no log entry at the
+     * requested version or the delta at that entry did not pass the user-provided search predicate
+     */
+    template <typename DeltaType, typename DummyObjectType = ObjectType>
+    std::enable_if_t<std::is_base_of<IDeltaSupport<DummyObjectType>, DummyObjectType>::value, bool>
+    getDeltaSignature(const version_t ver,
+             const std::function<bool(const DeltaType&)>& search_predicate,
+             unsigned char* signature, version_t& prev_ver,
              mutils::DeserializationManager* dm = nullptr) const;
 
     /**
@@ -930,6 +971,19 @@ public:
      * no version in the log with the requested version number
      */
     virtual bool getSignature(version_t ver, unsigned char* signature, version_t& prev_ver) const;
+
+    /**
+     * Retrieves the signature associated with the specified log index and copies
+     * it into the provided buffer, which must be of the correct length. This is only
+     * useful if the caller already knows the log index, so it's more likely to be used
+     * internally by other Persistant methods than by a client.
+     * @param index The log index to get the signature for
+     * @param signature A byte buffer into which the signature will be placed
+     * @param prev_ver A variable which will be updated to equal the previous
+     * version whose signature is included in this version's signature
+     * @return true if a signature was successfully retrieved, false if the index is invalid.
+     */
+    virtual bool getSignatureByIndex(int64_t index, unsigned char* signature, version_t& prev_ver) const;
 
     /**
      * Update the provided Verifier with the state of T at the specified version.

--- a/include/derecho/persistent/detail/FilePersistLog.hpp
+++ b/include/derecho/persistent/detail/FilePersistLog.hpp
@@ -200,9 +200,10 @@ public:
     virtual const void* getEntry(const HLC& hlc) override;
     virtual version_t persist(version_t ver,
                               bool preLocked = false) override;
-    virtual void processEntryAtVersion(version_t ver, const std::function<void(const void*, std::size_t)>& func);
-    virtual void addSignature(version_t ver, const unsigned char* signature, version_t previous_signed_version);
-    virtual bool getSignature(version_t ver, unsigned char* signature, version_t& previous_signed_version);
+    virtual void processEntryAtVersion(version_t ver, const std::function<void(const void*, std::size_t)>& func) override;
+    virtual void addSignature(version_t ver, const unsigned char* signature, version_t previous_signed_version) override;
+    virtual bool getSignature(version_t ver, unsigned char* signature, version_t& previous_signed_version) override;
+    virtual bool getSignatureByIndex(int64_t index, unsigned char* signature, version_t& prev_ver) override;
     virtual void trimByIndex(int64_t eno) override;
     virtual void trim(version_t ver) override;
     virtual void trim(const HLC& hlc) override;

--- a/include/derecho/persistent/detail/PersistLog.hpp
+++ b/include/derecho/persistent/detail/PersistLog.hpp
@@ -190,6 +190,21 @@ public:
                               version_t& prev_signed_ver) = 0;
 
     /**
+     * Retrieve a signature from a specific log index, assuming signatures are enabled.
+     * This is more efficient than getSignature, but only works if you already know the
+     * log index number, which is an implementation detail.
+     * @param index - log index number
+     * @param signature - A byte buffer into which the signature will be copied.
+     * Must be at least signature_size bytes.
+     * @param prev_ver A variable which will be updated to equal the previous
+     * version whose signature is included in this version's signature, or
+     * INVALID_VERSION if the index is invalid or signatures are disabled (in
+     * this case, no signature will be returned either)
+     * @return true if a signature was successfully retrieved, false if the index is
+     * invalid or signatures are disabled.
+     */
+    virtual bool getSignatureByIndex(int64_t index, unsigned char* signature, version_t& prev_ver) = 0;
+    /**
      * Trim the log till entry number eno, inclusively.
      * For exmaple, there is a log: [7,8,9,4,5,6]. After trim(3), it becomes [5,6]
      * @param eno -  the log number to be trimmed

--- a/include/derecho/persistent/detail/Persistent_impl.hpp
+++ b/include/derecho/persistent/detail/Persistent_impl.hpp
@@ -354,7 +354,7 @@ Persistent<ObjectType, storageType>::getDeltaSignature(const version_t ver,
     if(version_index == INVALID_INDEX) {
         return false;
     }
-    char* delta_data = reinterpret_cast<char*>(m_pLog->getEntryByIndex(version_index));
+    const char* delta_data = reinterpret_cast<const char*>(m_pLog->getEntryByIndex(version_index));
     if(mutils::deserialize_and_run(dm, delta_data, search_predicate)) {
         return m_pLog->getSignatureByIndex(version_index, signature, prev_ver);
     } else {

--- a/src/applications/demos/overlapping_replicated_objects.cpp
+++ b/src/applications/demos/overlapping_replicated_objects.cpp
@@ -76,15 +76,17 @@ int main(int argc, char** argv) {
 
     cout << "Finished constructing/joining Group" << endl;
 
+    uint32_t my_id = derecho::getConfUInt32(CONF_DERECHO_LOCAL_ID);
     //Now have each node send some updates to the Replicated objects
     //The code must be different depending on which subgroup this node is in,
-    //which we can determine based on which membership list it appears in
-    uint32_t my_id = derecho::getConfUInt32(CONF_DERECHO_LOCAL_ID);
-    std::vector<node_id_t> foo_members = group.get_subgroup_members<Foo>(0)[0];
-    std::vector<node_id_t> cache_members = group.get_subgroup_members<Cache>(0)[0];
-    auto find_in_foo_results = std::find(foo_members.begin(), foo_members.end(), my_id);
-    if(find_in_foo_results != foo_members.end()) {
-        uint32_t rank_in_foo_and_bar = std::distance(foo_members.begin(), find_in_foo_results);
+    //which we can determine by attempting to locate its shard in each subgroup.
+    //Note that there is only one subgroup of each type.
+    int32_t my_foo_shard = group.get_my_shard<Foo>();
+    int32_t my_cache_shard = group.get_my_shard<Cache>();
+    if(my_foo_shard != -1) {
+        std::vector<node_id_t> foo_members = group.get_subgroup_members<Foo>()[my_foo_shard];
+        //Any node in subgroup foo is also in subgroup bar
+        uint32_t rank_in_foo_and_bar = derecho::index_of(foo_members, my_id);
         Replicated<Foo>& foo_rpc_handle = group.get_subgroup<Foo>();
         Replicated<Bar>& bar_rpc_handle = group.get_subgroup<Bar>();
         if(rank_in_foo_and_bar == 0) {
@@ -125,7 +127,8 @@ int main(int argc, char** argv) {
             cout << "Clearing Bar's log" << endl;
             derecho::rpc::QueryResults<void> void_future = bar_rpc_handle.ordered_send<RPC_NAME(clear)>();
         }
-    } else {
+    } else if(my_cache_shard != -1) {
+        std::vector<node_id_t> cache_members = group.get_subgroup_members<Cache>()[my_cache_shard];
         uint32_t rank_in_cache = derecho::index_of(cache_members, my_id);
         Replicated<Cache>& cache_rpc_handle = group.get_subgroup<Cache>();
         if(rank_in_cache == 0) {
@@ -153,7 +156,8 @@ int main(int argc, char** argv) {
             //Do it twice just to send more messages, so that the "contains" and "get" calls can go through
             cache_rpc_handle.ordered_send<RPC_NAME(put)>("Ken", "Birman");
             cache_rpc_handle.ordered_send<RPC_NAME(put)>("Ken", "Birman");
-            node_id_t p2p_target = foo_members[2];
+            //Send to node rank 2 in shard 0 of the Foo subgroup
+            node_id_t p2p_target = group.get_subgroup_members<Foo>()[0][2];
             cout << "Reading Foo's state from node " << p2p_target << endl;
             ExternalCaller<Foo>& p2p_foo_handle = group.get_nonmember_subgroup<Foo>();
             derecho::rpc::QueryResults<int> foo_results = p2p_foo_handle.p2p_send<RPC_NAME(read_state)>(p2p_target);
@@ -164,6 +168,8 @@ int main(int argc, char** argv) {
             cache_rpc_handle.ordered_send<RPC_NAME(put)>("Ken", "Woodberry");
             cache_rpc_handle.ordered_send<RPC_NAME(put)>("Ken", "Woodberry");
         }
+    } else {
+        std::cout << "This node was not assigned to any subgroup!" << std::endl;
     }
 
     cout << "Reached end of main(), entering infinite loop so program doesn't exit" << std::endl;

--- a/src/applications/demos/signed_store_mockup.cpp
+++ b/src/applications/demos/signed_store_mockup.cpp
@@ -277,12 +277,12 @@ int main(int argc, char** argv) {
             signature_subgroup_factory);
 
     //Figure out which subgroup this node got assigned to
-    uint32_t my_id = derecho::getConfUInt32(CONF_DERECHO_LOCAL_ID);
-    std::vector<node_id_t> storage_members = group.get_subgroup_members<ObjectStore>(0)[0];
-    std::vector<node_id_t> signature_members = group.get_subgroup_members<SignatureStore>(0)[0];
-    std::vector<std::vector<node_id_t>> client_tier_shards = group.get_subgroup_members<ClientTier>(0);
-    if(member_of_shards(my_id, client_tier_shards)) {
-        std::cout << "Assigned the ClientTier role" << std::endl;
+    int32_t my_storage_shard = group.get_my_shard<ObjectStore>();
+    int32_t my_signature_shard = group.get_my_shard<SignatureStore>();
+    int32_t my_client_shard = group.get_my_shard<ClientTier>();
+    if(my_client_shard != -1) {
+        std::cout << "Assigned the ClientTier role, in shard " << my_client_shard << std::endl;
+        uint32_t my_id = derecho::getConfUInt32(CONF_DERECHO_LOCAL_ID);
         //Simulate getting a bunch of updates from a client and submitting them to the object store
         Blob test_update(nullptr, update_size);
         derecho::Replicated<ClientTier>& this_subgroup = group.get_subgroup<ClientTier>();
@@ -304,11 +304,11 @@ int main(int argc, char** argv) {
             }
             std::cout << std::dec << std::endl;
         }
-    } else if(std::find(signature_members.begin(), signature_members.end(), my_id) != signature_members.end()) {
+    } else if(my_signature_shard != -1) {
         std::cout << "Assigned the SignatureStore role." << std::endl;
         std::cout << "Press enter when finished with test." << std::endl;
         std::cin.get();
-    } else if(std::find(storage_members.begin(), storage_members.end(), my_id) != storage_members.end()) {
+    } else if(my_storage_shard != -1) {
         std::cout << "Assigned the ObjectStore role." << std::endl;
         std::cout << "Press enter when finished with test." << std::endl;
         std::cin.get();

--- a/src/applications/demos/signed_store_mockup.hpp
+++ b/src/applications/demos/signed_store_mockup.hpp
@@ -165,15 +165,15 @@ public:
 
     //This class has no serialized state, so DEFAULT_SERIALIZATION_SUPPORT won't work.
     //We must still provide trivial implementations of these functions.
-    std::size_t to_bytes(char* v) const { return 0; };
+    std::size_t to_bytes(char* v) const { return 0; }
 
-    std::size_t bytes_size() const { return 0; };
+    std::size_t bytes_size() const { return 0; }
 
-    void post_object(const std::function<void(char const* const, std::size_t)>& f) const {};
+    void post_object(const std::function<void(char const* const, std::size_t)>& f) const {}
 
     void ensure_registered(mutils::DeserializationManager&) {}
 
     static std::unique_ptr<ClientTier> from_bytes(mutils::DeserializationManager*, const char* const v) {
         return std::make_unique<ClientTier>();
-    };
+    }
 };

--- a/src/applications/demos/simple_replicated_objects.cpp
+++ b/src/applications/demos/simple_replicated_objects.cpp
@@ -47,16 +47,19 @@ int main(int argc, char** argv) {
 
     cout << "Finished constructing/joining Group" << endl;
 
-    //Now have each node send some updates to the Replicated objects
-    //The code must be different depending on which subgroup this node is in,
-    //which we can determine based on which membership list it appears in
     uint32_t my_id = derecho::getConfUInt32(CONF_DERECHO_LOCAL_ID);
-    std::vector<node_id_t> foo_members = group.get_subgroup_members<Foo>(0)[0];
-    std::vector<node_id_t> bar_members = group.get_subgroup_members<Bar>(0)[0];
-    auto find_in_foo_results = std::find(foo_members.begin(), foo_members.end(), my_id);
-    if(find_in_foo_results != foo_members.end()) {
-        uint32_t rank_in_foo = std::distance(foo_members.begin(), find_in_foo_results);
+    //Now have each node send some updates to the Replicated objects.
+    //The code must be different depending on which subgroup this node is in,
+    //which we can determine by attempting to locate its shard in each subgroup.
+    //Note that since there is only one subgroup of each type we can omit the
+    //subgroup_index parameter to many of the group.get_X() methods
+    int32_t my_foo_shard = group.get_my_shard<Foo>();
+    int32_t my_bar_shard = group.get_my_shard<Bar>();
+    if(my_foo_shard != -1) {
+        std::vector<node_id_t> foo_members = group.get_subgroup_members<Foo>()[my_foo_shard];
+        uint32_t rank_in_foo = derecho::index_of(foo_members, my_id);
         Replicated<Foo>& foo_rpc_handle = group.get_subgroup<Foo>();
+        //Each member within the shard sends a different multicast
         if(rank_in_foo == 0) {
             int new_value = 1;
             cout << "Changing Foo's state to " << new_value << endl;
@@ -85,7 +88,8 @@ int main(int argc, char** argv) {
                 cout << "Node " << reply_pair.first << " says the state is: " << reply_pair.second.get() << endl;
             }
         }
-    } else {
+    } else if(my_bar_shard != -1) {
+        std::vector<node_id_t> bar_members = group.get_subgroup_members<Bar>()[my_bar_shard];
         uint32_t rank_in_bar = derecho::index_of(bar_members, my_id);
         Replicated<Bar>& bar_rpc_handle = group.get_subgroup<Bar>();
         if(rank_in_bar == 0) {
@@ -100,7 +104,8 @@ int main(int argc, char** argv) {
         } else if(rank_in_bar == 1) {
             cout << "Appending to Bar" << endl;
             bar_rpc_handle.ordered_send<RPC_NAME(append)>("Write from 1...");
-            node_id_t p2p_target = foo_members[2];
+            //Send to node rank 2 in shard 0 of the Foo subgroup
+            node_id_t p2p_target = group.get_subgroup_members<Foo>()[0][2];
             cout << "Reading Foo's state from node " << p2p_target << endl;
             ExternalCaller<Foo>& p2p_foo_handle = group.get_nonmember_subgroup<Foo>();
             derecho::rpc::QueryResults<int> foo_results = p2p_foo_handle.p2p_send<RPC_NAME(read_state)>(p2p_target);
@@ -116,6 +121,8 @@ int main(int argc, char** argv) {
             cout << "Clearing Bar's log" << endl;
             derecho::rpc::QueryResults<void> void_future = bar_rpc_handle.ordered_send<RPC_NAME(clear)>();
         }
+    } else {
+        std::cout << "This node was not assigned to any subgroup!" << std::endl;
     }
 
     cout << "Reached end of main(), entering infinite loop so program doesn't exit" << std::endl;

--- a/src/applications/demos/simple_replicated_objects_json.cpp
+++ b/src/applications/demos/simple_replicated_objects_json.cpp
@@ -49,16 +49,19 @@ int main(int argc, char** argv) {
 
     cout << "Finished constructing/joining Group" << endl;
 
-    //Now have each node send some updates to the Replicated objects
-    //The code must be different depending on which subgroup this node is in,
-    //which we can determine based on which membership list it appears in
     uint32_t my_id = derecho::getConfUInt32(CONF_DERECHO_LOCAL_ID);
-    std::vector<node_id_t> foo_members = group.get_subgroup_members<Foo>(0)[0];
-    std::vector<node_id_t> bar_members = group.get_subgroup_members<Bar>(0)[0];
-    auto find_in_foo_results = std::find(foo_members.begin(), foo_members.end(), my_id);
-    if(find_in_foo_results != foo_members.end()) {
-        uint32_t rank_in_foo = std::distance(foo_members.begin(), find_in_foo_results);
-        Replicated<Foo>& foo_rpc_handle = group.get_subgroup<Foo>();
+    //Now have each node send some updates to the Replicated objects
+    //The code must be different depending on which subgroup this node is in
+    std::vector<uint32_t> my_foo_subgroups = group.get_my_subgroup_indexes<Foo>();
+    std::vector<uint32_t> my_bar_subgroups = group.get_my_subgroup_indexes<Bar>();
+    //There should only be one subgroup of each type, but if not, make each one behave exactly the same
+    //Note that this loop will do nothing if this node is not in a Foo subgroup.
+    for(const uint32_t foo_subgroup_index : my_foo_subgroups) {
+        int32_t my_foo_shard = group.get_my_shard<Foo>(foo_subgroup_index);
+        std::vector<node_id_t> shard_members = group.get_subgroup_members<Foo>(foo_subgroup_index)[my_foo_shard];
+        uint32_t rank_in_foo = derecho::index_of(shard_members, my_id);
+        Replicated<Foo>& foo_rpc_handle = group.get_subgroup<Foo>(foo_subgroup_index);
+        //Each member within the shard sends a different multicast
         if(rank_in_foo == 0) {
             int new_value = 1;
             cout << "Changing Foo's state to " << new_value << endl;
@@ -87,9 +90,13 @@ int main(int argc, char** argv) {
                 cout << "Node " << reply_pair.first << " says the state is: " << reply_pair.second.get() << endl;
             }
         }
-    } else {
+    }
+    //This loop does nothing if this node is not in a Bar subgroup
+    for(const uint32_t bar_subgroup_index : my_bar_subgroups) {
+        int32_t my_bar_shard = group.get_my_shard<Bar>(bar_subgroup_index);
+        std::vector<node_id_t> bar_members = group.get_subgroup_members<Bar>(bar_subgroup_index)[my_bar_shard];
         uint32_t rank_in_bar = derecho::index_of(bar_members, my_id);
-        Replicated<Bar>& bar_rpc_handle = group.get_subgroup<Bar>();
+        Replicated<Bar>& bar_rpc_handle = group.get_subgroup<Bar>(bar_subgroup_index);
         if(rank_in_bar == 0) {
             cout << "Appending to Bar." << endl;
             derecho::rpc::QueryResults<void> void_future = bar_rpc_handle.ordered_send<RPC_NAME(append)>("Write from 0...");
@@ -102,7 +109,8 @@ int main(int argc, char** argv) {
         } else if(rank_in_bar == 1) {
             cout << "Appending to Bar" << endl;
             bar_rpc_handle.ordered_send<RPC_NAME(append)>("Write from 1...");
-            node_id_t p2p_target = foo_members[2];
+            //Send to node rank 2 in shard 0 of the same Foo subgroup index as this Bar subgroup
+            node_id_t p2p_target = group.get_subgroup_members<Foo>(bar_subgroup_index)[0][2];
             cout << "Reading Foo's state from node " << p2p_target << endl;
             ExternalCaller<Foo>& p2p_foo_handle = group.get_nonmember_subgroup<Foo>();
             derecho::rpc::QueryResults<int> foo_results = p2p_foo_handle.p2p_send<RPC_NAME(read_state)>(p2p_target);
@@ -119,7 +127,9 @@ int main(int argc, char** argv) {
             derecho::rpc::QueryResults<void> void_future = bar_rpc_handle.ordered_send<RPC_NAME(clear)>();
         }
     }
-
+    if(my_bar_subgroups.size() == 0 && my_foo_subgroups.size() == 0) {
+        std::cout << "This node was not assigned to any subgroup!" << std::endl;
+    }
     cout << "Reached end of main(), entering infinite loop so program doesn't exit" << std::endl;
     while(true) {
     }

--- a/src/applications/tests/unit_tests/log_restart_test.cpp
+++ b/src/applications/tests/unit_tests/log_restart_test.cpp
@@ -127,10 +127,9 @@ int main(int argc, char** argv) {
         return 1;
     }
     //Determine whether the running process is in the persistent or non-persistent subgroup
-    uint32_t my_id = derecho::getConfUInt32(CONF_DERECHO_LOCAL_ID);
-    std::vector<node_id_t> non_persistent_members = group.get_subgroup_members<NonPersistentThing>(0)[0];
-    if(std::find(non_persistent_members.begin(), non_persistent_members.end(), my_id)
-       == non_persistent_members.end()) {
+    std::vector<uint32_t> my_persistent_subgroups = group.get_my_subgroup_indexes<PersistentThing>();
+    if(my_persistent_subgroups.size() > 0) {
+        assert(my_persistent_subgroups.size() == 1);
         //"Main" code for the members of PersistentThing shards
         std::cout << "In the PersistentThing subgroup" << std::endl;
         Replicated<PersistentThing>& persistent_handle = group.get_subgroup<PersistentThing>();
@@ -150,7 +149,7 @@ int main(int argc, char** argv) {
                 std::cout << "Done with counter = " << counter << std::endl;
             }
         }
-    } else {
+    } else if(group.get_my_subgroup_indexes<NonPersistentThing>().size() > 0) {
         //"Main" code for the members of the NonPersistentThing subgroup
         std::cout << "In the NonPersistentThing subgroup" << std::endl;
         Replicated<NonPersistentThing>& thing_handle = group.get_subgroup<NonPersistentThing>();
@@ -170,6 +169,8 @@ int main(int argc, char** argv) {
                 std::cout << "Done with counter = " << counter << std::endl;
             }
         }
+    } else {
+        std::cout << "This node was not assigned to any subgroup!" << std::endl;
     }
     std::cout << "Reached end of main(), entering infinite loop so program doesn't exit" << std::endl;
     while(true) {

--- a/src/applications/tests/unit_tests/view_change_test.cpp
+++ b/src/applications/tests/unit_tests/view_change_test.cpp
@@ -111,6 +111,7 @@ void nonpersistent_test(uint32_t num_shards, uint32_t max_shard_size, uint32_t n
 
     derecho::Group<TestObject> group({}, layout, {}, {&new_view_callback}, test_object_factory);
 
+    std::cout << "In shard " << group.get_my_shard<TestObject>() << std::endl;
     std::cout << "Sending " << num_updates << " multicast updates" << std::endl;
     derecho::Replicated<TestObject>& replica_group = group.get_subgroup<TestObject>();
     for(uint32_t counter = 0; counter < num_updates ; ++counter) {
@@ -150,6 +151,7 @@ void persistent_test(uint32_t num_shards, uint32_t max_shard_size, uint32_t num_
 
     derecho::Group<PersistentTestObject> group({}, layout, {}, {&new_view_callback}, test_object_factory);
 
+    std::cout << "In shard " << group.get_my_shard<PersistentTestObject>() << std::endl;
     std::cout << "Sending " << num_updates << " multicast updates" << std::endl;
     derecho::Replicated<PersistentTestObject>& replica_group = group.get_subgroup<PersistentTestObject>();
     for(uint32_t counter = 0; counter < num_updates; ++counter) {

--- a/src/core/view_manager.cpp
+++ b/src/core/view_manager.cpp
@@ -2448,6 +2448,11 @@ std::size_t ViewManager::get_number_of_shards_in_subgroup(subgroup_type_id_t sub
     return curr_view->subgroup_shard_views.at(subgroup_id).size();
 }
 
+uint32_t ViewManager::get_num_subgroups(subgroup_type_id_t subgroup_type) {
+    shared_lock_t read_lock(view_mutex);
+    return curr_view->subgroup_ids_by_type_id.at(subgroup_type).size();
+}
+
 int32_t ViewManager::get_my_shard(subgroup_type_id_t subgroup_type, uint32_t subgroup_index) {
     shared_lock_t read_lock(view_mutex);
     subgroup_id_t subgroup_id = curr_view->subgroup_ids_by_type_id.at(subgroup_type).at(subgroup_index);
@@ -2457,6 +2462,19 @@ int32_t ViewManager::get_my_shard(subgroup_type_id_t subgroup_type, uint32_t sub
     } else {
         return find_id_result->second;
     }
+}
+
+std::vector<uint32_t> ViewManager::get_my_subgroup_indexes(subgroup_type_id_t subgroup_type) {
+    std::vector<uint32_t> my_indexes;
+    shared_lock_t read_lock(view_mutex);
+    //The indexes of this vector are the subgroup indexes for the type
+    const std::vector<subgroup_id_t>& subgroup_ids_of_type = curr_view->subgroup_ids_by_type_id.at(subgroup_type);
+    for(uint32_t subgroup_index = 0; subgroup_index < subgroup_ids_of_type.size(); ++subgroup_index) {
+        if(curr_view->my_subgroups.find(subgroup_ids_of_type[subgroup_index]) != curr_view->my_subgroups.end()) {
+            my_indexes.push_back(subgroup_index);
+        }
+    }
+    return my_indexes;
 }
 
 bool ViewManager::subgroup_is_persistent(subgroup_id_t subgroup_id) const {


### PR DESCRIPTION
Weijia and I realized that some parts of Derecho would need additional functions in order to get CascadeChain to work the way I want it to. This branch implements those changes. Specifically:

* Persistent<T> has a new `getDeltaSignature<DeltaType>()` method that allows the caller to specify a "search function" that will be called on the delta value that is in the log at the specified version number (similar to the user-provided function in `getDelta<DeltaType>()`). If the search function returns false when called on the delta value, no signature will be returned and `getDeltaSignature` returns false.
* Persistent<T> also has a new `getSignatureByIndex()` method, which helps implement `getDeltaSignature()`
* Group has a new `get_num_subgroups<SubgroupType>()` method, which returns the number of subgroups of the same type that exist in the current configuration, and a new `get_my_subgroup_indexes<SubgroupType>()` method, which returns a vector of subgroup indexes (of that type) that the local node belongs to.
* I also added `get_num_subgroups()` to the `_Group` and `GroupProjection` classes, since they seem to implement all the other "get_number_of_X" methods, although I don't actually know what those classes are for.