### PR TITLE
Deliver new-view callbacks to replicated objects

### DIFF
--- a/include/derecho/core/detail/view_manager.hpp
+++ b/include/derecho/core/detail/view_manager.hpp
@@ -107,6 +107,7 @@ enum class ExternalClientRequest {
 template <typename T>
 using SharedLockedReference = LockedReference<std::shared_lock<std::shared_timed_mutex>, T>;
 
+/** Type of a function that can be called by ViewManager to notify another component that a new view was installed */
 using view_upcall_t = std::function<void(const View&)>;
 
 /** Type of a 2-dimensional vector used to store potential node IDs, or -1 */

--- a/include/derecho/core/notification.hpp
+++ b/include/derecho/core/notification.hpp
@@ -91,7 +91,12 @@ struct NotificationMessage : mutils::ByteRepresentable {
 
 using notification_handler_t = std::function<void(const NotificationMessage&)>;
 
-struct NotificationSupport {
+/**
+ * A base class that enables client-side notification support in a Derecho subgroup.
+ * The user-provided Replicated Object type (i.e. the T in Replicated<T>) must inherit
+ * from this class in order for clients of that type's subgroup to get notifications.
+ */
+class NotificationSupport {
 public:
     std::optional<notification_handler_t> handler;
 

--- a/src/applications/tests/unit_tests/CMakeLists.txt
+++ b/src/applications/tests/unit_tests/CMakeLists.txt
@@ -44,3 +44,6 @@ target_link_libraries(persistence_notification_test derecho)
 
 add_executable(deserialize_and_run_test deserialize_and_run_test.cpp)
 target_link_libraries(deserialize_and_run_test derecho)
+
+add_executable(subgroup_view_callbacks subgroup_view_callbacks.cpp)
+target_link_libraries(subgroup_view_callbacks derecho)

--- a/src/applications/tests/unit_tests/subgroup_view_callbacks.cpp
+++ b/src/applications/tests/unit_tests/subgroup_view_callbacks.cpp
@@ -1,0 +1,130 @@
+/**
+ * @file subgroup_view_callbacks.cpp
+ *
+ * This program can be used to test the GetsViewChangeCallback interface, which
+ * allows user-defined objects to get a new-view upcall when the Group installs
+ * a new View. It also tests the GroupReference interface, which allows user-
+ * defined objects to access a type-erased Group pointer, since this is necessary
+ * for the user-defined object to know which subgroup it is in (and thus find its
+ * subgroup in the new view).
+ */
+
+#include <cstdint>
+#include <iostream>
+#include <random>
+#include <string>
+
+#include <derecho/core/derecho.hpp>
+
+class CallbackTestObject : public mutils::ByteRepresentable,
+                           public derecho::GetsViewChangeCallback,
+                           public derecho::GroupReference {
+    using derecho::GroupReference::group;
+    using derecho::GroupReference::subgroup_index;
+
+    std::string state;
+
+public:
+    CallbackTestObject(const std::string& initial_state = "") : state(initial_state) {}
+    std::string get_state() const {
+        return state;
+    }
+    void update_state(const std::string& new_value) {
+        state = new_value;
+    }
+    void new_view_callback(const derecho::View& new_view);
+
+    DEFAULT_SERIALIZATION_SUPPORT(CallbackTestObject, state);
+    REGISTER_RPC_FUNCTIONS(CallbackTestObject, P2P_TARGETS(get_state), ORDERED_TARGETS(update_state));
+};
+
+void CallbackTestObject::new_view_callback(const derecho::View& new_view) {
+    derecho::subgroup_id_t my_subgroup_id = group->template get_subgroup<CallbackTestObject>(subgroup_index).get_subgroup_id();
+    std::uint32_t my_shard_num = group->template get_subgroup<CallbackTestObject>(subgroup_index).get_shard_num();
+    const derecho::SubView& my_shard_view = new_view.subgroup_shard_views.at(my_subgroup_id).at(my_shard_num);
+    std::cout << "Got a new view callback for view " << new_view.vid << "."
+              << " My CallbackTestObject shard members are: " << my_shard_view.members << std::endl;
+    if(my_shard_view.members[0] == group->get_my_id()) {
+        std::cout << "This node is the shard leader!" << std::endl;
+    }
+}
+
+class NoCallbackTestObject : public mutils::ByteRepresentable {
+    std::string state;
+
+public:
+    NoCallbackTestObject(const std::string& initial_state = "") : state(initial_state) {}
+    std::string get_state() const {
+        return state;
+    }
+    void update_state(const std::string& new_value) {
+        state = new_value;
+    }
+
+    DEFAULT_SERIALIZATION_SUPPORT(NoCallbackTestObject, state);
+    REGISTER_RPC_FUNCTIONS(NoCallbackTestObject, P2P_TARGETS(get_state), ORDERED_TARGETS(update_state));
+};
+
+int main(int argc, char** argv) {
+    pthread_setname_np(pthread_self(), "test_main");
+    const std::string characters("abcdefghijklmnopqrstuvwxyz");
+    std::mt19937 random_generator(getpid());
+    std::uniform_int_distribution<std::size_t> char_distribution(0, characters.size() - 1);
+
+    const int num_args = 3;
+    if(argc < (num_args + 1) || (argc > (num_args + 1) && strcmp("--", argv[argc - (num_args + 1)]) != 0)) {
+        std::cout << "Invalid command line arguments." << std::endl;
+        std::cout << "Usage: " << argv[0] << " [derecho-config-options -- ] callback_subgroup_size no_callback_subgroup_size num_updates" << std::endl;
+        return -1;
+    }
+
+    const unsigned int callback_size = std::stoi(argv[argc - num_args]);
+    const unsigned int no_callback_size = std::stoi(argv[argc - num_args + 1]);
+    const unsigned int num_updates = std::stoi(argv[argc - 1]);
+    derecho::Conf::initialize(argc, argv);
+
+    derecho::SubgroupInfo subgroup_info(
+            derecho::DefaultSubgroupAllocator({
+                    {std::type_index(typeid(CallbackTestObject)),
+                     derecho::one_subgroup_policy(derecho::flexible_even_shards(
+                             1, 1, callback_size))},
+                    {std::type_index(typeid(NoCallbackTestObject)),
+                     derecho::one_subgroup_policy(derecho::flexible_even_shards(
+                             1, 1, no_callback_size))},
+            }));
+
+    derecho::Group<CallbackTestObject, NoCallbackTestObject> group(
+            subgroup_info,
+            [](persistent::PersistentRegistry*, derecho::subgroup_id_t) { return std::make_unique<CallbackTestObject>(); },
+            [](persistent::PersistentRegistry*, derecho::subgroup_id_t) { return std::make_unique<NoCallbackTestObject>(); });
+    // Figure out which subgroup this node got assigned to
+    int32_t my_shard_callback_subgroup = group.get_my_shard<CallbackTestObject>();
+    int32_t my_shard_nocallback_subgroup = group.get_my_shard<NoCallbackTestObject>();
+    if(my_shard_callback_subgroup != 1) {
+        std::cout << "In the CallbackTestObject subgroup" << std::endl;
+        derecho::Replicated<CallbackTestObject>& subgroup_handle = group.get_subgroup<CallbackTestObject>();
+        // Send some random updates so there is some activity besides the view changes
+        for(unsigned counter = 0; counter < num_updates; ++counter) {
+            std::string new_string('a', 32);
+            std::generate(new_string.begin(), new_string.end(),
+                          [&]() { return characters[char_distribution(random_generator)]; });
+            subgroup_handle.ordered_send<RPC_NAME(update_state)>(new_string);
+        }
+        // At some point while these updates are sending, you should kill a group member to cause a view change
+    } else if(my_shard_nocallback_subgroup != 1) {
+        std::cout << "In the NoCallbackTestObject subgroup" << std::endl;
+        derecho::Replicated<NoCallbackTestObject>& subgroup_handle = group.get_subgroup<NoCallbackTestObject>();
+        for(unsigned counter = 0; counter < num_updates; ++counter) {
+            std::string new_string('a', 32);
+            std::generate(new_string.begin(), new_string.end(),
+                          [&]() { return characters[char_distribution(random_generator)]; });
+            subgroup_handle.ordered_send<RPC_NAME(update_state)>(new_string);
+        }
+    }
+
+    std::cout << "Press enter to shut down" << std::endl;
+    std::cin.get();
+    group.barrier_sync();
+    group.leave(true);
+    return 0;
+}

--- a/src/core/git_version.cpp
+++ b/src/core/git_version.cpp
@@ -13,8 +13,8 @@ namespace derecho {
 const int MAJOR_VERSION = 2;
 const int MINOR_VERSION = 3;
 const int PATCH_VERSION = 0;
-const int COMMITS_AHEAD_OF_VERSION = 53;
+const int COMMITS_AHEAD_OF_VERSION = 54;
 const char* VERSION_STRING = "2.3.0";
-const char* VERSION_STRING_PLUS_COMMITS = "2.3.0+53";
+const char* VERSION_STRING_PLUS_COMMITS = "2.3.0+54";
 
 }

--- a/src/core/git_version.cpp
+++ b/src/core/git_version.cpp
@@ -13,8 +13,8 @@ namespace derecho {
 const int MAJOR_VERSION = 2;
 const int MINOR_VERSION = 3;
 const int PATCH_VERSION = 0;
-const int COMMITS_AHEAD_OF_VERSION = 52;
+const int COMMITS_AHEAD_OF_VERSION = 53;
 const char* VERSION_STRING = "2.3.0";
-const char* VERSION_STRING_PLUS_COMMITS = "2.3.0+52";
+const char* VERSION_STRING_PLUS_COMMITS = "2.3.0+53";
 
 }


### PR DESCRIPTION
I added a mechanism to deliver new-view callbacks to the user-provided objects that define each subgroup (i.e. the T in a Replicated<T>) so that these objects can react to a view change if they want to. If a user-provided object inherits from GetsViewChangeCallback, and implements a method named `new_view_callback`, that method will be called by ViewManager during the last phase of a view change (along with the other "view upcalls"). The existing `view_upcalls` parameter to the Group constructor can't be used to provide this feature because the user-provided replicated objects are constructed within the Group constructor, and thus don't yet exist at the time you would need to declare a callback function for that parameter.