### PR TITLE
Serialization fixes

### DIFF
--- a/src/applications/tests/unit_tests/rpc_function_types.cpp
+++ b/src/applications/tests/unit_tests/rpc_function_types.cpp
@@ -1,22 +1,11 @@
 #include <derecho/core/derecho.hpp>
 #include <derecho/mutils-serialization/SerializationSupport.hpp>
 
-/*
- * The Eclipse CDT parser crashes if it tries to expand the REGISTER_RPC_FUNCTIONS
- * macro, probably because there are too many layers of variadic argument expansion.
- * This definition makes the RPC macros no-ops when the CDT parser tries to expand
- * them, which allows it to continue syntax-highlighting the rest of the file.
- */
-#ifdef __CDT_PARSER__
-#define REGISTER_RPC_FUNCTIONS(...)
-#define RPC_NAME(...) 0ULL
-#endif
-
 class ConstTest : public mutils::ByteRepresentable {
     int state;
 
 public:
-    //Const member functions should be allowed
+    // Const member functions should be allowed
     int read_state() const {
         return state;
     }
@@ -26,23 +15,23 @@ public:
     ConstTest(int initial_state = 0) : state(initial_state) {}
 
     DEFAULT_SERIALIZATION_SUPPORT(ConstTest, state);
-    REGISTER_RPC_FUNCTIONS(ConstTest, ORDERED_TARGETS(read_state, change_state));
+    REGISTER_RPC_FUNCTIONS(ConstTest, P2P_TARGETS(read_state), ORDERED_TARGETS(read_state, change_state));
 };
 
 class ReferenceTest : public mutils::ByteRepresentable {
     std::string state;
 
 public:
-    //Causes a compile error: you can't return a reference from an RPC function
-    //    std::string& get_state() {
-    //Correct version:
+    // Causes a compile error: you can't return a reference from an RPC function
+    //     std::string& get_state() {
+    // Correct version:
     std::string get_state() {
         return state;
     }
 
-    //Causes a compile error: RPC functions must pass arguments by reference
-    //    void set_state(std::string new_state) {
-    //Correct version:
+    // Causes a compile error: RPC functions must pass arguments by reference
+    //     void set_state(std::string new_state) {
+    // Correct version:
     void set_state(const std::string& new_state) {
         state = new_state;
     }
@@ -57,29 +46,59 @@ public:
     REGISTER_RPC_FUNCTIONS(ReferenceTest, ORDERED_TARGETS(get_state, set_state, append_string));
 };
 
-using derecho::fixed_even_shards;
+class MapTest : public mutils::ByteRepresentable {
+    std::map<uint32_t, uint64_t> map_state;
+
+public:
+    // Not a compile error: passing an int argument by value is allowed
+    void put(uint32_t key, uint64_t value) {
+        map_state[key] = value;
+    }
+    uint64_t get(uint32_t key) const {
+        return map_state.at(key);
+    }
+    // Passing an entire map as a const reference should work
+    void set_map(const std::map<uint32_t, uint64_t>& new_map) {
+        map_state = new_map;
+    }
+    std::map<uint32_t, uint64_t> get_map() const {
+        return map_state;
+    }
+
+    MapTest(const std::map<uint32_t, uint64_t>& initial_map = {}) : map_state(initial_map) {}
+
+    DEFAULT_SERIALIZATION_SUPPORT(MapTest, map_state);
+    REGISTER_RPC_FUNCTIONS(MapTest, P2P_TARGETS(get, get_map), ORDERED_TARGETS(put, get, set_map, get_map))
+};
+
+using derecho::flexible_even_shards;
 using derecho::one_subgroup_policy;
 
 int main(int argc, char** argv) {
     // Read configurations from the command line options as well as the default config file
     derecho::Conf::initialize(argc, argv);
 
-    derecho::SubgroupInfo subgroup_function(derecho::DefaultSubgroupAllocator({
-        {std::type_index(typeid(ConstTest)), one_subgroup_policy(fixed_even_shards(1, 3))},
-        {std::type_index(typeid(ReferenceTest)), one_subgroup_policy(fixed_even_shards(1, 3))}
-    }));
-    auto const_test_factory = [](persistent::PersistentRegistry*,derecho::subgroup_id_t) { return std::make_unique<ConstTest>(); };
-    auto reference_test_factory = [](persistent::PersistentRegistry*,derecho::subgroup_id_t) { return std::make_unique<ReferenceTest>(); };
+    derecho::SubgroupInfo subgroup_function(derecho::DefaultSubgroupAllocator(
+            {{std::type_index(typeid(ConstTest)), one_subgroup_policy(flexible_even_shards(1, 1, 3))},
+             {std::type_index(typeid(ReferenceTest)), one_subgroup_policy(flexible_even_shards(1, 1, 3))},
+             {std::type_index(typeid(MapTest)), one_subgroup_policy(flexible_even_shards(1, 1, 3))}}));
+    auto const_test_factory = [](persistent::PersistentRegistry*, derecho::subgroup_id_t) { return std::make_unique<ConstTest>(); };
+    auto reference_test_factory = [](persistent::PersistentRegistry*, derecho::subgroup_id_t) { return std::make_unique<ReferenceTest>(); };
+    auto map_test_factory = [](persistent::PersistentRegistry*, derecho::subgroup_id_t) { return std::make_unique<MapTest>(); };
 
-    derecho::Group<ConstTest, ReferenceTest> group(derecho::UserMessageCallbacks{}, subgroup_function, {},
-                                                   std::vector<derecho::view_upcall_t>{},
-                                                   const_test_factory, reference_test_factory);
+    derecho::Group<ConstTest, ReferenceTest, MapTest> group(derecho::UserMessageCallbacks{}, subgroup_function, {},
+                                                            std::vector<derecho::view_upcall_t>{},
+                                                            const_test_factory, reference_test_factory, map_test_factory);
     int my_id = derecho::getConfInt32(CONF_DERECHO_LOCAL_ID);
     const std::vector<node_id_t> const_test_group_members = group.get_subgroup_members<ConstTest>()[0];
     bool in_const_test_group = std::find(const_test_group_members.begin(),
-                                         const_test_group_members.end(), my_id) !=
-                                                 const_test_group_members.end();
+                                         const_test_group_members.end(), my_id)
+                               != const_test_group_members.end();
+    const std::vector<node_id_t> ref_test_group_members = group.get_subgroup_members<ReferenceTest>()[0];
+    bool in_ref_test_group = std::find(ref_test_group_members.begin(), ref_test_group_members.end(), my_id)
+                             != ref_test_group_members.end();
     if(in_const_test_group) {
+        std::cout << "In the ConstTest subgroup" << std::endl;
         derecho::Replicated<ConstTest>& const_test = group.get_subgroup<ConstTest>();
         uint32_t my_node_rank = group.get_my_rank();
         const_test.ordered_send<RPC_NAME(change_state)>(my_node_rank);
@@ -94,7 +113,8 @@ int main(int argc, char** argv) {
             }
         }
         std::cout << "Current state according to ordered_send: " << curr_state << std::endl;
-    } else {
+    } else if(in_ref_test_group) {
+        std::cout << "In the ReferenceTest subgroup" << std::endl;
         derecho::Replicated<ReferenceTest>& reference_test = group.get_subgroup<ReferenceTest>();
         reference_test.ordered_send<RPC_NAME(set_state)>("Hello, testing.");
         reference_test.ordered_send<RPC_NAME(append_string)>(" Another string. ");
@@ -107,5 +127,16 @@ int main(int argc, char** argv) {
                 std::cout << "No query reply due to node_removed_from_group_exception: " << ex.what() << std::endl;
             }
         }
+    } else {
+        std::cout << "In the MapTest subgroup" << std::endl;
+        derecho::Replicated<MapTest>& map_test = group.get_subgroup<MapTest>();
+        map_test.ordered_send<RPC_NAME(put)>(18, 36);
+        map_test.ordered_send<RPC_NAME(put)>(66666, 8888888);
+        derecho::rpc::QueryResults<std::map<uint32_t, uint64_t>> get_map_results = map_test.ordered_send<RPC_NAME(get_map)>();
+        decltype(get_map_results)::ReplyMap& replies = get_map_results.get();
+        std::map<uint32_t, uint64_t> map_state = replies.begin()->second.get();
+        map_state.emplace(64, 128);
+        map_state.emplace(65536, 1024);
+        map_test.ordered_send<RPC_NAME(set_map)>(map_state);
     }
 }

--- a/src/core/git_version.cpp
+++ b/src/core/git_version.cpp
@@ -13,8 +13,8 @@ namespace derecho {
 const int MAJOR_VERSION = 2;
 const int MINOR_VERSION = 3;
 const int PATCH_VERSION = 0;
-const int COMMITS_AHEAD_OF_VERSION = 52;
+const int COMMITS_AHEAD_OF_VERSION = 54;
 const char* VERSION_STRING = "2.3.0";
-const char* VERSION_STRING_PLUS_COMMITS = "2.3.0+52";
+const char* VERSION_STRING_PLUS_COMMITS = "2.3.0+54";
 
 }

--- a/src/mutils-serialization/CMakeLists.txt
+++ b/src/mutils-serialization/CMakeLists.txt
@@ -4,13 +4,18 @@ set(CMAKE_DISABLE_IN_SOURCE_BUILD ON)
 project (mutils-serialization)
 
 add_library(mutils-serialization OBJECT SerializationSupport.cpp)
-target_include_directories(mutils-serialization PRIVATE 
+target_include_directories(mutils-serialization PRIVATE
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
   $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>)
 
 add_custom_target(format_mutils-serialization clang-format-3.8 -i *.cpp *.hpp)
 
-add_executable(test test_new_deserialization.cpp SerializationSupport.cpp)
-target_include_directories(test PRIVATE 
+add_executable(test serialization-test.cpp SerializationSupport.cpp)
+target_include_directories(test PRIVATE
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+  $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>)
+
+add_executable(deserialization_test test_new_deserialization.cpp SerializationSupport.cpp)
+target_include_directories(deserialization_test PRIVATE
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
   $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>)

--- a/src/mutils-serialization/serialization-test.cpp
+++ b/src/mutils-serialization/serialization-test.cpp
@@ -157,6 +157,8 @@ int main(int argc, char** argv) {
     std::unique_ptr<TestObject> deserialized_obj;
     std::size_t buffer_size = mutils::bytes_size(obj);
     // Scope for test_buffer
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-variable"
     {
         uint8_t test_buffer[buffer_size];
         mutils::to_bytes(obj, test_buffer);
@@ -167,6 +169,7 @@ int main(int argc, char** argv) {
         assert(result == (5 + 6 + 7 + 8));
         deserialized_obj = mutils::from_bytes<TestObject>(&dsm, test_buffer);
     }
+#pragma GCC diagnostic pop
     assert(obj == *deserialized_obj);
 
     std::cout << "Test passed" << std::endl;

--- a/src/mutils-serialization/serialization-test.cpp
+++ b/src/mutils-serialization/serialization-test.cpp
@@ -1,0 +1,173 @@
+#include <derecho/mutils-serialization/SerializationSupport.hpp>
+
+#include <cassert>
+#include <cstdint>
+#include <iostream>
+#include <list>
+#include <map>
+#include <memory>
+#include <set>
+#include <string>
+#include <tuple>
+#include <unordered_map>
+#include <vector>
+
+struct PODStruct {
+    int field_one;
+    int field_two;
+    bool a_bool;
+};
+
+struct TestObject : public mutils::ByteRepresentable {
+    int test_int;
+    std::string test_string;
+    std::pair<std::uint32_t, std::uint64_t> test_pair;
+    std::tuple<int, std::string, std::uint64_t> test_tuple;
+    std::set<int> test_set;
+    std::list<int> test_list;
+    std::vector<int> test_vector;
+    std::map<int, std::string> test_map;
+    std::unordered_map<int, std::string> test_hashmap;
+    PODStruct test_pod;
+    TestObject(int i, const std::string& str, const std::pair<std::uint32_t, std::uint64_t> p,
+               const std::tuple<int, std::string, std::uint64_t>& t, const std::set<int>& s,
+               const std::list<int>& l, const std::vector<int>& v, const std::map<int, std::string>& m,
+               const std::unordered_map<int, std::string>& u, const PODStruct& pod)
+        : test_int(i),
+          test_string(str),
+          test_pair(p),
+          test_tuple(t),
+          test_set(s),
+          test_list(l),
+          test_vector(v),
+          test_map(m),
+          test_hashmap(u),
+          test_pod(pod) {}
+
+    // Mostly use DEFAULT_SERIALIZATION_SUPPORT, but don't use the default from_bytes_noalloc
+    DEFAULT_SERIALIZE(test_int, test_string, test_pair, test_tuple,
+                      test_set, test_list, test_vector, test_map, test_hashmap, test_pod);
+    DEFAULT_DESERIALIZE(TestObject, test_int, test_string, test_pair, test_tuple,
+                        test_set, test_list, test_vector, test_map, test_hashmap, test_pod);
+    // Provide a from_bytes_noalloc that recursively calls from_bytes_noalloc so we actually test from_bytes_noalloc
+    static mutils::context_ptr<TestObject> from_bytes_noalloc(mutils::DeserializationManager* dsm, uint8_t const* buf) {
+        auto int_ptr = mutils::from_bytes_noalloc<int>(dsm, buf);
+        std::size_t bytes_read = mutils::bytes_size(*int_ptr);
+        auto string_ptr = mutils::from_bytes_noalloc<std::string>(dsm, buf + bytes_read);
+        bytes_read += mutils::bytes_size(*string_ptr);
+        auto pair_ptr = mutils::from_bytes_noalloc<std::pair<std::uint32_t, std::uint64_t>>(dsm, buf + bytes_read);
+        bytes_read += mutils::bytes_size(*pair_ptr);
+        auto tuple_ptr = mutils::from_bytes_noalloc<std::tuple<int, std::string, std::uint64_t>>(dsm, buf + bytes_read);
+        bytes_read += mutils::bytes_size(*tuple_ptr);
+        auto set_ptr = mutils::from_bytes_noalloc<std::set<int>>(dsm, buf + bytes_read);
+        bytes_read += mutils::bytes_size(*set_ptr);
+        auto list_ptr = mutils::from_bytes_noalloc<std::list<int>>(dsm, buf + bytes_read);
+        bytes_read += mutils::bytes_size(*list_ptr);
+        auto vec_ptr = mutils::from_bytes_noalloc<std::vector<int>>(dsm, buf + bytes_read);
+        bytes_read += mutils::bytes_size(*vec_ptr);
+        auto map_ptr = mutils::from_bytes_noalloc<std::map<int, std::string>>(dsm, buf + bytes_read);
+        bytes_read += mutils::bytes_size(*map_ptr);
+        auto hashmap_ptr = mutils::from_bytes_noalloc<std::unordered_map<int, std::string>>(dsm, buf + bytes_read);
+        bytes_read += mutils::bytes_size(*hashmap_ptr);
+        auto pod_ptr = mutils::from_bytes_noalloc<PODStruct>(dsm, buf + bytes_read);
+        bytes_read += mutils::bytes_size(*pod_ptr);
+        return mutils::context_ptr<TestObject>(new TestObject(*int_ptr, *string_ptr, *pair_ptr, *tuple_ptr, *set_ptr,
+                                                              *list_ptr, *vec_ptr, *map_ptr, *hashmap_ptr, *pod_ptr));
+    };
+    static mutils::context_ptr<const TestObject> from_bytes_noalloc_const(mutils::DeserializationManager* dsm, uint8_t const* buf) {
+        auto int_ptr = mutils::from_bytes_noalloc<const int>(dsm, buf);
+        std::size_t bytes_read = mutils::bytes_size(*int_ptr);
+        auto string_ptr = mutils::from_bytes_noalloc<const std::string>(dsm, buf + bytes_read);
+        bytes_read += mutils::bytes_size(*string_ptr);
+        auto pair_ptr = mutils::from_bytes_noalloc<const std::pair<std::uint32_t, std::uint64_t>>(dsm, buf + bytes_read);
+        bytes_read += mutils::bytes_size(*pair_ptr);
+        auto tuple_ptr = mutils::from_bytes_noalloc<const std::tuple<int, std::string, std::uint64_t>>(dsm, buf + bytes_read);
+        bytes_read += mutils::bytes_size(*tuple_ptr);
+        auto set_ptr = mutils::from_bytes_noalloc<const std::set<int>>(dsm, buf + bytes_read);
+        bytes_read += mutils::bytes_size(*set_ptr);
+        auto list_ptr = mutils::from_bytes_noalloc<const std::list<int>>(dsm, buf + bytes_read);
+        bytes_read += mutils::bytes_size(*list_ptr);
+        auto vec_ptr = mutils::from_bytes_noalloc<const std::vector<int>>(dsm, buf + bytes_read);
+        bytes_read += mutils::bytes_size(*vec_ptr);
+        auto map_ptr = mutils::from_bytes_noalloc<const std::map<int, std::string>>(dsm, buf + bytes_read);
+        bytes_read += mutils::bytes_size(*map_ptr);
+        auto hashmap_ptr = mutils::from_bytes_noalloc<const std::unordered_map<int, std::string>>(dsm, buf + bytes_read);
+        bytes_read += mutils::bytes_size(*hashmap_ptr);
+        auto pod_ptr = mutils::from_bytes_noalloc<const PODStruct>(dsm, buf + bytes_read);
+        bytes_read += mutils::bytes_size(*pod_ptr);
+        return mutils::context_ptr<const TestObject>(new TestObject(*int_ptr, *string_ptr, *pair_ptr, *tuple_ptr, *set_ptr,
+                                                                    *list_ptr, *vec_ptr, *map_ptr, *hashmap_ptr, *pod_ptr));
+    }
+
+    void ensure_registered(mutils::DeserializationManager&){};
+};
+
+bool operator==(const TestObject& lhs, const TestObject& rhs) {
+    return lhs.test_int == rhs.test_int &&
+           lhs.test_string == rhs.test_string &&
+           lhs.test_pair == rhs.test_pair &&
+           lhs.test_tuple == rhs.test_tuple &&
+           lhs.test_set == rhs.test_set &&
+           lhs.test_list == rhs.test_list &&
+           lhs.test_vector == rhs.test_vector &&
+           lhs.test_map == rhs.test_map &&
+           lhs.test_hashmap == rhs.test_hashmap &&
+           lhs.test_pod.field_one == rhs.test_pod.field_one &&
+           lhs.test_pod.field_two == rhs.test_pod.field_two &&
+           lhs.test_pod.a_bool == rhs.test_pod.a_bool;
+}
+
+int test_object_function(const TestObject& arg) {
+    std::cout << "Called test_object_function with this object: " << std::endl;
+    std::cout << "{ " << arg.test_int << ", " << arg.test_string << ", (" << arg.test_pair.first << "," << arg.test_pair.second << "), ("
+              << std::get<0>(arg.test_tuple) << ", " << std::get<1>(arg.test_tuple) << ", " << std::get<2>(arg.test_tuple) << "), {";
+    int set_sum = 0;
+    for(const auto& i : arg.test_set) {
+        set_sum += i;
+        std::cout << i << ",";
+    }
+    std::cout << "}, {";
+    for(const auto& i : arg.test_list) {
+        std::cout << i << ",";
+    }
+    std::cout << "}, [";
+    for(const auto& i : arg.test_vector) {
+        std::cout << i << ",";
+    }
+    std::cout << "], {";
+    for(const auto& entry : arg.test_map) {
+        std::cout << "{" << entry.first << " => " << entry.second << "}, ";
+    }
+    std::cout << "}, {";
+    for(const auto& entry : arg.test_hashmap) {
+        std::cout << "{" << entry.first << " => " << entry.second << "}, ";
+    }
+    std::cout << "}, PODStruct{" << arg.test_pod.field_one << ", " << arg.test_pod.field_two << ", " << arg.test_pod.a_bool << "} }" << std::endl;
+    return set_sum;
+}
+
+int main(int argc, char** argv) {
+    mutils::DeserializationManager dsm{{}};
+    TestObject obj(123456789, "Foo", {666666, 88888888},
+                   {-987654321, "Bar", 12345678909876543210ull},
+                   {5, 6, 7, 8}, {1, 2, 3, 4}, {9, 9, 9, 9, 9},
+                   {{1, "One"}, {2, "Two"}, {3, "Three"}},
+                   {{4, "Four"}, {5, "Five"}, {6, "Six"}, {7, "Seven"}},
+                   PODStruct{-1, -2, false});
+    std::unique_ptr<TestObject> deserialized_obj;
+    std::size_t buffer_size = mutils::bytes_size(obj);
+    // Scope for test_buffer
+    {
+        uint8_t test_buffer[buffer_size];
+        mutils::to_bytes(obj, test_buffer);
+        mutils::context_ptr<TestObject> temp_deserialized_obj = mutils::from_bytes_noalloc<TestObject>(&dsm, test_buffer);
+        assert(obj == *temp_deserialized_obj);
+        // deserialize_and_run can't take bare functions, it can only take lambdas
+        auto result = mutils::deserialize_and_run(&dsm, test_buffer, [](const TestObject& arg) { return test_object_function(arg); });
+        assert(result == (5 + 6 + 7 + 8));
+        deserialized_obj = mutils::from_bytes<TestObject>(&dsm, test_buffer);
+    }
+    assert(obj == *deserialized_obj);
+
+    std::cout << "Test passed" << std::endl;
+}


### PR DESCRIPTION
While attempting to write an RPC function for Cascade that accepted a std::map parameter, I discovered some bugs in the mutils-serialization library. I fixed them in the standalone [mutils-serialization repository](https://github.com/derecho-project/mutils-serialization), where it's easier to test changes that affect only that library. This copies in the changes to the Derecho repository's copy of mutils-serialization, and also pulls in another commit that was somehow only in the standalone repository and not in Derecho's copy.