### PR TITLE
Expose frontiers through Replicated<T>

### DIFF
--- a/include/derecho/core/detail/multicast_group.hpp
+++ b/include/derecho/core/detail/multicast_group.hpp
@@ -368,6 +368,11 @@ private:
     std::vector<std::unique_ptr<std::atomic<persistent::version_t>>> minimum_verified_version;
 
 
+    /**
+     * store the delivered_version
+     */
+    std::vector<std::unique_ptr<std::atomic<persistent::version_t>>> delivered_version;
+
     std::recursive_mutex msg_state_mtx;
     std::condition_variable_any sender_cv;
 

--- a/include/derecho/core/detail/replicated_impl.hpp
+++ b/include/derecho/core/detail/replicated_impl.hpp
@@ -281,6 +281,22 @@ const uint64_t Replicated<T>::compute_global_stability_frontier() {
 }
 
 template <typename T>
+persistent::version_t Replicated<T>::get_global_persistence_frontier () {
+    return group_rpc_manager.view_manager.get_global_persistence_frontier(subgroup_id);
+}
+
+template <typename T>
+bool Replicated<T>::wait_for_global_persistence_frontier(persistent::version_t version) {
+    return group_rpc_manager.view_manager.wait_for_global_persistence_frontier(subgroup_id,version);
+}
+
+template <typename T>
+persistent::version_t Replicated<T>::get_global_verified_frontier () {
+    return group_rpc_manager.view_manager.get_global_verified_frontier(subgroup_id);
+}
+
+
+template <typename T>
 ExternalCaller<T>::ExternalCaller(uint32_t type_id, node_id_t nid, subgroup_id_t subgroup_id,
                                   rpc::RPCManager& group_rpc_manager)
         : node_id(nid),

--- a/include/derecho/core/detail/view_manager.hpp
+++ b/include/derecho/core/detail/view_manager.hpp
@@ -877,6 +877,28 @@ public:
     const uint64_t compute_global_stability_frontier(subgroup_id_t subgroup_num);
 
     /**
+     * Get the current global persistence frontier. For persisted data ONLY.
+     * @param subgroup_num  the subgroup id
+     * @return the current persistence_frontier version
+     */
+    const persistent::version_t get_global_persistence_frontier(subgroup_id_t subgroup_num) const;
+
+    /**
+     * Wait on global persistent frontier
+     * @param subgroup_num  the subgroup id
+     * @param version   the version to wait on
+     * @return false if the given version is beyond the latest atomic broadcast.
+     */
+    bool wait_for_global_persistence_frontier(subgroup_id_t subgroup_num,persistent::version_t version) const;
+
+    /**
+     * Get the current global verified frontier. For persisted and signed data ONLY.
+     * @param subgroup_num  the subgroup id
+     * @return the current verified frontier version
+     */
+    const persistent::version_t get_global_verified_frontier(subgroup_id_t subgroup_num) const;
+
+    /**
      * @return a reference to the current View, wrapped in a container that
      * holds a read-lock on the View pointer. This allows the Group that
      * contains this ViewManager to look at the current View (and set it up

--- a/include/derecho/core/replicated.hpp
+++ b/include/derecho/core/replicated.hpp
@@ -301,6 +301,25 @@ public:
     virtual persistent::version_t get_minimum_latest_persisted_version();
 
     /**
+     * Returns the current global persistence frontier, aka, stable frontier that will survive whole system restart.
+     * Please note this applies to persistent data ONLY. The data not in Persistent<> are not saved.
+     */
+    virtual persistent::version_t get_global_persistence_frontier();
+
+    /**
+     * Wait until the current global persistence frontier advanced beyond a version.
+     * @param version   the version
+     * @return false if the given version is beyond the latest atomic broadcast.
+     */
+    virtual bool wait_for_global_persistence_frontier(persistent::version_t version);
+
+    /**
+     * Returns the current global verified frontier, aka, stable frontier that will survive whole system restart.
+     * Please note this applies to persistent data ONLY. The data not in Persistent<> are not saved.
+     */
+    virtual persistent::version_t get_global_verified_frontier();
+
+    /**
      * make a version for all the persistent<T> members.
      * @param ver - the version number to be made
      */

--- a/include/derecho/persistent/Persistent.hpp
+++ b/include/derecho/persistent/Persistent.hpp
@@ -898,6 +898,13 @@ public:
     virtual int64_t getIndexAtTime(const HLC& hlc) const;
 
     /**
+     * getVersionAtTime
+     *
+     * Get the latest version invlusively before time.
+     */
+    virtual persistent::version_t getVersionAtTime(const HLC& hlc) const;
+
+    /**
      * set(ObjectType&, version_t,const HLC&)
      *
      * Make a version with a version number and mhlc clock

--- a/include/derecho/persistent/detail/FilePersistLog.hpp
+++ b/include/derecho/persistent/detail/FilePersistLog.hpp
@@ -192,6 +192,7 @@ public:
     virtual int64_t getLatestIndex() override;
     virtual int64_t getVersionIndex(version_t ver, bool exact) override;
     virtual int64_t getHLCIndex(const HLC& hlc) override;
+    virtual version_t getHLCVersion(const HLC& hlc) override;
     virtual version_t getEarliestVersion() override;
     virtual version_t getLatestVersion() override;
     virtual version_t getLastPersistedVersion() override;

--- a/include/derecho/persistent/detail/PersistLog.hpp
+++ b/include/derecho/persistent/detail/PersistLog.hpp
@@ -123,6 +123,9 @@ public:
     // Get the Index corresponding to an HLC timestamp
     virtual int64_t getHLCIndex(const HLC& hlc) = 0;
 
+    // Get the version corresponding to an HLC timestamp
+    virtual version_t getHLCVersion(const HLC& hlc) = 0;
+
     // Get the Earlist version
     virtual version_t getEarliestVersion() = 0;
 

--- a/include/derecho/persistent/detail/Persistent_impl.hpp
+++ b/include/derecho/persistent/detail/Persistent_impl.hpp
@@ -313,7 +313,7 @@ auto Persistent<ObjectType, storageType>::get(
     }
     if constexpr(std::is_base_of<IDeltaSupport<ObjectType>, ObjectType>::value) {
         // "So far, the IDeltaSupport does not work with zero-copy 'Persistent::get()'. Emulate with the copy version."
-        return f(*this->get(ver, dm));
+        return fun(*this->get(ver, dm));
     } else {
         return mutils::deserialize_and_run(dm, pdat, fun);
     }

--- a/include/derecho/persistent/detail/Persistent_impl.hpp
+++ b/include/derecho/persistent/detail/Persistent_impl.hpp
@@ -507,6 +507,12 @@ int64_t Persistent<ObjectType, storageType>::getIndexAtTime(const HLC& hlc) cons
 
 template <typename ObjectType,
           StorageType storageType>
+version_t Persistent<ObjectType, storageType>::getVersionAtTime(const HLC& hlc) const {
+    return this->m_pLog->getHLCVersion(hlc);
+}
+
+template <typename ObjectType,
+          StorageType storageType>
 void Persistent<ObjectType, storageType>::set(ObjectType& v, version_t ver, const HLC& mhlc) {
     dbg_default_trace("append to log with ver({}),hlc({},{})", ver, mhlc.m_rtc_us, mhlc.m_logic);
     if constexpr(std::is_base_of<IDeltaSupport<ObjectType>, ObjectType>::value) {

--- a/src/core/multicast_group.cpp
+++ b/src/core/multicast_group.cpp
@@ -1235,7 +1235,9 @@ bool MulticastGroup::wait_for_global_persistence_frontier(subgroup_id_t subgroup
     }
 
     std::unique_lock<std::mutex> lck{minimum_persisted_mtx[subgroup_num]};
-    minimum_persisted_cv[subgroup_num].wait(lck, [this,subgroup_num,version]{return this->minimum_persisted_version[subgroup_num]->load(std::memory_order_relaxed) > version;});
+    minimum_persisted_cv[subgroup_num].wait(lck, [this,subgroup_num,version]{
+        return this->minimum_persisted_version[subgroup_num]->load(std::memory_order_relaxed) >= version;
+    });
 
     return true;
 }

--- a/src/core/view_manager.cpp
+++ b/src/core/view_manager.cpp
@@ -2418,6 +2418,18 @@ const uint64_t ViewManager::compute_global_stability_frontier(subgroup_id_t subg
     return curr_view->multicast_group->compute_global_stability_frontier(subgroup_num);
 }
 
+const persistent::version_t ViewManager::get_global_persistence_frontier(subgroup_id_t subgroup_num) const {
+    return curr_view->multicast_group->get_global_persistence_frontier(subgroup_num);
+}
+
+bool ViewManager::wait_for_global_persistence_frontier(subgroup_id_t subgroup_num, persistent::version_t version) const {
+    return curr_view->multicast_group->wait_for_global_persistence_frontier(subgroup_num, version);
+}
+
+const persistent::version_t ViewManager::get_global_verified_frontier(subgroup_id_t subgroup_num) const {
+    return curr_view->multicast_group->get_global_verified_frontier(subgroup_num);
+}
+
 void ViewManager::add_view_upcall(const view_upcall_t& upcall) {
     view_upcalls.emplace_back(upcall);
 }

--- a/src/persistent/FilePersistLog.cpp
+++ b/src/persistent/FilePersistLog.cpp
@@ -596,6 +596,16 @@ int64_t FilePersistLog::getHLCIndex(const HLC& rhlc) {
     return INVALID_INDEX;
 }
 
+version_t FilePersistLog::getHLCVersion(const HLC& rhlc) {
+    int64_t idx = getHLCIndex(rhlc);
+
+    if (idx != INVALID_INDEX) {
+        return LOG_ENTRY_AT(idx)->fields.ver;
+    }
+
+    return INVALID_VERSION;
+}
+
 const void* FilePersistLog::getEntry(const HLC& rhlc) {
     LogEntry* ple = nullptr;
 


### PR DESCRIPTION
Although we expose the stability frontiers by a set of callbacks passed to the Derecho group constructor, application code inside a subgroup type wrapped in `Replicated<T>` also needs access to those frontiers. This patch exposes those frontiers through a set of methods in the group handle available to `Replicated<T>`.

1. `Replicated<T>::get_global_persistence_frontier()`
1. `Replicated<T>::get_global_verified_frontier()`
1. `wait_for_global_persistence_frontier()`

`wait_for_global_verified_frontier()` is left for future, when we really need it. The mechanism should be the same as that of `wait_for_global_persistence_frontier()`.

I've tested it using the Cascade branch [`refactor_get_api`](https://github.com/Derecho-Project/cascade/tree/refactor_get_api) and it works.