### PR TITLE
Partial fix for P2PConnection concurrency issues

### DIFF
--- a/include/derecho/core/detail/external_group_impl.hpp
+++ b/include/derecho/core/detail/external_group_impl.hpp
@@ -55,13 +55,13 @@ auto ExternalClientCaller<T, ExternalGroupType>::p2p_send(node_id_t dest_node, A
                 const std::size_t max_p2p_request_payload_size = getConfUInt64(CONF_DERECHO_MAX_P2P_REQUEST_PAYLOAD_SIZE);
                 if(size <= max_p2p_request_payload_size) {
                     return (uint8_t*)group.get_sendbuffer_ptr(dest_node,
-                                                              sst::REQUEST_TYPE::P2P_REQUEST);
+                                                              sst::MESSAGE_TYPE::P2P_REQUEST);
                 } else {
                     throw derecho_exception("The size of serialized args exceeds the maximum message size (CONF_DERECHO_MAX_P2P_REQUEST_PAYLOAD_SIZE).");
                 }
             },
             std::forward<Args>(args)...);
-    group.finish_p2p_send(dest_node, subgroup_id, return_pair.pending);
+    group.send_p2p_message(dest_node, subgroup_id, return_pair.pending);
     return std::move(*return_pair.results);
 }
 
@@ -173,8 +173,8 @@ void ExternalGroup<ReplicatedTypes...>::clean_up() {
 
     for(auto& fulfilled_pending_results_pair : fulfilled_pending_results) {
         const subgroup_id_t subgroup_id = fulfilled_pending_results_pair.first;
-        //For each PendingResults in this subgroup, check the departed list of each shard in
-        //the subgroup, and call set_exception_for_removed_node for the departed nodes
+        // For each PendingResults in this subgroup, check the departed list of each shard in
+        // the subgroup, and call set_exception_for_removed_node for the departed nodes
         for(auto pending_results_iter = fulfilled_pending_results_pair.second.begin();
             pending_results_iter != fulfilled_pending_results_pair.second.end();) {
             std::shared_ptr<AbstractPendingResults> live_pending_results = pending_results_iter->lock();
@@ -183,15 +183,15 @@ void ExternalGroup<ReplicatedTypes...>::clean_up() {
                     shard_num < curr_view->subgroup_shard_views[subgroup_id].size();
                     ++shard_num) {
                     for(auto removed_id : curr_view->subgroup_shard_views[subgroup_id][shard_num].departed) {
-                        //This will do nothing if removed_id was never in the
-                        //shard this PendingResult corresponds to
+                        // This will do nothing if removed_id was never in the
+                        // shard this PendingResult corresponds to
                         dbg_default_debug("Setting exception for removed node {} on PendingResults for subgroup {}, shard {}", removed_id, subgroup_id, shard_num);
                         live_pending_results->set_exception_for_removed_node(removed_id);
                     }
                 }
                 pending_results_iter++;
             } else {
-                //Garbage-collect PendingResults pointers that are obsolete
+                // Garbage-collect PendingResults pointers that are obsolete
                 pending_results_iter = fulfilled_pending_results_pair.second.erase(pending_results_iter);
             }
         }
@@ -240,7 +240,7 @@ ExternalClientCaller<SubgroupType, ExternalGroup<ReplicatedTypes...>>& ExternalG
 }
 
 template <typename... ReplicatedTypes>
-volatile uint8_t* ExternalGroup<ReplicatedTypes...>::get_sendbuffer_ptr(uint32_t dest_id, sst::REQUEST_TYPE type) {
+volatile uint8_t* ExternalGroup<ReplicatedTypes...>::get_sendbuffer_ptr(uint32_t dest_id, sst::MESSAGE_TYPE type) {
     volatile uint8_t* buf;
     do {
         try {
@@ -254,9 +254,9 @@ volatile uint8_t* ExternalGroup<ReplicatedTypes...>::get_sendbuffer_ptr(uint32_t
 }
 
 template <typename... ReplicatedTypes>
-void ExternalGroup<ReplicatedTypes...>::finish_p2p_send(node_id_t dest_id, subgroup_id_t dest_subgroup_id, std::weak_ptr<rpc::AbstractPendingResults> pending_results_handle) {
+void ExternalGroup<ReplicatedTypes...>::send_p2p_message(node_id_t dest_id, subgroup_id_t dest_subgroup_id, std::weak_ptr<rpc::AbstractPendingResults> pending_results_handle) {
     try {
-        p2p_connections->send(dest_id);
+        p2p_connections->send(dest_id, sst::MESSAGE_TYPE::P2P_REQUEST);
     } catch(std::out_of_range& map_error) {
         throw node_removed_from_group_exception(dest_id);
     }
@@ -277,7 +277,7 @@ std::exception_ptr ExternalGroup<ReplicatedTypes...>::receive_message(
     if(receiver_function_entry == receivers->end()) {
         dbg_default_error("Received an RPC message with an invalid RPC opcode! Opcode was ({}, {}, {}, {}).",
                           indx.class_id, indx.subgroup_id, indx.function_id, indx.is_reply);
-        //TODO: We should reply with some kind of "no such method" error in this case
+        // TODO: We should reply with some kind of "no such method" error in this case
         return std::exception_ptr{};
     }
     std::size_t reply_header_size = header_space();
@@ -305,22 +305,12 @@ void ExternalGroup<ReplicatedTypes...>::p2p_message_handler(node_id_t sender_id,
     node_id_t received_from;
     uint32_t flags;
     retrieve_header(nullptr, msg_buf, payload_size, indx, received_from, flags);
-    size_t reply_size = 0;
     if(indx.is_reply) {
         // REPLYs can be handled here because they do not block.
         receive_message(indx, received_from, msg_buf + header_size, payload_size,
-                        [this, &reply_size, &sender_id](size_t _size) {
-                            reply_size = _size;
-                            if(reply_size <= p2p_connections->get_max_p2p_reply_size()) {
-                                return p2p_connections->get_sendbuffer_ptr(
-                                        sender_id, sst::REQUEST_TYPE::P2P_REPLY);
-                            } else {
-                                throw buffer_overflow_exception("Size of a P2P reply exceeds the maximum P2P reply message size");
-                            }
+                        [](size_t _size) -> uint8_t* {
+                            throw derecho::derecho_exception("A P2P reply message attempted to generate another reply");
                         });
-        if(reply_size > 0) {
-            p2p_connections->send(sender_id);
-        }
     } else if(RPC_HEADER_FLAG_TST(flags, CASCADE)) {
         // TODO: what is the lifetime of msg_buf? discuss with Sagar to make
         // sure the buffers are safely managed.
@@ -368,18 +358,20 @@ void ExternalGroup<ReplicatedTypes...>::p2p_request_worker() {
                             reply_size = _size;
                             if(reply_size <= p2p_connections->get_max_p2p_reply_size()) {
                                 return p2p_connections->get_sendbuffer_ptr(
-                                        request.sender_id, sst::REQUEST_TYPE::P2P_REPLY);
+                                        request.sender_id, sst::MESSAGE_TYPE::P2P_REPLY);
                             } else {
                                 throw buffer_overflow_exception("Size of a P2P reply exceeds the maximum P2P reply size.");
                             }
                         });
         if(reply_size > 0) {
-            p2p_connections->send(request.sender_id);
+            p2p_connections->send(request.sender_id, sst::MESSAGE_TYPE::P2P_REPLY);
         } else {
             // hack for now to "simulate" a reply for p2p_sends to functions that do not generate a reply
-            uint8_t* buf = p2p_connections->get_sendbuffer_ptr(request.sender_id, sst::REQUEST_TYPE::P2P_REPLY);
-            buf[0] = 0;
-            p2p_connections->send(request.sender_id);
+            uint8_t* buf = p2p_connections->get_sendbuffer_ptr(request.sender_id, sst::MESSAGE_TYPE::P2P_REPLY);
+            assert(buf != nullptr);
+            dbg_default_trace("Sending a null reply to node {} for a void P2P call", request.sender_id);
+            reinterpret_cast<size_t*>(buf)[0] = 0;
+            p2p_connections->send(request.sender_id, sst::MESSAGE_TYPE::P2P_REPLY);
         }
     }
 }
@@ -395,13 +387,14 @@ void ExternalGroup<ReplicatedTypes...>::p2p_receive_loop() {
 
     // loop event
     while(!thread_shutdown) {
-        //No need to get a View lock here, since ExternalGroup doesn't have a ViewManager or view-change events
-        auto optional_reply_pair = p2p_connections->probe_all();
-        if(optional_reply_pair) {
-            auto reply_pair = optional_reply_pair.value();
-            if(reply_pair.first != INVALID_NODE_ID) {
-                p2p_message_handler(reply_pair.first, (uint8_t*)reply_pair.second);
-                p2p_connections->update_incoming_seq_num(reply_pair.first);
+        // No need to get a View lock here, since ExternalGroup doesn't have a ViewManager or view-change events
+        auto optional_message = p2p_connections->probe_all();
+        if(optional_message) {
+            auto message_handle = optional_message.value();
+            // Invalid ID means the message was empty (a null reply)
+            if(message_handle.sender_id != INVALID_NODE_ID) {
+                p2p_message_handler(message_handle.sender_id, message_handle.buf);
+                p2p_connections->increment_incoming_seq_num(message_handle.sender_id, message_handle.type);
             }
 
             // update last time

--- a/include/derecho/core/detail/p2p_connection.hpp
+++ b/include/derecho/core/detail/p2p_connection.hpp
@@ -17,34 +17,32 @@
 namespace sst {
 class P2PConnectionManager;
 
-enum REQUEST_TYPE {
+enum MESSAGE_TYPE {
     P2P_REPLY = 0,
     P2P_REQUEST,
     RPC_REPLY
 };
-static const REQUEST_TYPE p2p_request_types[] = {P2P_REPLY,
+static const MESSAGE_TYPE p2p_message_types[] = {P2P_REPLY,
                                                  P2P_REQUEST,
                                                  RPC_REPLY};
-static const uint8_t num_request_types = 3;
+static const uint8_t num_p2p_message_types = 3;
 
-struct RequestParams {
-    uint32_t window_sizes[num_request_types];
-    uint32_t max_msg_sizes[num_request_types];
-    uint64_t offsets[num_request_types];
+struct ConnectionParams {
+    uint32_t window_sizes[num_p2p_message_types];
+    uint32_t max_msg_sizes[num_p2p_message_types];
+    uint64_t offsets[num_p2p_message_types];
 };
 
 class P2PConnection {
     const uint32_t my_node_id;
     const uint32_t remote_id;
-    const RequestParams& request_params;
+    const ConnectionParams& connection_params;
     std::unique_ptr<volatile uint8_t[]> incoming_p2p_buffer;
     std::unique_ptr<volatile uint8_t[]> outgoing_p2p_buffer;
     std::unique_ptr<resources> res;
-    std::map<REQUEST_TYPE, std::atomic<uint64_t>> incoming_seq_nums_map, outgoing_seq_nums_map;
-    REQUEST_TYPE prev_mode;
-    REQUEST_TYPE last_type;
-    uint64_t getOffsetSeqNum(REQUEST_TYPE type, uint64_t seq_num);
-    uint64_t getOffsetBuf(REQUEST_TYPE type, uint64_t seq_num);
+    std::map<MESSAGE_TYPE, std::atomic<uint64_t>> incoming_seq_nums_map, outgoing_seq_nums_map;
+    uint64_t getOffsetSeqNum(MESSAGE_TYPE type, uint64_t seq_num);
+    uint64_t getOffsetBuf(MESSAGE_TYPE type, uint64_t seq_num);
 
 protected:
     friend class P2PConnectionManager;
@@ -52,33 +50,32 @@ protected:
     uint32_t num_rdma_writes = 0;
 
 public:
-    P2PConnection(uint32_t my_node_id, uint32_t remote_id, uint64_t p2p_buf_size, const RequestParams& request_params);
+    P2PConnection(uint32_t my_node_id, uint32_t remote_id, uint64_t p2p_buf_size,
+                  const ConnectionParams& connection_params);
     ~P2PConnection();
 
     /**
-     * Returns a pointer into an incoming message buffer if there is a new
-     * incoming message from the remote node, or a null pointer if there are
-     * no new messages.
+     * Returns the pair (pointer into an incoming message buffer, type of message)
+     * if there is a new incoming message from the remote node, or std::nullopt if
+     * there are no new messages.
      */
-    uint8_t* probe();
+    std::optional<std::pair<uint8_t*, MESSAGE_TYPE>> probe();
     /**
-     * Increments the sequence number of the incoming message type last
-     * retrieved by probe(). This assumes that it is called immediately
-     * after a successful call to probe().
+     * Increments the incoming sequence number for the specified message type,
+     * indicating that the caller is finished handling the current incoming
+     * message of that type.
      */
-    void update_incoming_seq_num();
+    void increment_incoming_seq_num(MESSAGE_TYPE type);
     /**
      * Returns a pointer to the beginning of the next available message buffer
-     * for the specified request type, or a null pointer if no message buffer
+     * for the specified message type, or a null pointer if no message buffer
      * is available.
      */
-    uint8_t* get_sendbuffer_ptr(REQUEST_TYPE type);
+    uint8_t* get_sendbuffer_ptr(MESSAGE_TYPE type);
     /**
      * Sends the next outgoing message, i.e. the one populated by the most
-     * recent call to get_sendbuffer_ptr. This assumes the message's
-     * REQUEST_TYPE is the same as the one supplied to the most recent call
-     * to get_sendbuffer_ptr.
+     * recent call to get_sendbuffer_ptr, of the specified message type.
      */
-    void send();
+    void send(MESSAGE_TYPE type);
 };
 }  // namespace sst

--- a/include/derecho/core/detail/p2p_connection_manager.hpp
+++ b/include/derecho/core/detail/p2p_connection_manager.hpp
@@ -32,10 +32,16 @@ struct P2PParams {
     failure_upcall_t failure_upcall;
 };
 
+struct MessagePointer {
+    node_id_t sender_id;
+    uint8_t* buf;
+    MESSAGE_TYPE type;
+};
+
 class P2PConnectionManager {
     const node_id_t my_node_id;
 
-    RequestParams request_params;
+    ConnectionParams request_params;
     /**
      * Contains one entry per possible Node ID; the vector index is the node ID.
      * Each entry is a pair consisting of a mutex protecting that entry and a
@@ -82,32 +88,34 @@ public:
      */
     std::size_t get_max_rpc_reply_size();
     /**
-     * Increments the sequence number of the last-received message type for
-     * the specified node's connection.
+     * Increments the sequence number of the specified message type for
+     * the specified node's connection, indicating that the caller is done
+     * receiving the current message of that type.
      */
-    void update_incoming_seq_num(node_id_t node_id);
+    void increment_incoming_seq_num(node_id_t node_id, MESSAGE_TYPE type);
     /**
      * Checks all the P2P connection buffers for new messages. If any
-     * connection has a new message, this returns a pair containing the
-     * sender's ID and a pointer into the message buffer.
-     * @return (remote node ID, message byte buffer)
+     * connection has a new message, this returns a MessagePointer object
+     * describing the message: the sender's ID, a pointer into the message
+     * buffer, and the type of message in the buffer.
+     * @return A MessagePointer struct, or std::nullopt if no connection has a new message.
      */
-    std::optional<std::pair<node_id_t, uint8_t*>> probe_all();
+    std::optional<MessagePointer> probe_all();
     /**
      * Returns a pointer to the beginning of the next available message buffer
-     * for the specified request type in the specified node's P2P connection
+     * for the specified message type in the specified node's P2P connection
      * channel, or a null pointer if no such message buffer is available.
      * @param node_id The ID of the remote node that will be sent to
      * @param type The type of P2P message to send
      * @return A pointer to the beginning of a message buffer, or null
      */
-    uint8_t* get_sendbuffer_ptr(node_id_t node_id, REQUEST_TYPE type);
+    uint8_t* get_sendbuffer_ptr(node_id_t node_id, MESSAGE_TYPE type);
     /**
      * Sends the next outgoing message to the specified node, i.e. the one
      * populated by the most recent call to get_sendbuffer_ptr.
      * @param node_id The ID of the remote node to send to.
      */
-    void send(node_id_t node_id);
+    void send(node_id_t node_id, MESSAGE_TYPE type);
     /**
      * Compares the set of P2P connections to a list of known live nodes and
      * removes any connections to nodes not in that list. This is used to

--- a/include/derecho/core/detail/replicated_impl.hpp
+++ b/include/derecho/core/detail/replicated_impl.hpp
@@ -103,18 +103,18 @@ auto Replicated<T>::p2p_send(node_id_t dest_node, Args&&... args) const {
         }
         //Convert the user's desired tag into an "internal" function tag for a P2P function
         auto return_pair = wrapped_this->template send<rpc::to_internal_tag<true>(tag)>(
-                //Invoke the sending function with a buffer-allocator that uses the P2P request buffers
+                // Invoke the sending function with a buffer-allocator that uses the P2P request buffers
                 [this, &dest_node](std::size_t size) -> uint8_t* {
                     const std::size_t max_p2p_request_payload_size = getConfUInt64(CONF_DERECHO_MAX_P2P_REQUEST_PAYLOAD_SIZE);
                     if(size <= max_p2p_request_payload_size) {
                         return (uint8_t*)group_rpc_manager.get_sendbuffer_ptr(dest_node,
-                                                                           sst::REQUEST_TYPE::P2P_REQUEST);
+                                                                              sst::MESSAGE_TYPE::P2P_REQUEST);
                     } else {
                         throw buffer_overflow_exception("The size of a P2P message exceeds the maximum P2P message size.");
                     }
                 },
                 std::forward<Args>(args)...);
-        group_rpc_manager.finish_p2p_send(dest_node, subgroup_id, return_pair.pending);
+        group_rpc_manager.send_p2p_message(dest_node, subgroup_id, return_pair.pending);
         return std::move(*return_pair.results);
     } else {
         throw empty_reference_exception{"Attempted to use an empty Replicated<T>"};
@@ -154,7 +154,7 @@ auto Replicated<T>::ordered_send(Args&&... args) {
             return group_rpc_manager.view_manager.curr_view
                     ->multicast_group->send(subgroup_id, payload_size_for_multicast_send, serializer, true);
         });
-        group_rpc_manager.finish_rpc_send(subgroup_id, pending_ptr);
+        group_rpc_manager.register_rpc_results(subgroup_id, pending_ptr);
         return std::move(*results_ptr);
     } else {
         throw empty_reference_exception{"Attempted to use an empty Replicated<T>"};
@@ -321,13 +321,13 @@ auto ExternalCaller<T>::p2p_send(node_id_t dest_node, Args&&... args) {
                     const std::size_t max_payload_size = group_rpc_manager.view_manager.get_max_payload_sizes().at(subgroup_id);
                     if(size <= max_payload_size) {
                         return (uint8_t*)group_rpc_manager.get_sendbuffer_ptr(dest_node,
-                                                                           sst::REQUEST_TYPE::P2P_REQUEST);
+                                                                           sst::MESSAGE_TYPE::P2P_REQUEST);
                     } else {
                         throw buffer_overflow_exception("The size of a P2P message exceeds the maximum P2P message size.");
                     }
                 },
                 std::forward<Args>(args)...);
-        group_rpc_manager.finish_p2p_send(dest_node, subgroup_id, return_pair.pending);
+        group_rpc_manager.send_p2p_message(dest_node, subgroup_id, return_pair.pending);
         return std::move(*return_pair.results);
     } else {
         throw empty_reference_exception{"Attempted to use an empty Replicated<T>"};

--- a/include/derecho/core/detail/rpc_manager.hpp
+++ b/include/derecho/core/detail/rpc_manager.hpp
@@ -376,16 +376,16 @@ public:
      * @param pending_results_handle A non-owning pointer to the "promise object"
      * created by RemoteInvoker for this send.
      */
-    void finish_rpc_send(subgroup_id_t subgroup_id, std::weak_ptr<AbstractPendingResults> pending_results_handle);
+    void register_rpc_results(subgroup_id_t subgroup_id, std::weak_ptr<AbstractPendingResults> pending_results_handle);
 
     /**
      * Retrieves a buffer for sending P2P messages from the RPCManager's pool of
      * P2P RDMA connections. After filling it with data, the next call to
-     * finish_p2p_send will send it.
+     * send_p2p_message will send it.
      * @param dest_id The ID of the node that the P2P message will be sent to
      * @param type The type of P2P message that will be sent
      */
-    volatile uint8_t* get_sendbuffer_ptr(uint32_t dest_id, sst::REQUEST_TYPE type);
+    volatile uint8_t* get_sendbuffer_ptr(uint32_t dest_id, sst::MESSAGE_TYPE type);
 
     /**
      * Sends the next P2P message buffer over an RDMA connection to the specified node,
@@ -396,7 +396,7 @@ public:
      * @param pending_results_handle A non-owning pointer to the "promise object"
      * created by RemoteInvoker for this send.
      */
-    void finish_p2p_send(node_id_t dest_node, subgroup_id_t dest_subgroup_id, std::weak_ptr<AbstractPendingResults> pending_results_handle);
+    void send_p2p_message(node_id_t dest_node, subgroup_id_t dest_subgroup_id, std::weak_ptr<AbstractPendingResults> pending_results_handle);
 };
 
 //Now that RPCManager is finished being declared, we can declare these convenience types

--- a/include/derecho/core/external_group.hpp
+++ b/include/derecho/core/external_group.hpp
@@ -68,8 +68,8 @@ private:
      */
     bool get_view(const node_id_t nid);
     void clean_up();
-    volatile uint8_t* get_sendbuffer_ptr(uint32_t dest_id, sst::REQUEST_TYPE type);
-    void finish_p2p_send(node_id_t dest_id, subgroup_id_t dest_subgroup_id, std::weak_ptr<AbstractPendingResults> pending_results_handle);
+    volatile uint8_t* get_sendbuffer_ptr(uint32_t dest_id, sst::MESSAGE_TYPE type);
+    void send_p2p_message(node_id_t dest_id, subgroup_id_t dest_subgroup_id, std::weak_ptr<AbstractPendingResults> pending_results_handle);
     uint32_t get_index_of_type(const std::type_info& ti) const;
 
     /** ======================== copy/paste from rpc_manager ======================== **/

--- a/src/core/p2p_connection.cpp
+++ b/src/core/p2p_connection.cpp
@@ -10,12 +10,12 @@
 #include <sys/time.h>
 
 namespace sst {
-P2PConnection::P2PConnection(uint32_t my_node_id, uint32_t remote_id, uint64_t p2p_buf_size, const RequestParams& request_params)
-        : my_node_id(my_node_id), remote_id(remote_id), request_params(request_params) {
+P2PConnection::P2PConnection(uint32_t my_node_id, uint32_t remote_id, uint64_t p2p_buf_size, const ConnectionParams& connection_params)
+        : my_node_id(my_node_id), remote_id(remote_id), connection_params(connection_params) {
     incoming_p2p_buffer = std::make_unique<volatile uint8_t[]>(p2p_buf_size);
     outgoing_p2p_buffer = std::make_unique<volatile uint8_t[]>(p2p_buf_size);
 
-    for(auto type : p2p_request_types) {
+    for(auto type : p2p_message_types) {
         incoming_seq_nums_map.try_emplace(type, 0);
         outgoing_seq_nums_map.try_emplace(type, 0);
     }
@@ -36,39 +36,38 @@ P2PConnection::P2PConnection(uint32_t my_node_id, uint32_t remote_id, uint64_t p
 resources* P2PConnection::get_res() {
     return res.get();
 }
-uint64_t P2PConnection::getOffsetSeqNum(REQUEST_TYPE type, uint64_t seq_num) {
-    return request_params.offsets[type] + request_params.max_msg_sizes[type] * ((seq_num % request_params.window_sizes[type]) + 1) - sizeof(uint64_t);
-    // return max_msg_size * (type * window_size + (seq_num % window_size) + 1) - sizeof(uint64_t);
+uint64_t P2PConnection::getOffsetSeqNum(MESSAGE_TYPE type, uint64_t seq_num) {
+    return connection_params.offsets[type] + connection_params.max_msg_sizes[type] * ((seq_num % connection_params.window_sizes[type]) + 1) - sizeof(uint64_t);
 }
 
-uint64_t P2PConnection::getOffsetBuf(REQUEST_TYPE type, uint64_t seq_num) {
-    return request_params.offsets[type] + request_params.max_msg_sizes[type] * (seq_num % request_params.window_sizes[type]);
-    // return max_msg_size * (type * window_size + (seq_num % window_size));
+uint64_t P2PConnection::getOffsetBuf(MESSAGE_TYPE type, uint64_t seq_num) {
+    return connection_params.offsets[type] + connection_params.max_msg_sizes[type] * (seq_num % connection_params.window_sizes[type]);
 }
 
 // check if there's a new request from some node
-uint8_t* P2PConnection::probe() {
-    for(auto type : p2p_request_types) {
-        if((uint64_t&)incoming_p2p_buffer[getOffsetSeqNum(type, incoming_seq_nums_map[type])]
+std::optional<std::pair<uint8_t*, MESSAGE_TYPE>> P2PConnection::probe() {
+    for(auto type : p2p_message_types) {
+        // C-style cast: reinterpret the bytes of the buffer as a uint64_t, and also cast away volatile
+        if(((uint64_t&)incoming_p2p_buffer[getOffsetSeqNum(type, incoming_seq_nums_map[type])])
            == incoming_seq_nums_map[type] + 1) {
-            last_type = type;
-            return const_cast<uint8_t*>(incoming_p2p_buffer.get())
-                   + getOffsetBuf(type, incoming_seq_nums_map[type]);
+            return std::make_pair(const_cast<uint8_t*>(incoming_p2p_buffer.get())
+                                          + getOffsetBuf(type, incoming_seq_nums_map[type]),
+                                  type);
         }
     }
-    return nullptr;
+    return std::nullopt;
 }
 
-void P2PConnection::update_incoming_seq_num() {
-    incoming_seq_nums_map[last_type]++;
+void P2PConnection::increment_incoming_seq_num(MESSAGE_TYPE type) {
+    incoming_seq_nums_map[type]++;
 }
 
-uint8_t* P2PConnection::get_sendbuffer_ptr(REQUEST_TYPE type) {
-    prev_mode = type;
-    if(type != REQUEST_TYPE::P2P_REQUEST
-       || static_cast<int32_t>(incoming_seq_nums_map[REQUEST_TYPE::P2P_REPLY])
-                  > static_cast<int32_t>(outgoing_seq_nums_map[REQUEST_TYPE::P2P_REQUEST] - request_params.window_sizes[P2P_REQUEST])) {
-        (uint64_t&)outgoing_p2p_buffer[getOffsetSeqNum(type, outgoing_seq_nums_map[type])]
+uint8_t* P2PConnection::get_sendbuffer_ptr(MESSAGE_TYPE type) {
+    if(type != MESSAGE_TYPE::P2P_REQUEST
+       || outgoing_seq_nums_map[MESSAGE_TYPE::P2P_REQUEST] - incoming_seq_nums_map[MESSAGE_TYPE::P2P_REPLY]
+                  < connection_params.window_sizes[P2P_REQUEST]) {
+        // C-style cast: reinterpret the bytes of the buffer as a uint64_t, and also cast away volatile
+        ((uint64_t&)outgoing_p2p_buffer[getOffsetSeqNum(type, outgoing_seq_nums_map[type])])
                 = outgoing_seq_nums_map[type] + 1;
         return const_cast<uint8_t*>(outgoing_p2p_buffer.get())
                + getOffsetBuf(type, outgoing_seq_nums_map[type]);
@@ -76,19 +75,18 @@ uint8_t* P2PConnection::get_sendbuffer_ptr(REQUEST_TYPE type) {
     return nullptr;
 }
 
-void P2PConnection::send() {
-    auto type = prev_mode;
+void P2PConnection::send(MESSAGE_TYPE type) {
     if(remote_id == my_node_id) {
         // there's no reason why memcpy shouldn't also copy guard and data separately
         std::memcpy(const_cast<uint8_t*>(incoming_p2p_buffer.get()) + getOffsetBuf(type, outgoing_seq_nums_map[type]),
                     const_cast<uint8_t*>(outgoing_p2p_buffer.get()) + getOffsetBuf(type, outgoing_seq_nums_map[type]),
-                    request_params.max_msg_sizes[type] - sizeof(uint64_t));
+                    connection_params.max_msg_sizes[type] - sizeof(uint64_t));
         std::memcpy(const_cast<uint8_t*>(incoming_p2p_buffer.get()) + getOffsetSeqNum(type, outgoing_seq_nums_map[type]),
                     const_cast<uint8_t*>(outgoing_p2p_buffer.get()) + getOffsetSeqNum(type, outgoing_seq_nums_map[type]),
                     sizeof(uint64_t));
     } else {
         res->post_remote_write(getOffsetBuf(type, outgoing_seq_nums_map[type]),
-                               request_params.max_msg_sizes[type] - sizeof(uint64_t));
+                               connection_params.max_msg_sizes[type] - sizeof(uint64_t));
         res->post_remote_write(getOffsetSeqNum(type, outgoing_seq_nums_map[type]),
                                sizeof(uint64_t));
     }

--- a/src/core/rpc_manager.cpp
+++ b/src/core/rpc_manager.cpp
@@ -149,7 +149,7 @@ void RPCManager::rpc_message_handler(subgroup_id_t subgroup_id, node_id_t sender
                           reply_size = size;
                           if(reply_size <= connections->get_max_rpc_reply_size()) {
                               reply_buf = (uint8_t*)connections->get_sendbuffer_ptr(
-                                      sender_id, sst::REQUEST_TYPE::RPC_REPLY);
+                                      sender_id, sst::MESSAGE_TYPE::RPC_REPLY);
                               return reply_buf;
                           } else {
                               // the reply size is too large - not part of the design to handle it
@@ -196,7 +196,7 @@ void RPCManager::rpc_message_handler(subgroup_id_t subgroup_id, node_id_t sender
         }
     } else if(reply_size > 0) {
         //Otherwise, the only thing to do is send the reply (if there was one)
-        connections->send(sender_id);
+        connections->send(sender_id, sst::MESSAGE_TYPE::RPC_REPLY);
     }
 
     // clear the thread local rpc_handler context
@@ -211,22 +211,14 @@ void RPCManager::p2p_message_handler(node_id_t sender_id, uint8_t* msg_buf) {
     node_id_t received_from;
     uint32_t flags;
     retrieve_header(nullptr, msg_buf, payload_size, indx, received_from, flags);
-    size_t reply_size = 0;
+    dbg_default_trace("Handling a P2P message: function_id = {}, is_reply = {}, received_from = {}, payload_size = {}, invocation_id = {}",
+                      indx.function_id, indx.is_reply, received_from, payload_size, ((long*)(msg_buf + header_size))[0]);
     if(indx.is_reply) {
         // REPLYs can be handled here because they do not block.
         receive_message(indx, received_from, msg_buf + header_size, payload_size,
-                        [this, &reply_size, &sender_id](size_t _size) -> uint8_t* {
-                            reply_size = _size;
-                            if(reply_size <= connections->get_max_p2p_reply_size()) {
-                                return (uint8_t*)connections->get_sendbuffer_ptr(
-                                        sender_id, sst::REQUEST_TYPE::P2P_REPLY);
-                            } else {
-                                throw buffer_overflow_exception("Size of a P2P reply exceeds the maximum P2P reply message size");
-                            }
+                        [](size_t _size) -> uint8_t* {
+                            throw derecho::derecho_exception("A P2P reply message attempted to generate another reply");
                         });
-        if(reply_size > 0) {
-            connections->send(sender_id);
-        }
     } else if(RPC_HEADER_FLAG_TST(flags, CASCADE)) {
         // TODO: what is the lifetime of msg_buf? discuss with Sagar to make
         // sure the buffers are safely managed.
@@ -402,13 +394,13 @@ void RPCManager::add_external_connection(node_id_t node_id) {
     connections->add_connections({node_id});
 }
 
-void RPCManager::finish_rpc_send(subgroup_id_t subgroup_id, std::weak_ptr<AbstractPendingResults> pending_results_handle) {
+void RPCManager::register_rpc_results(subgroup_id_t subgroup_id, std::weak_ptr<AbstractPendingResults> pending_results_handle) {
     std::lock_guard<std::mutex> lock(pending_results_mutex);
     pending_results_to_fulfill[subgroup_id].push(pending_results_handle);
     pending_results_cv.notify_all();
 }
 
-volatile uint8_t* RPCManager::get_sendbuffer_ptr(uint32_t dest_id, sst::REQUEST_TYPE type) {
+volatile uint8_t* RPCManager::get_sendbuffer_ptr(uint32_t dest_id, sst::MESSAGE_TYPE type) {
     volatile uint8_t* buf;
     int curr_vid = -1;
     do {
@@ -429,12 +421,13 @@ volatile uint8_t* RPCManager::get_sendbuffer_ptr(uint32_t dest_id, sst::REQUEST_
     return buf;
 }
 
-void RPCManager::finish_p2p_send(node_id_t dest_id, subgroup_id_t dest_subgroup_id, std::weak_ptr<AbstractPendingResults> pending_results_handle) {
+void RPCManager::send_p2p_message(node_id_t dest_id, subgroup_id_t dest_subgroup_id, std::weak_ptr<AbstractPendingResults> pending_results_handle) {
     try {
-        //ViewManager's view_mutex also prevents connections from being removed (because
-        //that happens in new_view_callback)
+        // ViewManager's view_mutex also prevents connections from being removed (because
+        // that happens in new_view_callback)
         SharedLockedReference<View> view_and_lock = view_manager.get_current_view();
-        connections->send(dest_id);
+        // The type of message being sent here is always a P2P request, not a reply
+        connections->send(dest_id, sst::MESSAGE_TYPE::P2P_REQUEST);
     } catch(std::out_of_range& map_error) {
         throw node_removed_from_group_exception(dest_id);
     }
@@ -481,19 +474,22 @@ void RPCManager::p2p_request_worker() {
                             reply_size = _size;
                             if(reply_size <= connections->get_max_p2p_reply_size()) {
                                 return (uint8_t*)connections->get_sendbuffer_ptr(
-                                        request.sender_id, sst::REQUEST_TYPE::P2P_REPLY);
+                                        request.sender_id, sst::MESSAGE_TYPE::P2P_REPLY);
                             } else {
                                 throw buffer_overflow_exception("Size of a P2P reply exceeds the maximum P2P reply size.");
                             }
                         });
         if(reply_size > 0) {
-            connections->send(request.sender_id);
+            dbg_default_trace("Sending a P2P reply to node {} for invocation ID {} of function {}",
+                              request.sender_id, ((long*)(request.msg_buf + header_size))[0], indx.function_id);
+            connections->send(request.sender_id, sst::MESSAGE_TYPE::P2P_REPLY);
         } else {
             // hack for now to "simulate" a reply for p2p_sends to functions that do not generate a reply
-            uint8_t* buf = connections->get_sendbuffer_ptr(request.sender_id, sst::REQUEST_TYPE::P2P_REPLY);
+            uint8_t* buf = connections->get_sendbuffer_ptr(request.sender_id, sst::MESSAGE_TYPE::P2P_REPLY);
             if(buf != nullptr) {
-                buf[0] = 0;
-                connections->send(request.sender_id);
+                dbg_default_trace("Sending a null reply to node {} for a void P2P call", request.sender_id);
+                reinterpret_cast<size_t*>(buf)[0] = 0;
+                connections->send(request.sender_id, sst::MESSAGE_TYPE::P2P_REPLY);
             }
         }
     }
@@ -524,13 +520,14 @@ void RPCManager::p2p_receive_loop() {
         // successful probe_all() and the call to p2p_message_handler)
         {
             SharedLockedReference<View> locked_view = view_manager.get_current_view();
-            auto optional_reply_pair = connections->probe_all();
-            if(optional_reply_pair) {
+            auto optional_message = connections->probe_all();
+            if(optional_message) {
                 message_received = true;
-                auto reply_pair = optional_reply_pair.value();
-                if(reply_pair.first != INVALID_NODE_ID) {
-                    p2p_message_handler(reply_pair.first, (uint8_t*)reply_pair.second);
-                    connections->update_incoming_seq_num(reply_pair.first);
+                auto message_handle = optional_message.value();
+                // Invalid ID means the message was empty (a null reply)
+                if(message_handle.sender_id != INVALID_NODE_ID) {
+                    p2p_message_handler(message_handle.sender_id, message_handle.buf);
+                    connections->increment_incoming_seq_num(message_handle.sender_id, message_handle.type);
                 }
                 // update last time
                 clock_gettime(CLOCK_REALTIME, &last_time);


### PR DESCRIPTION
This is a first step towards solving the thread safety problem identified in #217. P2PConnection now requires callers to specify the message type for get_sendbuffer_ptr, send, and increment_incoming_seq_num, instead of trying to internally keep track of the "last used" type with the instance variables prev_mode and last_type. This fixes the race condition I encountered while testing external-client notifications, though it still doesn't make P2PConnection completely thread-safe.

Since these changes are pretty straightforward, and I tested them to confirm they don't break any existing functionality, I think we should merge them before adding more synchronization to P2PConnection.