### PR TITLE
Make Persist return a version

### DIFF
--- a/include/derecho/core/detail/replicated_impl.hpp
+++ b/include/derecho/core/detail/replicated_impl.hpp
@@ -220,14 +220,13 @@ persistent::version_t Replicated<T>::persist(persistent::version_t version, uint
         // tell the persistent thread that we are done.
         return version;
     }
-    persistent::version_t next_persisted_ver;
+    persistent::version_t next_persisted_ver = persistent::INVALID_VERSION;
     // Ask PersistentRegistry to persist all the Persistent fields
     do {
-        next_persisted_ver = persistent_registry->getMinimumLatestVersion();
         if constexpr(std::is_base_of_v<SignedPersistentFields, T>) {
             persistent_registry->sign(next_persisted_ver, *signer, signature);
         }
-        persistent_registry->persist(next_persisted_ver);
+        next_persisted_ver = persistent_registry->persist(next_persisted_ver);
     } while(next_persisted_ver < version);
     return next_persisted_ver;
 };

--- a/include/derecho/persistent/Persistent.hpp
+++ b/include/derecho/persistent/Persistent.hpp
@@ -148,9 +148,12 @@ public:
     /**
      * Persist versions up to a specified version, which should be the result of
      * calling getMinimumLatestVersion().
+     *
      * @param latest_version The version to persist up to.
+     *
+     * @return a version equal to getMinimumLatestPersistedVersion()
      */
-    void persist(version_t latest_version);
+    version_t persist(version_t latest_version);
 
     /** Trims the log of all versions earlier than the argument. */
     void trim(version_t earliest_version);
@@ -976,7 +979,7 @@ public:
      *
      * @param latest_version The version to persist up to
      */
-    virtual void persist(version_t latest_version);
+    virtual version_t persist(version_t latest_version);
 
     /**
      * Update the provided Signer with the state of T at the specified version.

--- a/include/derecho/persistent/PersistentInterface.hpp
+++ b/include/derecho/persistent/PersistentInterface.hpp
@@ -73,8 +73,10 @@ public:
     /**
      * Persists versions to persistent storage, up to the provided version.
      * @param version The highest version number to persist
+     *
+     * @return the real persisted version which might be higher than the requested one.
      */
-    virtual void persist(version_t version) = 0;
+    virtual version_t persist(version_t version) = 0;
     /**
      * Trims the beginning (oldest part) of the log, discarding versions older
      * than the specified version

--- a/include/derecho/persistent/detail/Persistent_impl.hpp
+++ b/include/derecho/persistent/detail/Persistent_impl.hpp
@@ -631,16 +631,17 @@ void Persistent<ObjectType, storageType>::updateVerifier(version_t ver, openssl:
 
 template <typename ObjectType,
           StorageType storageType>
-void Persistent<ObjectType, storageType>::persist(version_t ver) {
+version_t Persistent<ObjectType, storageType>::persist(version_t ver) {
 #if defined(_PERFORMANCE_DEBUG)
     struct timespec t1, t2;
     clock_gettime(CLOCK_REALTIME, &t1);
-    this->m_pLog->persist(ver);
+    version_t ret = this->m_pLog->persist(ver);
     clock_gettime(CLOCK_REALTIME, &t2);
     cnt_in_persist++;
     ns_in_persist += ((t2.tv_sec - t1.tv_sec) * 1000000000ul + t2.tv_nsec - t1.tv_nsec);
+    return ret;
 #else
-    this->m_pLog->persist(ver);
+    return this->m_pLog->persist(ver);
 #endif  //_PERFORMANCE_DEBUG
 }
 

--- a/src/core/git_version.cpp
+++ b/src/core/git_version.cpp
@@ -13,8 +13,8 @@ namespace derecho {
 const int MAJOR_VERSION = 2;
 const int MINOR_VERSION = 3;
 const int PATCH_VERSION = 0;
-const int COMMITS_AHEAD_OF_VERSION = 18;
+const int COMMITS_AHEAD_OF_VERSION = 23;
 const char* VERSION_STRING = "2.3.0";
-const char* VERSION_STRING_PLUS_COMMITS = "2.3.0+18";
+const char* VERSION_STRING_PLUS_COMMITS = "2.3.0+23";
 
 }

--- a/src/persistent/Persistent.cpp
+++ b/src/persistent/Persistent.cpp
@@ -125,10 +125,16 @@ bool PersistentRegistry::verify(version_t version, openssl::Verifier& verifier, 
     return verifier.finalize(signature, signature_size);
 }
 
-void PersistentRegistry::persist(version_t latest_version) {
+version_t PersistentRegistry::persist(version_t latest_version) {
+    version_t min = INVALID_VERSION;
     for(auto& entry : m_registry) {
-        entry.second->persist(latest_version);
+        version_t ver = entry.second->persist(latest_version);
+        if (min == INVALID_VERSION || 
+            min > ver) {
+            min = ver;
+        }
     }
+    return min;
 };
 
 void PersistentRegistry::trim(version_t earliest_version) {


### PR DESCRIPTION
Although the implementations of the Persistent<T>::persist() method (in e.g. FilePersistLog) have always returned the version actually persisted, which is sometimes greater than the requested version, the top-level persist method and the PersistentRegistry version did not. This turned out to be a problem for my signatures code, since it meant versions could get persisted without being signed if they were persisted "automatically" within FilePersistLog::persist(). Weijia added logic to return the version actually persisted from Persistent<T> and PersistentRegistry, and I fixed the loop in Replicated<T> to repeat the sign() method if more versions were persisted than initially expected.