### PR TITLE
Improve TCP error handling and external client handling

### DIFF
--- a/include/derecho/core/detail/group_impl.hpp
+++ b/include/derecho/core/detail/group_impl.hpp
@@ -252,6 +252,7 @@ Group<ReplicatedTypes...>::Group(const UserMessageCallbacks& callbacks,
     rpc_manager.start_listening();
     view_manager.start();
     persistence_manager.start();
+    dbg_default_info("Derecho Group successfully started");
 }
 
 /* A simpler constructor that uses "default" options for callbacks, upcalls, and deserialization context */
@@ -357,8 +358,6 @@ std::set<std::pair<subgroup_id_t, node_id_t>> Group<ReplicatedTypes...>::constru
                 subgroup_index, ExternalClientCallback<FirstType>(subgroup_type_id,
                                                                   my_id, subgroup_id, rpc_manager));
     }
-    // add the client callback object
-    // client_callback = std::make_unique<ExternalClientCallback<NotificationSupport>>(subgroup_type_id, my_id, rpc_manager);
     return functional_insert(subgroups_to_receive, construct_objects<RestTypes...>(curr_view, old_shard_leaders, in_restart));
 }
 
@@ -419,7 +418,7 @@ ExternalClientCallback<SubgroupType>& Group<ReplicatedTypes...>::get_client_call
     try {
         return external_client_callbacks.template get<SubgroupType>().at(subgroup_index);
     } catch(std::out_of_range& ex) {
-        throw invalid_subgroup_exception("No ExternalClientCallback exists for the requested subgroup; this node may be a member of the subgroup");
+        throw invalid_subgroup_exception("No ExternalClientCallback exists for the requested subgroup");
     }
 }
 

--- a/include/derecho/core/detail/replicated_impl.hpp
+++ b/include/derecho/core/detail/replicated_impl.hpp
@@ -350,6 +350,11 @@ ExternalClientCallback<T>::ExternalClientCallback(uint32_t type_id, node_id_t ni
           wrapped_this(rpc::make_remote_invoker<T>(nid, type_id, subgroup_id,
                                                    T::register_functions(), *group_rpc_manager.receivers)) {}
 
+template <typename T>
+bool ExternalClientCallback<T>::has_external_client(node_id_t client_id) const {
+    return group_rpc_manager.connections->contains_node(client_id);
+}
+
 // This is literally copied and pasted from PeerCaller<T>, except that this does not check if the receiver
 //  is in the subgroup.
 

--- a/include/derecho/core/detail/view_manager.hpp
+++ b/include/derecho/core/detail/view_manager.hpp
@@ -144,6 +144,12 @@ private:
     std::list<std::pair<node_id_t, tcp::socket>> pending_join_sockets;
     /** The sockets connected to clients that will join in the next view, if any */
     std::list<std::pair<node_id_t, tcp::socket>> proposed_join_sockets;
+    /**
+     * Sockets for external clients that initiated join requests during system startup.
+     * These must wait until the first view has committed and the SST is created before
+     * being handled. After system startup, this list will be empty.
+     */
+    std::list<std::pair<node_id_t, tcp::socket>> startup_pending_external_sockets;
 
     /** Contains old Views that need to be cleaned up. */
     std::queue<std::unique_ptr<View>> old_views;

--- a/include/derecho/core/replicated.hpp
+++ b/include/derecho/core/replicated.hpp
@@ -456,7 +456,19 @@ public:
     ExternalClientCallback(const ExternalClientCallback&) = delete;
 
     /**
-     * Sends a peer-to-peer message to a single member of the subgroup that
+     * Checks if this node currently has a P2P connection to an external client
+     * with the specified ID. An external client must establish a P2P connection
+     * before ExternalClientCallback can be used to send it messages, so if this
+     * returns false, p2p_send will fail.
+     *
+     * @param client_id The node ID of a possible external client
+     * @return true if this ExternalClientCallback<T> could send a P2P message to
+     * that client, false if there is no client with that ID connected.
+     */
+    bool has_external_client(node_id_t client_id) const;
+
+    /**
+     * Sends a peer-to-peer message to a single external client of the subgroup that
      * this ExternalClientCallback<T> connects to, invoking the RPC function identified
      * by the FunctionTag template parameter.
      * @param dest_node The ID of the node that the P2P message should be sent to

--- a/src/applications/tests/unit_tests/external_notification_test.cpp
+++ b/src/applications/tests/unit_tests/external_notification_test.cpp
@@ -86,12 +86,12 @@ bool TestPersistentObject::set_data(const std::string& new_data) const {
     return true;
 }
 
-void run_nonpersistent_test(uint32_t external_node_id, bool is_sender, int num_nodes, uint32_t num_messages) {
+void run_nonpersistent_test(uint32_t external_node_id, int num_senders, int num_nodes, uint32_t num_messages) {
     node_id_t my_id = derecho::getConfUInt64(CONF_DERECHO_LOCAL_ID);
     uint64_t max_msg_size = derecho::getConfUInt64(CONF_SUBGROUP_DEFAULT_MAX_PAYLOAD_SIZE);
 
     if(external_node_id != my_id) {
-        //Put each node in its own subgroup, which has 1 shard with 1 member
+        // Put each node in its own subgroup, which has 1 shard with 1 member
         derecho::SubgroupInfo subgroup_info{derecho::DefaultSubgroupAllocator(
                 {{std::type_index(typeid(TestObject)),
                   derecho::identical_subgroups_policy(num_nodes, derecho::fixed_even_shards(1, 1))}})};
@@ -100,12 +100,14 @@ void run_nonpersistent_test(uint32_t external_node_id, bool is_sender, int num_n
         derecho::Group<TestObject> group({}, subgroup_info, {}, std::vector<derecho::view_upcall_t>{}, object_factory);
         std::cout << "Finished constructing/joining Group" << std::endl;
 
-        if(is_sender) {
-            uint32_t my_subgroup_index = *group.get_my_subgroup_indexes<TestObject>().begin();
+        uint32_t my_subgroup_index = group.get_my_subgroup_indexes<TestObject>()[0];
+        if(my_subgroup_index < static_cast<uint32_t>(num_senders)) {
+            std::cout << "Waiting for the external node to connect" << std::endl;
+            while(!group.get_client_callback<TestObject>(my_subgroup_index).has_external_client(external_node_id)) {
+                std::this_thread::sleep_for(std::chrono::seconds(1));
+            }
             for(uint i = 0; i < num_messages; ++i) {
-                // group.notify(2, bytes);
                 derecho::ExternalClientCallback<TestObject>& handle = group.get_client_callback<TestObject>(my_subgroup_index);
-                std::cout << "acquired notification support callback!" << std::endl;
                 uint64_t msg_size = max_msg_size - 128;
                 derecho::NotificationMessage message(1, msg_size);
                 for(uint64_t j = 0; j < msg_size - 1; ++j) {
@@ -114,30 +116,34 @@ void run_nonpersistent_test(uint32_t external_node_id, bool is_sender, int num_n
                 // notification!
                 handle.p2p_send<RPC_NAME(notify)>(external_node_id, message);
             }
+            std::cout << "Done sending all notifications" << std::endl;
+        } else {
+            std::cout << "Not sending any notifications." << std::endl;
         }
-        std::cout << "Done sending all notifications" << std::endl;
         std::cout << "Press enter when finished with test." << std::endl;
         std::cin.get();
-
+        group.leave(true);
     } else {
         auto dummy_object_factory = []() { return std::make_unique<TestObject>(); };
         derecho::ExternalGroupClient<TestObject> group(dummy_object_factory);
 
         cout << "Finished constructing ExternalGroupClient" << endl;
 
+        // Each member node is in its own subgroup, and the first num_senders of them will send notifications
         std::vector<node_id_t> members = group.get_members();
-        ExternalClientCaller<TestObject, decltype(group)>& handle1 = group.get_subgroup_caller<TestObject>(0);
-        ExternalClientCaller<TestObject, decltype(group)>& handle2 = group.get_subgroup_caller<TestObject>(1);
+        std::vector<std::reference_wrapper<ExternalClientCaller<TestObject, decltype(group)>>> client_callers;
+        for(int subgroup_num = 0; subgroup_num < num_senders; ++subgroup_num) {
+            client_callers.emplace_back(group.get_subgroup_caller<TestObject>(subgroup_num));
+        }
 
-        // register notification handler
-        handle1.add_p2p_connection(members[0]);
-        handle1.register_notification_handler([](const derecho::NotificationMessage& message) {
-            std::cout << "Notification Successful from subgroup 0! Message type = " << message.message_type << " Size: " << message.size << ", Data: " << message.body << std::endl;
-        });
-        handle2.add_p2p_connection(members[1]);
-        handle2.register_notification_handler([](const derecho::NotificationMessage& message) {
-            std::cout << "Notification Successful from subgroup 1! Message type = " << message.message_type << " Size: " << message.size << ", Data: " << message.body << std::endl;
-        });
+        for(int subgroup_num = 0; subgroup_num < num_senders; ++subgroup_num) {
+            // register notification handler
+            client_callers[subgroup_num].get().add_p2p_connection(members[subgroup_num]);
+            client_callers[subgroup_num].get().register_notification_handler([=](const derecho::NotificationMessage& message) {
+                std::cout << "Notification successful from subgroup " << subgroup_num << "!  Message type = "
+                          << message.message_type << " Size: " << message.size << ", Data: " << message.body << std::endl;
+            });
+        }
 
         std::cout << "Awaiting notifications." << std::endl;
         std::cout << "Press enter when finished with test." << std::endl;
@@ -145,12 +151,12 @@ void run_nonpersistent_test(uint32_t external_node_id, bool is_sender, int num_n
     }
 }
 
-void run_persistent_test(uint32_t external_node_id, bool is_sender, int num_nodes, uint32_t num_messages) {
+void run_persistent_test(uint32_t external_node_id, int num_senders, int num_nodes, uint32_t num_messages) {
     node_id_t my_id = derecho::getConfUInt64(CONF_DERECHO_LOCAL_ID);
     uint64_t max_msg_size = derecho::getConfUInt64(CONF_SUBGROUP_DEFAULT_MAX_PAYLOAD_SIZE);
 
     if(external_node_id != my_id) {
-        //Put each node in its own subgroup, which has 1 shard with 1 member
+        // Put each node in its own subgroup, which has 1 shard with 1 member
         derecho::SubgroupInfo subgroup_info{derecho::DefaultSubgroupAllocator(
                 {{std::type_index(typeid(TestPersistentObject)),
                   derecho::identical_subgroups_policy(num_nodes, derecho::fixed_even_shards(1, 1))}})};
@@ -161,12 +167,14 @@ void run_persistent_test(uint32_t external_node_id, bool is_sender, int num_node
         derecho::Group<TestPersistentObject> group({}, subgroup_info, {}, std::vector<derecho::view_upcall_t>{}, object_factory);
         std::cout << "Finished constructing/joining Group" << std::endl;
 
-        if(is_sender) {
-            uint32_t my_subgroup_index = *group.get_my_subgroup_indexes<TestPersistentObject>().begin();
+        uint32_t my_subgroup_index = group.get_my_subgroup_indexes<TestPersistentObject>()[0];
+        if(my_subgroup_index < static_cast<uint32_t>(num_senders)) {
+            std::cout << "Waiting for the external node to connect" << std::endl;
+            while(!group.get_client_callback<TestPersistentObject>(my_subgroup_index).has_external_client(external_node_id)) {
+                std::this_thread::sleep_for(std::chrono::seconds(1));
+            }
             for(uint i = 0; i < num_messages; ++i) {
-                // group.notify(2, bytes);
                 derecho::ExternalClientCallback<TestPersistentObject>& handle = group.get_client_callback<TestPersistentObject>(my_subgroup_index);
-                std::cout << "acquired notification support callback!" << std::endl;
                 uint64_t msg_size = max_msg_size - 128;
                 derecho::NotificationMessage message(1, msg_size);
                 for(uint64_t j = 0; j < msg_size - 1; ++j) {
@@ -175,32 +183,37 @@ void run_persistent_test(uint32_t external_node_id, bool is_sender, int num_node
                 // notification!
                 handle.p2p_send<RPC_NAME(notify)>(external_node_id, message);
             }
+            std::cout << "Done sending all notifications" << std::endl;
+        } else {
+            std::cout << "Not sending any notifications." << std::endl;
         }
-        std::cout << "Done sending all notifications" << std::endl;
         std::cout << "Press enter when finished with test." << std::endl;
         std::cin.get();
-
+        group.leave(true);
     } else {
-        //A Persistent<T> constructed with a null PersistentRegistry won't work, but we don't need it to work
+        // A Persistent<T> constructed with a null PersistentRegistry won't work, but we don't need it to work
         auto dummy_object_factory = []() { return std::make_unique<TestPersistentObject>(nullptr); };
 
         derecho::ExternalGroupClient<TestPersistentObject> group(dummy_object_factory);
 
         cout << "Finished constructing ExternalGroupClient" << endl;
 
+        // Each member node is in its own subgroup, and the first num_senders of them will send notifications
         std::vector<node_id_t> members = group.get_members();
-        ExternalClientCaller<TestPersistentObject, decltype(group)>& handle1 = group.get_subgroup_caller<TestPersistentObject>(0);
-        ExternalClientCaller<TestPersistentObject, decltype(group)>& handle2 = group.get_subgroup_caller<TestPersistentObject>(1);
+        std::vector<std::reference_wrapper<ExternalClientCaller<TestPersistentObject, decltype(group)>>> client_callers;
+        for(int subgroup_num = 0; subgroup_num < num_senders; ++subgroup_num) {
+            client_callers.emplace_back(group.get_subgroup_caller<TestPersistentObject>(subgroup_num));
+        }
 
-        // register notification handler
-        handle1.add_p2p_connection(members[0]);
-        handle1.register_notification_handler([](const derecho::NotificationMessage& message) {
-            std::cout << "Notification Successful from subgroup 0! Message type = " << message.message_type << " Size: " << message.size << ", Data: " << message.body << std::endl;
-        });
-        handle2.add_p2p_connection(members[1]);
-        handle2.register_notification_handler([](const derecho::NotificationMessage& message) {
-            std::cout << "Notification Successful from subgroup 1! Message type = " << message.message_type << " Size: " << message.size << ", Data: " << message.body << std::endl;
-        });
+        for(int subgroup_num = 0; subgroup_num < num_senders; ++subgroup_num) {
+            // register notification handler
+            client_callers[subgroup_num].get().add_p2p_connection(members[subgroup_num]);
+            client_callers[subgroup_num].get().register_notification_handler([=](const derecho::NotificationMessage& message) {
+                std::cout << "Notification successful from subgroup " << subgroup_num << "!  Message type = "
+                          << message.message_type << " Size: " << message.size << ", Data: " << message.body << std::endl;
+            });
+        }
+
         std::cout << "Awaiting notifications." << std::endl;
         std::cout << "Press enter when finished with test." << std::endl;
         std::cin.get();
@@ -211,20 +224,26 @@ int main(int argc, char** argv) {
     const int num_args = 5;
     if(argc < (num_args + 1) || (argc > (num_args + 1) && strcmp("--", argv[argc - (num_args + 1)]) != 0)) {
         cout << "Invalid command line arguments." << endl;
-        cout << "USAGE:" << argv[0] << "[ derecho-config-list -- ] external_node_id is_sender num_nodes num_messages persistence_on" << endl;
+        cout << "USAGE:" << argv[0] << "[ derecho-config-list -- ] external_node_id num_senders num_nodes num_messages persistence_on" << endl;
         cout << "Thank you" << endl;
         return -1;
     }
     derecho::Conf::initialize(argc, argv);
     const uint32_t external_node_id = std::stoi(argv[argc - num_args]);
-    const bool is_sender = std::stoi(argv[argc - num_args + 1]) != 0;
-    int num_of_nodes = std::stoi(argv[argc - num_args + 2]);
+    const int num_senders = std::stoi(argv[argc - num_args + 1]);
+    const int num_of_nodes = std::stoi(argv[argc - num_args + 2]);
     const uint32_t count = std::stoi(argv[argc - num_args + 3]);
     const bool persistence_on = std::stoi(argv[argc - num_args + 4]) != 0;
 
+    if(num_senders > num_of_nodes) {
+        cout << "Invalid command line arguments: num_senders can't be greater than num_nodes" << endl;
+        cout << "USAGE:" << argv[0] << "[ derecho-config-list -- ] external_node_id num_senders num_nodes num_messages persistence_on" << endl;
+        return -1;
+    }
+
     if(persistence_on) {
-        run_persistent_test(external_node_id, is_sender, num_of_nodes, count);
+        run_persistent_test(external_node_id, num_senders, num_of_nodes, count);
     } else {
-        run_nonpersistent_test(external_node_id, is_sender, num_of_nodes, count);
+        run_nonpersistent_test(external_node_id, num_senders, num_of_nodes, count);
     }
 }

--- a/src/core/git_version.cpp
+++ b/src/core/git_version.cpp
@@ -13,8 +13,8 @@ namespace derecho {
 const int MAJOR_VERSION = 2;
 const int MINOR_VERSION = 3;
 const int PATCH_VERSION = 0;
-const int COMMITS_AHEAD_OF_VERSION = 4;
+const int COMMITS_AHEAD_OF_VERSION = 16;
 const char* VERSION_STRING = "2.3.0";
-const char* VERSION_STRING_PLUS_COMMITS = "2.3.0+4";
+const char* VERSION_STRING_PLUS_COMMITS = "2.3.0+16";
 
 }


### PR DESCRIPTION
As Ken reported in an e-mail, an external client that attempts to contact the leader while a group is starting up (awaiting its first adequate view) will cause the group to crash. This happens for two reasons:
1. The await_first_view() method assumes any client that connects to the leader is another replica node starting up, not an external client, so it does not properly handle external client requests the way process_new_sockets() would during normal operation. This means it will either fail or hang when it attempts to read joiner_gms_port and the other ports from the client socket, because external clients don't send this list of ports.
2. The await_first_view() method doesn't catch TCP exceptions that socket operations might throw when it is doing the initial "handshake" of exchanging version codes and JoinRequest/JoinResponses, even though it properly catches exceptions later when attempting to send each node the initial View. This means that any client (replica node or external client) that opens a TCP socket but then immediately fails would cause the leader to crash during the "handshake" exchange.

To fix the first issue, I added the proper check for `join_request.is_external` and put any external clients that attempt to join during startup in a pending queue until the initial view commits. To fix the second issue, I added try-catch blocks to all the socket operations involved in handling a join request, both in await_first_view() and in the corresponding code in receive_join(). If a socket operation fails during the initial handshake process, the leader simply drops the failed connection and ignores the join request.

I also added a few more logging statements to the code that runs the initial startup sequence, to make it clearer what the system is waiting for when it appears to be stuck. They're at the "info" level so users will see them even with the default configuration that sets logging to info-only.

While testing these changes, I also improved external_notification_test and added a has_external_client() method to ExternalClientCallback (to help the server avoid a node_removed_from_group_exception if it tries to send a notification before the client is ready).