### PR TITLE
Replace macro-based persistent exceptions with real exceptions

### DIFF
--- a/include/derecho/persistent/Persistent.hpp
+++ b/include/derecho/persistent/Persistent.hpp
@@ -557,7 +557,7 @@ public:
      *
      * @return  Returns whatever fun returns.
      *
-     * @throws PERSIST_EXP_INV_ENTRY_IDX(int64_t) if the idx is not found.
+     * @throws persistent_invalid_index if the idx is not found.
      */
     template <typename Func>
     auto getByIndex(
@@ -577,7 +577,7 @@ public:
      *
      * @return Return a copy of the object held by a unique pointer.
      *
-     * @throws PERSIST_EXP_INV_ENTRY_IDX(int64_t), if the idx is not found.
+     * @throws persistent_invalid_index, if the idx is not found.
      */
     std::unique_ptr<ObjectType> getByIndex(
             int64_t idx,
@@ -594,13 +594,13 @@ public:
      *
      * @param ver   if 'ver', the specified version, matches a log entry, the state corresponding to that entry will be
      *              send to 'fun'; if 'ver' does not match a log entry, the latest state before 'ver' will be applied to
-     *              'fun'; if the latest state before 'ver' is empty, it throws PERSIST_EXP_INV_VERSION.
+     *              'fun'; if the latest state before 'ver' is empty, it throws persistent_invalid_version.
      * @param fun   the user function to process a const ObjectType& object
      * @param dm    the deserialization manager
      *
      * @return Returns whatever fun returns.
      *
-     * @throws PERSIST_EXP_INV_VERSION, when the state at 'ver' has no state.
+     * @throws persistent_invalid_version, when the state at 'ver' has no state.
      */
     template <typename Func>
     auto get(
@@ -617,12 +617,12 @@ public:
      *
      * @param ver   if 'ver', the specified version, matches a log entry, the state corresponding to that entry will be
      *              send to 'fun'; if 'ver' does not match a log entry, the latest state before 'ver' will be applied to
-     *              'fun'; if the latest state before 'ver' is empty, it throws PERSIST_EXP_INV_VERSION.
+     *              'fun'; if the latest state before 'ver' is empty, it throws persistent_invalid_version.
      * @param dm    the deserialization manager
      *
      * @return a unique pointer to the deserialized copy of ObjectType.
      *
-     * @throws PERSIST_EXP_INV_VERSION, when the state at 'ver' has no state.
+     * @throws persistent_invalid_version, when the state at 'ver' has no state.
      */
     std::unique_ptr<ObjectType> get(
             const version_t ver,
@@ -646,7 +646,7 @@ public:
      *
      * @return Returns whatever fun returns.
      *
-     * @throws PERSIST_EXP_INV_INDEX, when the index 'idx' does not exists.
+     * @throws persistent_invalid_index, when the index 'idx' does not exists.
      */
     template <typename DeltaType, typename Func>
     std::enable_if_t<std::is_base_of<IDeltaSupport<ObjectType>, ObjectType>::value, std::result_of_t<Func(const DeltaType&)>>
@@ -668,7 +668,7 @@ public:
      *
      * @return Returns a unique pointer to the copied DeltaType object.
      *
-     * @throws PERSIST_EXP_INV_INDEX, when the index 'idx' does not exists.
+     * @throws persistent_invalid_index, when the index 'idx' does not exists.
      */
     template <typename DeltaType>
     std::enable_if_t<std::is_base_of<IDeltaSupport<ObjectType>, ObjectType>::value, std::unique_ptr<DeltaType>>
@@ -695,7 +695,7 @@ public:
      *
      * @return Returns whatever fun returns.
      *
-     * @throws PERSIST_EXP_INV_VERSION, when version 'ver' is not found in the log.
+     * @throws persistent_invalid_version, when version 'ver' is not found in the log.
      */
     template <typename DeltaType, typename Func>
     std::enable_if_t<std::is_base_of<IDeltaSupport<ObjectType>, ObjectType>::value, std::result_of_t<Func(const DeltaType&)>>
@@ -719,7 +719,7 @@ public:
      *
      * @return Returns a unique pointer to the copied DeltaType object.
      *
-     * @throws PERSIST_EXP_INV_VERSION, when version 'ver' is not found in the log.
+     * @throws persistent_invalid_version, when version 'ver' is not found in the log.
      */
     template <typename DeltaType>
     std::enable_if_t<std::is_base_of<IDeltaSupport<ObjectType>, ObjectType>::value, std::unique_ptr<DeltaType>>
@@ -796,7 +796,7 @@ public:
      *
      * @return Returns whatever fun returns.
      *
-     * @throws PERSIST_EXP_BEYOND_GSF if hlc is beyond the global stability frontier.
+     * @throws persistent_version_not_stable if hlc is beyond the global stability frontier.
      */
     template <typename Func>
     auto get(
@@ -816,7 +816,7 @@ public:
      *
      * @return a unique pointer to the copied ObjectType object.
      *
-     * @throws PERSIST_EXP_BEYOND_GSF if hlc is beyond the global stability frontier.
+     * @throws persistent_version_not_stable if hlc is beyond the global stability frontier.
      */
     std::unique_ptr<ObjectType> get(
             const HLC& hlc,
@@ -946,7 +946,7 @@ public:
      *              will throw an exception.
      * @param mhlc  the timestamp for this value, normally assigned by callbacks in PersistentRegistry.
      *
-     * @throws  PERSIST_EXP_INV_VERSION when ver is inclusively lower than the latest version in the log.
+     * @throws  persistent_invalid_version when ver is inclusively lower than the latest version in the log.
      */
     virtual void set(ObjectType& v, version_t ver, const HLC& mhlc);
 
@@ -959,7 +959,7 @@ public:
      * @param ver   the version of this value, if ver is inclusively lower than the latest version in the log, set()
      *              will throw an exception.
      *
-     * @throws  PERSIST_EXP_INV_VERSION when ver is inclusively lower than the latest version in the log.
+     * @throws  persistent_invalid_version when ver is inclusively lower than the latest version in the log.
      */
     virtual void set(ObjectType& v, version_t ver);
 
@@ -976,7 +976,7 @@ public:
      * @param ver   the version of this value, if ver is inclusively lower than the latest version in the log, set()
      *              will throw an exception.
      *
-     * @throws  PERSIST_EXP_INV_VERSION when ver is inclusively lower than the latest version in the log.
+     * @throws  persistent_invalid_version when ver is inclusively lower than the latest version in the log.
      */
     virtual void version(version_t ver);
 

--- a/include/derecho/persistent/detail/FilePersistLog.hpp
+++ b/include/derecho/persistent/detail/FilePersistLog.hpp
@@ -129,39 +129,39 @@ protected:
     pthread_mutex_t m_perslock;
 
 // lock macro
-#define FPL_WRLOCK                                        \
-    do {                                                  \
-        if(pthread_rwlock_wrlock(&this->m_rwlock) != 0) { \
-            throw PERSIST_EXP_RWLOCK_WRLOCK(errno);       \
-        }                                                 \
+#define FPL_WRLOCK                                                           \
+    do {                                                                     \
+        if(pthread_rwlock_wrlock(&this->m_rwlock) != 0) {                    \
+            throw persistent_lock_error("rwlock_wrlock failed.", errno); \
+        }                                                                    \
     } while(0)
 
-#define FPL_RDLOCK                                        \
-    do {                                                  \
-        if(pthread_rwlock_rdlock(&this->m_rwlock) != 0) { \
-            throw PERSIST_EXP_RWLOCK_WRLOCK(errno);       \
-        }                                                 \
+#define FPL_RDLOCK                                                           \
+    do {                                                                     \
+        if(pthread_rwlock_rdlock(&this->m_rwlock) != 0) {                    \
+            throw persistent_lock_error("rwlock_rdlock failed.", errno); \
+        }                                                                    \
     } while(0)
 
-#define FPL_UNLOCK                                        \
-    do {                                                  \
-        if(pthread_rwlock_unlock(&this->m_rwlock) != 0) { \
-            throw PERSIST_EXP_RWLOCK_UNLOCK(errno);       \
-        }                                                 \
+#define FPL_UNLOCK                                                           \
+    do {                                                                     \
+        if(pthread_rwlock_unlock(&this->m_rwlock) != 0) {                    \
+            throw persistent_lock_error("rwlock_unlock failed.", errno); \
+        }                                                                    \
     } while(0)
 
-#define FPL_PERS_LOCK                                    \
-    do {                                                 \
-        if(pthread_mutex_lock(&this->m_perslock) != 0) { \
-            throw PERSIST_EXP_MUTEX_LOCK(errno);         \
-        }                                                \
+#define FPL_PERS_LOCK                                                     \
+    do {                                                                  \
+        if(pthread_mutex_lock(&this->m_perslock) != 0) {                  \
+            throw persistent_lock_error("mutex_lock failed.", errno); \
+        }                                                                 \
     } while(0)
 
-#define FPL_PERS_UNLOCK                                    \
-    do {                                                   \
-        if(pthread_mutex_unlock(&this->m_perslock) != 0) { \
-            throw PERSIST_EXP_MUTEX_UNLOCK(errno);         \
-        }                                                  \
+#define FPL_PERS_UNLOCK                                                     \
+    do {                                                                    \
+        if(pthread_mutex_unlock(&this->m_perslock) != 0) {                  \
+            throw persistent_lock_error("mutex_unlock failed.", errno); \
+        }                                                                   \
     } while(0)
 
     // load the log from files. This method may through exceptions if read from
@@ -245,7 +245,7 @@ public:
                 // it.
                 version_t ver = LOG_ENTRY_AT(CURR_LOG_IDX)->fields.ver;
                 persist(ver, true);
-            } catch(uint64_t e) {
+            } catch(std::exception& e) {
                 FPL_UNLOCK;
                 FPL_PERS_UNLOCK;
                 throw e;
@@ -253,7 +253,6 @@ public:
             FPL_PERS_UNLOCK;
             //TODO:remove delete entries from the index. This is tricky because
             // HLC order and idex order does not agree with each other.
-            // throw PERSIST_EXP_UNIMPLEMENTED;
         } else {
             FPL_UNLOCK;
             return;

--- a/include/derecho/persistent/detail/PersistLog.hpp
+++ b/include/derecho/persistent/detail/PersistLog.hpp
@@ -24,6 +24,13 @@ enum StorageType {
     ST_3DXP
 };
 
+struct persistent_unknown_storage_type : public persistent_exception {
+    StorageType requested_type;
+    persistent_unknown_storage_type(StorageType requested_type)
+            : persistent_exception("Unknown storage type: " + std::to_string(requested_type)),
+              requested_type(requested_type) {}
+};
+
 constexpr version_t INVALID_VERSION = -1L;
 constexpr int64_t INVALID_INDEX = INT64_MAX;
 

--- a/include/derecho/persistent/detail/PersistNoLog_impl.hpp
+++ b/include/derecho/persistent/detail/PersistNoLog_impl.hpp
@@ -26,17 +26,17 @@ void saveNoLogObjectInFile(
     // 3 - write to tmp file
     int fd = open(tmpfilepath, O_RDWR | O_CREAT, S_IWUSR | S_IRUSR | S_IRGRP | S_IWGRP | S_IROTH);
     if(fd == -1) {
-        throw PERSIST_EXP_OPEN_FILE(errno);
+        throw persistent_file_error("Failed to open file.", errno);
     }
     ssize_t nWrite = write(fd, buf, size);
     delete[] buf;
     if(nWrite != (ssize_t)size) {
-        throw PERSIST_EXP_WRITE_FILE(errno);
+        throw persistent_file_error("Failed to write to file.", errno);
     }
     close(fd);
     // 4 - atomically rename
     if(rename(tmpfilepath, filepath) != 0) {
-        throw PERSIST_EXP_RENAME_FILE(errno);
+        throw persistent_file_error("Failed to rename file.", errno);
     }
 }
 
@@ -54,7 +54,7 @@ std::unique_ptr<ObjectType> loadNoLogObjectFromFile(
         if(fs::exists(filepath)) {
             if(!fs::remove(filepath)) {
                 dbg_default_error("{} loadNoLogObjectFromFile failed to remove file {}.", _NOLOG_OBJECT_NAME_, filepath);
-                throw PERSIST_EXP_REMOVE_FILE(errno);
+                throw persistent_file_error("Failed to remove file.", errno);
             }
         }
     }
@@ -67,17 +67,17 @@ std::unique_ptr<ObjectType> loadNoLogObjectFromFile(
     int fd = open(filepath, O_RDONLY);
     struct stat stat_buf;
     if(fd == -1 || (fstat(fd, &stat_buf) != 0)) {
-        throw PERSIST_EXP_READ_FILE(errno);
+        throw persistent_file_error("Failed to read file.", errno);
     }
 
     uint8_t* buf = new uint8_t[stat_buf.st_size];
     if(!buf) {
         close(fd);
-        throw PERSIST_EXP_OOM(errno);
+        throw persistent_file_error("Failed to allocate memory for reading file.", errno);
     }
     if(read(fd, buf, stat_buf.st_size) != stat_buf.st_size) {
         close(fd);
-        throw PERSIST_EXP_READ_FILE(errno);
+        throw persistent_file_error("Failed to read file.", errno);
     }
     close(fd);
 

--- a/include/derecho/persistent/detail/Persistent_impl.hpp
+++ b/include/derecho/persistent/detail/Persistent_impl.hpp
@@ -24,7 +24,7 @@ template <typename ObjectType, StorageType storageType>
 _NameMaker<ObjectType, storageType>::_NameMaker() : m_sObjectTypeName(typeid(ObjectType).name()) {
     this->m_iCounter = 0;
     if(pthread_spin_init(&this->m_oLck, PTHREAD_PROCESS_SHARED) != 0) {
-        throw PERSIST_EXP_SPIN_INIT(errno);
+        throw persistent_lock_error("pthread_spin_init failed.", errno);
     }
 }
 
@@ -37,11 +37,11 @@ template <typename ObjectType, StorageType storageType>
 std::unique_ptr<std::string> _NameMaker<ObjectType, storageType>::make(const char* prefix) {
     int cnt;
     if(pthread_spin_lock(&this->m_oLck) != 0) {
-        throw PERSIST_EXP_SPIN_LOCK(errno);
+        throw persistent_lock_error("pthread_spin_lock failed.", errno);
     }
     cnt = this->m_iCounter++;
     if(pthread_spin_unlock(&this->m_oLck) != 0) {
-        throw PERSIST_EXP_SPIN_UNLOCK(errno);
+        throw persistent_lock_error("pthread_spin_unlock failed.", errno);
     }
     std::unique_ptr<std::string> ret = std::make_unique<std::string>();
     //char * buf = (char *)malloc((strlen(this->m_sObjectTypeName)+13)/8*8);
@@ -53,7 +53,7 @@ std::unique_ptr<std::string> _NameMaker<ObjectType, storageType>::make(const cha
     } catch(openssl::openssl_error& ex) {
         dbg_default_error("{}:{} Unable to compute SHA256 of typename. string = {}, length = {}, OpenSSL error: {}",
                           __FILE__, __func__, this->m_sObjectTypeName, strlen(this->m_sObjectTypeName), ex.what());
-        throw PERSIST_EXP_SHA256_HASH(errno);
+        throw;
     }
 
     // char prefix[strlen(this->m_sObjectTypeName) * 2 + 32];
@@ -83,7 +83,7 @@ inline void Persistent<ObjectType, storageType>::initialize_log(const char* obje
         case ST_FILE:
             this->m_pLog = std::make_unique<FilePersistLog>(object_name, enable_signatures);
             if(this->m_pLog == nullptr) {
-                throw PERSIST_EXP_NEW_FAILED_UNKNOWN;
+                throw persistent_exception("Failed to create FilePersistLog for an unknown reason");
             }
             break;
         // volatile
@@ -91,13 +91,13 @@ inline void Persistent<ObjectType, storageType>::initialize_log(const char* obje
             // const std::string tmpfsPath = "/dev/shm/volatile_t";
             this->m_pLog = std::make_unique<FilePersistLog>(object_name, getPersRamdiskPath(), enable_signatures);
             if(this->m_pLog == nullptr) {
-                throw PERSIST_EXP_NEW_FAILED_UNKNOWN;
+                throw persistent_exception("Failed to create FilePersistLog for an unknown reason");
             }
             break;
         }
         //default
         default:
-            throw PERSIST_EXP_STORAGE_TYPE_UNKNOWN(storageType);
+            throw persistent_unknown_storage_type(storageType);
     }
 }
 
@@ -309,7 +309,7 @@ auto Persistent<ObjectType, storageType>::get(
         mutils::DeserializationManager* dm) const {
     uint8_t* pdat = (uint8_t*)this->m_pLog->getEntry(ver);
     if(pdat == nullptr) {
-        throw PERSIST_EXP_INV_VERSION;
+        throw persistent_invalid_version(ver);
     }
     if constexpr(std::is_base_of<IDeltaSupport<ObjectType>, ObjectType>::value) {
         // "So far, the IDeltaSupport does not work with zero-copy 'Persistent::get()'. Emulate with the copy version."
@@ -328,7 +328,7 @@ Persistent<ObjectType, storageType>::getDelta(const version_t ver,
                                               const Func& fun, mutils::DeserializationManager* dm) const {
     uint8_t * pdat = (uint8_t*)this->m_pLog->getEntry(ver, exact);
     if(pdat == nullptr) {
-        throw PERSIST_EXP_INV_VERSION;
+        throw persistent_invalid_version(ver);
     }
     return mutils::deserialize_and_run(dm, pdat, fun);
 }
@@ -340,7 +340,7 @@ std::unique_ptr<ObjectType> Persistent<ObjectType, storageType>::get(
         mutils::DeserializationManager* dm) const {
     int64_t idx = this->m_pLog->getVersionIndex(ver);
     if(idx == INVALID_INDEX) {
-        throw PERSIST_EXP_INV_VERSION;
+        throw persistent_invalid_version(ver);
     }
 
     if constexpr(std::is_base_of<IDeltaSupport<ObjectType>, ObjectType>::value) {
@@ -360,7 +360,7 @@ Persistent<ObjectType, storageType>::getDelta(
         mutils::DeserializationManager* dm) const {
     int64_t idx = this->m_pLog->getVersionIndex(ver, exact);
     if(idx == INVALID_INDEX) {
-        throw PERSIST_EXP_INV_VERSION;
+        throw persistent_invalid_version(ver);
     }
 
     return mutils::from_bytes<DeltaType>(dm, (const uint8_t*)this->m_pLog->getEntryByIndex(idx));
@@ -421,19 +421,19 @@ auto Persistent<ObjectType, storageType>::get(
         mutils::DeserializationManager* dm) const {
     // global stability frontier test
     if(m_pRegistry != nullptr && m_pRegistry->getFrontier() <= hlc) {
-        throw PERSIST_EXP_BEYOND_GSF;
+        throw persistent_version_not_stable();
     }
 
     if constexpr(std::is_base_of<IDeltaSupport<ObjectType>, ObjectType>::value) {
         int64_t idx = this->m_pLog->getHLCIndex(hlc);
         if(idx == INVALID_INDEX) {
-            throw PERSIST_EXP_INV_HLC;
+            throw persistent_invalid_hlc();
         }
         return getByIndex(idx, fun, dm);
     } else {
         uint8_t* pdat = (uint8_t*)this->m_pLog->getEntry(hlc);
         if(pdat == nullptr) {
-            throw PERSIST_EXP_INV_HLC;
+            throw persistent_invalid_hlc();
         }
         return mutils::deserialize_and_run(dm, pdat, fun);
     }
@@ -446,18 +446,18 @@ std::unique_ptr<ObjectType> Persistent<ObjectType, storageType>::get(
         mutils::DeserializationManager* dm) const {
     // global stability frontier test
     if(m_pRegistry != nullptr && m_pRegistry->getFrontier() <= hlc) {
-        throw PERSIST_EXP_BEYOND_GSF;
+        throw persistent_version_not_stable();
     }
     if constexpr(std::is_base_of<IDeltaSupport<ObjectType>, ObjectType>::value) {
         int64_t idx = this->m_pLog->getHLCIndex(hlc);
         if(idx == INVALID_INDEX) {
-            throw PERSIST_EXP_INV_HLC;
+            throw persistent_invalid_hlc();
         }
         return getByIndex(idx, dm);
     } else {
         uint8_t const* pdat = (uint8_t const*)this->m_pLog->getEntry(hlc);
         if(pdat == nullptr) {
-            throw PERSIST_EXP_INV_HLC;
+            throw persistent_invalid_hlc();
         }
         return mutils::from_bytes<ObjectType>(dm, pdat);
     }
@@ -766,7 +766,7 @@ void saveObject(ObjectType& obj, const char* object_name) {
             break;
         }
         default:
-            throw PERSIST_EXP_STORAGE_TYPE_UNKNOWN(storageType);
+            throw persistent_unknown_storage_type(storageType);
     }
 }
 
@@ -780,7 +780,7 @@ std::unique_ptr<ObjectType> loadObject(const char* object_name) {
         case ST_MEM:
             return loadNoLogObjectFromMem<ObjectType>(object_name);
         default:
-            throw PERSIST_EXP_STORAGE_TYPE_UNKNOWN(storageType);
+            throw persistent_unknown_storage_type(storageType);
     }
 }
 

--- a/include/derecho/persistent/detail/util.hpp
+++ b/include/derecho/persistent/detail/util.hpp
@@ -2,7 +2,7 @@
 #define PERSISTENT_UTIL_HPP
 
 #include "../PersistException.hpp"
-#include <derecho/conf/conf.hpp>
+#include "derecho/conf/conf.hpp"
 #include <errno.h>
 #include <fcntl.h>
 #include <string>
@@ -44,12 +44,12 @@ inline void checkOrCreateDir(const std::string& dirPath) {
     struct stat sb;
     if(stat(dirPath.c_str(), &sb) == 0) {
         if(!S_ISDIR(sb.st_mode)) {
-            throw PERSIST_EXP_INV_PATH;
+            throw persistent::persistent_exception("Invalid path: " + dirPath);
         }
     } else {
         // create it
         if(mkdir(dirPath.c_str(), 0700) != 0) {
-            throw PERSIST_EXP_CREATE_PATH(errno);
+            throw persistent::persistent_file_error("Failed to create path.", errno);
         }
     }
 }
@@ -61,7 +61,7 @@ inline bool checkRegularFile(const std::string& file) {
 
     if(stat(file.c_str(), &sb) == 0) {
         if(!S_ISREG(sb.st_mode)) {
-            throw PERSIST_EXP_INV_FILE;
+            throw persistent::persistent_exception("Invalid file: " + file);
         }
     } else {
         bRet = false;
@@ -80,11 +80,11 @@ inline bool checkOrCreateFileWithSize(const std::string& file, uint64_t size) {
 
     fd = open(file.c_str(), O_RDWR | O_CREAT, S_IWUSR | S_IRUSR | S_IRGRP | S_IWGRP | S_IROTH);
     if(fd < 0) {
-        throw PERSIST_EXP_CREATE_FILE(errno);
+        throw persistent::persistent_file_error("Failed to create file.", errno);
     }
 
     if(ftruncate(fd, size) != 0) {
-        throw PERSIST_EXP_TRUNCATE_FILE(errno);
+        throw persistent::persistent_file_error("Failed to truncate file.", errno);
     }
     close(fd);
     return bCreate;

--- a/src/applications/archive/persistent_temporal_send_test.cpp
+++ b/src/applications/archive/persistent_temporal_send_test.cpp
@@ -245,8 +245,8 @@ int main(int argc, char* argv[]) {
                 last = cur;
             };
 
-        } catch(uint64_t exp) {
-            std::cout << "Exception caught:0x" << std::hex << exp << std::endl;
+        } catch(std::exception& exp) {
+            std::cout << "Exception caught: " << typeid(exp).name() << ": " << exp.what() << std::endl;
             return -1;
         }
     }

--- a/src/applications/archive/volatile_temporal_send_test.cpp
+++ b/src/applications/archive/volatile_temporal_send_test.cpp
@@ -247,8 +247,8 @@ int main(int argc, char *argv[]) {
                 last = cur;
             };
 
-        } catch(uint64_t exp) {
-            std::cout << "Exception caught:0x" << std::hex << exp << std::endl;
+        } catch(std::exception& exp) {
+            std::cout << "Exception caught: " << typeid(exp).name() << ": " << exp.what() << std::endl;
             return -1;
         }
     }

--- a/src/applications/archive/volatile_temporal_stability_test.cpp
+++ b/src/applications/archive/volatile_temporal_stability_test.cpp
@@ -150,7 +150,7 @@ int main(int argc, char *argv[]) {
                     std::unique_ptr<Bytes> bs = (*handle.user_object_ptr)->vola_bytes.get(tqhlc);
                     dbg_default_debug("query returned from vola_bytes");
                     clock_gettime(CLOCK_REALTIME, &at);
-                    PayLoad *pl = (PayLoad *)(bs->bytes);
+                    PayLoad *pl = (PayLoad *)(bs->get());
 
                     if(node_rank_seen != pl->node_rank || msg_seqno_seen != pl->msg_seqno) {
                         query_time_us[num_datapoints] = tqhlc.m_rtc_us;
@@ -171,19 +171,16 @@ int main(int argc, char *argv[]) {
                         bQuit = true;
                     }
                     break;
-                } catch(unsigned long long exp) {
-                    dbg_default_debug("query thread return:{0:x}", exp);
-                    // query time is too late or too early:
-                    if(exp == PERSIST_EXP_BEYOND_GSF) {
-                        usleep(10);  // sleep for 10 microseconds.
-                    } else if(exp == PERSIST_EXP_INV_HLC) {
-                        usleep(10);
-                        pthread_yield();
-                        dbg_default_trace("give up query with hlc({},{}) because it is too early.", tqhlc.m_rtc_us, tqhlc.m_logic);
-                        break;
-                    } else {
-                        dbg_default_warn("unexpected exception({:x})", exp);
-                    }
+                } catch(persistent_version_not_stable& exp) {
+                    // query time is too late
+                    usleep(10);  // sleep for 10 microseconds.
+                } catch(persistent_invalid_hlc& exp) {
+                    usleep(10);
+                    pthread_yield();
+                    dbg_default_trace("give up query with hlc({},{}) because it is too early.", tqhlc.m_rtc_us, tqhlc.m_logic);
+                    break;
+                } catch(persistent_exception& exp) {
+                     dbg_default_warn("unexpected exception({:x})", typeid(exp).name());
                 }
             }
         }
@@ -218,8 +215,8 @@ int main(int argc, char *argv[]) {
                     handle.ordered_send<RPC_NAME(change_vola_bytes)>(bs);
                 }
             }
-        } catch(uint64_t exp) {
-            std::cout << "Exception caught:0x" << std::hex << exp << std::endl;
+        } catch(std::exception& exp) {
+            std::cout << "Exception caught: " << typeid(exp).name() << ": " << exp.what() << std::endl;
             return -1;
         }
     }

--- a/src/applications/archive/volatile_typed_subgroup_bw_test.cpp
+++ b/src/applications/archive/volatile_typed_subgroup_bw_test.cpp
@@ -166,8 +166,8 @@ int main(int argc, char* argv[]) {
             }
             clock_gettime(CLOCK_REALTIME, &t2);
 
-        } catch(uint64_t exp) {
-            std::cout << "Exception caught:0x" << std::hex << exp << std::endl;
+        } catch(std::exception& exp) {
+            std::cout << "Exception caught: " << typeid(exp).name() << ": " << exp.what() << std::endl;
             return -1;
         }
         int64_t nsec = ((int64_t)t2.tv_sec - t1.tv_sec) * 1000000000 + t2.tv_nsec - t1.tv_nsec;

--- a/src/applications/tests/performance_tests/persistent_latency_test.cpp
+++ b/src/applications/tests/performance_tests/persistent_latency_test.cpp
@@ -256,8 +256,8 @@ int main(int argc, char* argv[]) {
                 }
             }
 
-        } catch(uint64_t exp) {
-            std::cout << "Exception caught:0x" << std::hex << exp << std::endl;
+        } catch(std::exception& exp) {
+            std::cout << "Exception caught: " << typeid(exp).name() << ": " << exp.what() << std::endl;
             return -1;
         }
     }

--- a/src/core/git_version.cpp
+++ b/src/core/git_version.cpp
@@ -13,8 +13,8 @@ namespace derecho {
 const int MAJOR_VERSION = 2;
 const int MINOR_VERSION = 3;
 const int PATCH_VERSION = 0;
-const int COMMITS_AHEAD_OF_VERSION = 68;
+const int COMMITS_AHEAD_OF_VERSION = 69;
 const char* VERSION_STRING = "2.3.0";
-const char* VERSION_STRING_PLUS_COMMITS = "2.3.0+68";
+const char* VERSION_STRING_PLUS_COMMITS = "2.3.0+69";
 
 }

--- a/src/core/persistence_manager.cpp
+++ b/src/core/persistence_manager.cpp
@@ -137,9 +137,9 @@ void PersistenceManager::handle_persist_request(subgroup_id_t subgroup_id, persi
                        Vc.gmsSST->persisted_num,
                        subgroup_id);
         last_persisted_version[subgroup_id] = persisted_version;
-    } catch(uint64_t exp) {
-        dbg_default_debug("exception on persist():subgroup={},ver={},exp={}.", subgroup_id, version, exp);
-        std::cout << "exception on persistent:subgroup=" << subgroup_id << ",ver=" << version << "exception=0x" << std::hex << exp << std::endl;
+    } catch(persistent::persistent_exception& exp) {
+        dbg_default_debug("exception on persist():subgroup={},ver={},what={}.", subgroup_id, version, exp.what());
+        std::cout << "exception on persistent:subgroup=" << subgroup_id << ",ver=" << version << "exception message:" << exp.what() << std::endl;
     }
 }
 

--- a/src/persistent/FilePersistLog.cpp
+++ b/src/persistent/FilePersistLog.cpp
@@ -2,6 +2,7 @@
 
 #include "derecho/conf/conf.hpp"
 #include "derecho/persistent/detail/util.hpp"
+#include "derecho/persistent/PersistException.hpp"
 
 #include <dirent.h>
 #include <errno.h>
@@ -46,10 +47,10 @@ FilePersistLog::FilePersistLog(const string& name, const string& dataPath, bool 
           m_pLog(MAP_FAILED),
           m_pData(MAP_FAILED) {
     if(pthread_rwlock_init(&this->m_rwlock, NULL) != 0) {
-        throw PERSIST_EXP_RWLOCK_INIT(errno);
+        throw persistent_lock_error("rwlock_init failed", errno);
     }
     if(pthread_mutex_init(&this->m_perslock, NULL) != 0) {
-        throw PERSIST_EXP_MUTEX_INIT(errno);
+        throw persistent_lock_error("mutex_init failed", errno);
     }
     dbg_default_trace("{0} constructor: before load()", name);
     if(derecho::getConfBoolean(CONF_PERS_RESET)) {
@@ -64,15 +65,15 @@ void FilePersistLog::reset() {
     if(fs::exists(this->m_sMetaFile)) {
         if(!fs::remove(this->m_sMetaFile)) {
             dbg_default_error("{0} reset failed to remove the file:{1}", this->m_sName, this->m_sMetaFile);
-            throw PERSIST_EXP_REMOVE_FILE(errno);
+            throw persistent_file_error("Failed to remove file.", errno);
         }
         if(!fs::remove(this->m_sLogFile)) {
             dbg_default_error("{0} reset failed to remove the file:{1}", this->m_sName, this->m_sLogFile);
-            throw PERSIST_EXP_REMOVE_FILE(errno);
+            throw persistent_file_error("Failed to remove file.", errno);
         }
         if(!fs::remove(this->m_sDataFile)) {
             dbg_default_error("{0} reset failed to remove the file:{1}", this->m_sName, this->m_sDataFile);
-            throw PERSIST_EXP_REMOVE_FILE(errno);
+            throw persistent_file_error("Failed to remove file.", errno);
         }
     }
     dbg_default_trace("{0} reset state...done", this->m_sName);
@@ -91,11 +92,11 @@ void FilePersistLog::load() {
     // STEP 2: open files
     this->m_iLogFileDesc = open(this->m_sLogFile.c_str(), O_RDWR);
     if(this->m_iLogFileDesc == -1) {
-        throw PERSIST_EXP_OPEN_FILE(errno);
+        throw persistent_file_error("Failed to open file.", errno);
     }
     this->m_iDataFileDesc = open(this->m_sDataFile.c_str(), O_RDWR);
     if(this->m_iDataFileDesc == -1) {
-        throw PERSIST_EXP_OPEN_FILE(errno);
+        throw persistent_file_error("Failed to open file.", errno);
     }
     // STEP 3: mmap to memory
     //// we map the log entry and data twice to faciliate the search and data
@@ -104,29 +105,29 @@ void FilePersistLog::load() {
     this->m_pLog = mmap(NULL, MAX_LOG_SIZE << 1, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
     if(this->m_pLog == MAP_FAILED) {
         dbg_default_error("{0}:reserve map space for log failed.", this->m_sName);
-        throw PERSIST_EXP_MMAP_FILE(errno);
+        throw persistent_file_error("mmap failed.", errno);
     }
     if(mmap(this->m_pLog, MAX_LOG_SIZE, PROT_READ | PROT_WRITE, MAP_SHARED | MAP_FIXED, this->m_iLogFileDesc, 0) == MAP_FAILED) {
         dbg_default_error("{0}:map ringbuffer space for the first half of log failed. Is the size of log ringbuffer aligned to page?", this->m_sName);
-        throw PERSIST_EXP_MMAP_FILE(errno);
+        throw persistent_file_error("mmap failed.", errno);
     }
     if(mmap((void*)((uint64_t)this->m_pLog + MAX_LOG_SIZE), MAX_LOG_SIZE, PROT_READ | PROT_WRITE, MAP_SHARED | MAP_FIXED, this->m_iLogFileDesc, 0) == MAP_FAILED) {
         dbg_default_error("{0}:map ringbuffer space for the second half of log failed. Is the size of log ringbuffer aligned to page?", this->m_sName);
-        throw PERSIST_EXP_MMAP_FILE(errno);
+        throw persistent_file_error("mmap failed.", errno);
     }
     //// data ringbuffer
     this->m_pData = mmap(NULL, (size_t)(MAX_DATA_SIZE << 1), PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
     if(this->m_pData == MAP_FAILED) {
         dbg_default_error("{0}:reserve map space for data failed.", this->m_sName);
-        throw PERSIST_EXP_MMAP_FILE(errno);
+        throw persistent_file_error("mmap failed.", errno);
     }
     if(mmap(this->m_pData, (size_t)(MAX_DATA_SIZE), PROT_READ | PROT_WRITE, MAP_SHARED | MAP_FIXED, this->m_iDataFileDesc, 0) == MAP_FAILED) {
         dbg_default_error("{0}:map ringbuffer space for the first half of data failed. Is the size of data ringbuffer aligned to page?", this->m_sName);
-        throw PERSIST_EXP_MMAP_FILE(errno);
+        throw persistent_file_error("mmap failed.", errno);
     }
     if(mmap((void*)((uint64_t)this->m_pData + MAX_DATA_SIZE), (size_t)MAX_DATA_SIZE, PROT_READ | PROT_WRITE, MAP_SHARED | MAP_FIXED, this->m_iDataFileDesc, 0) == MAP_FAILED) {
         dbg_default_error("{0}:map ringbuffer space for the second half of data failed. Is the size of data ringbuffer aligned to page?", this->m_sName);
-        throw PERSIST_EXP_MMAP_FILE(errno);
+        throw persistent_file_error("mmap failed.", errno);
     }
     dbg_default_trace("{0}:data/meta file mapped to memory", this->m_sName);
     // STEP 4: initialize the header for new created Metafile
@@ -143,10 +144,10 @@ void FilePersistLog::load() {
 
         try {
             persistMetaHeaderAtomically(&m_currMetaHeader);
-        } catch(uint64_t e) {
+        } catch(std::exception& e) {
             FPL_PERS_UNLOCK;
             FPL_UNLOCK;
-            throw e;
+            throw;
         }
         FPL_PERS_UNLOCK;
         FPL_UNLOCK;
@@ -157,12 +158,12 @@ void FilePersistLog::load() {
         try {
             int fd = open(this->m_sMetaFile.c_str(), O_RDONLY);
             if(fd == -1) {
-                throw PERSIST_EXP_OPEN_FILE(errno);
+                throw persistent_file_error("Failed to open file.", errno);
             }
             ssize_t nRead = read(fd, (void*)&m_persMetaHeader, sizeof(MetaHeader));
             if(nRead != sizeof(MetaHeader)) {
                 close(fd);
-                throw PERSIST_EXP_READ_FILE(errno);
+                throw persistent_file_error("Failed to read file.", errno);
             }
             close(fd);
             m_currMetaHeader = m_persMetaHeader;
@@ -174,10 +175,10 @@ void FilePersistLog::load() {
                 _ent.log_idx = idx;
                 this->hidx.insert(_ent);
             }
-        } catch(uint64_t e) {
+        } catch(std::exception& e) {
             FPL_PERS_UNLOCK;
             FPL_UNLOCK;
-            throw e;
+            throw;
         }
 
         FPL_PERS_UNLOCK;
@@ -219,17 +220,17 @@ inline void FilePersistLog::do_append_validation(const uint64_t size, const int6
                           this->m_sName, NUM_FREE_SLOTS);
         dbg_default_flush();
         FPL_UNLOCK;
-        std::cerr << "PERSIST_EXP_NOSPACE_LOG: FREESLOT=" << NUM_FREE_SLOTS << ",version=" << ver << std::endl;
-        throw PERSIST_EXP_NOSPACE_LOG;
+        std::cerr << "No space in log: FREESLOT=" << NUM_FREE_SLOTS << ",version=" << ver << std::endl;
+        throw persistent_log_full("No free slots in the log.");
     }
     if(NUM_FREE_BYTES < (signature_size + size)) {
         dbg_default_error("{0}-append exception no space for data: NUM_FREE_BYTES={1}, size={2}, signature_size={3}",
                           this->m_sName, NUM_FREE_BYTES, size, signature_size);
         dbg_default_flush();
         FPL_UNLOCK;
-        std::cerr << "PERSIST_EXP_NOSPACE_DATA: FREE:" << NUM_FREE_BYTES << ",size=" << size
+        std::cerr << "No space for data: FREE:" << NUM_FREE_BYTES << ",size=" << size
                   << ",signature_size=" << signature_size << std::endl;
-        throw PERSIST_EXP_NOSPACE_DATA;
+        throw persistent_log_full("Insufficient space in the log for the data.");
     }
     if((CURR_LOG_IDX != INVALID_INDEX) && (m_currMetaHeader.fields.ver >= ver)) {
         int64_t cver = m_currMetaHeader.fields.ver;
@@ -237,8 +238,8 @@ inline void FilePersistLog::do_append_validation(const uint64_t size, const int6
                           (int64_t)cver, (int64_t)ver);
         dbg_default_flush();
         FPL_UNLOCK;
-        std::cerr << "PERSIST_EXP_INV_VERSION:cver=" << cver << ",ver=" << ver << std::endl;
-        throw PERSIST_EXP_INV_VERSION;
+        std::cerr << "Invalid version: cver=" << cver << ",ver=" << ver << std::endl;
+        throw persistent_invalid_version(ver);
     }
 }
 
@@ -266,25 +267,14 @@ void FilePersistLog::append(const void* pdat, uint64_t size, version_t ver, cons
     NEXT_LOG_ENTRY->fields.ofst = NEXT_DATA_OFST;
     NEXT_LOG_ENTRY->fields.hlc_r = mhlc.m_rtc_us;
     NEXT_LOG_ENTRY->fields.hlc_l = mhlc.m_logic;
-    /* No Sync required here.
-    if (msync(ALIGN_TO_PAGE(NEXT_LOG_ENTRY),
-        sizeof(LogEntry) + (((uint64_t)NEXT_LOG_ENTRY) % PAGE_SIZE),MS_SYNC) != 0) {
-      FPL_UNLOCK;
-      throw PERSIST_EXP_MSYNC(errno);
-    }
-    */
+    /* No Sync required here. */
 
     // update meta header
     this->hidx.insert(hlc_index_entry{mhlc, m_currMetaHeader.fields.tail});
     m_currMetaHeader.fields.tail++;
     m_currMetaHeader.fields.ver = ver;
     dbg_default_trace("{0} append:log entry and meta data are updated.", this->m_sName);
-    /* No sync
-    if (msync(this->m_pMeta,sizeof(MetaHeader),MS_SYNC) != 0) {
-      FPL_UNLOCK;
-      throw PERSIST_EXP_MSYNC(errno);
-    }
-    */
+    /* No sync */
     dbg_default_debug("{0} append a log ver:{1} hlc:({2},{3})", this->m_sName,
                       ver, mhlc.m_rtc_us, mhlc.m_logic);
     FPL_UNLOCK;
@@ -297,7 +287,7 @@ void FilePersistLog::advanceVersion(version_t ver) {
         m_currMetaHeader.fields.ver = ver;
     } else {
         FPL_UNLOCK;
-        throw PERSIST_EXP_INV_VERSION;
+        throw persistent_invalid_version(ver);
     }
     FPL_UNLOCK;
 }
@@ -348,21 +338,21 @@ version_t FilePersistLog::persist(version_t ver, bool preLocked) {
         }
         if(flush_dlen > 0) {
             if(msync(flush_dstart, flush_dlen, MS_SYNC) != 0) {
-                throw PERSIST_EXP_MSYNC(errno);
+                throw persistent_file_error("msync failed.", errno);
             }
         }
         if(flush_llen > 0) {
             if(msync(flush_lstart, flush_llen, MS_SYNC) != 0) {
-                throw PERSIST_EXP_MSYNC(errno);
+                throw persistent_file_error("msync failed.", errno);
             }
         }
         // flush meta data
         this->persistMetaHeaderAtomically(&shadow_header);
-    } catch(uint64_t e) {
+    } catch(std::exception& e) {
         if(!preLocked) {
             FPL_PERS_UNLOCK;
         }
-        throw e;
+        throw;
     }
     dbg_default_trace("{0} flush data,log,and meta...done.", this->m_sName);
 
@@ -442,7 +432,6 @@ bool FilePersistLog::getSignatureByIndex(int64_t index, uint8_t* signature, vers
     if(m_currMetaHeader.fields.tail <= ridx || ridx < m_currMetaHeader.fields.head) {
         FPL_UNLOCK;
         return false;
-        // throw PERSIST_EXP_INV_ENTRY_IDX(index);
     }
     FPL_UNLOCK;
 
@@ -535,7 +524,7 @@ const void* FilePersistLog::getEntryByIndex(int64_t eidx) {
 
     if(m_currMetaHeader.fields.tail <= ridx || ridx < m_currMetaHeader.fields.head) {
         FPL_UNLOCK;
-        throw PERSIST_EXP_INV_ENTRY_IDX(eidx);
+        throw persistent_invalid_index(eidx);
     }
     FPL_UNLOCK;
 
@@ -715,16 +704,15 @@ void FilePersistLog::trimByIndex(int64_t idx) {
         // This has a widespreading on the design and needs extensive test before replying on
         // it.
         persist(LOG_ENTRY_AT(CURR_LOG_IDX)->fields.ver, true);
-    } catch(uint64_t e) {
+    } catch(std::exception& e) {
         FPL_UNLOCK;
         FPL_PERS_UNLOCK;
-        throw e;
+        throw;
     }
     //TODO: remove entry from index...this is tricky because HLC
     // order does not agree with index order.
     FPL_UNLOCK;
     FPL_PERS_UNLOCK;
-    // throw PERSIST_EXP_UNIMPLEMENTED;
     dbg_default_trace("{0} trim at index: {1}...done", this->m_sName, idx);
 }
 
@@ -744,7 +732,7 @@ void FilePersistLog::trim(const HLC& hlc) {
     //          LOG_ENTRY_AT(idx)->fields.hlc_l);
     //      });
     //TODO: This is hard because HLC order does not agree with index order.
-    throw PERSIST_EXP_UNIMPLEMENTED;
+    throw persistent_not_implemented("trim(const HLC&)");
     dbg_default_trace("{0} trim at time: {1}.{2}...done", this->m_sName, hlc.m_rtc_us, hlc.m_logic);
 }
 
@@ -755,17 +743,17 @@ void FilePersistLog::persistMetaHeaderAtomically(MetaHeader* pShadowHeader) {
     // STEP 2: write current meta header to swap file
     int fd = open(swpFile.c_str(), O_RDWR | O_CREAT, S_IWUSR | S_IRUSR | S_IRGRP | S_IWGRP | S_IROTH);
     if(fd == -1) {
-        throw PERSIST_EXP_OPEN_FILE(errno);
+        throw persistent_file_error("Failed to open file.", errno);
     }
     ssize_t nWrite = write(fd, pShadowHeader, sizeof(MetaHeader));
     if(nWrite != sizeof(MetaHeader)) {
-        throw PERSIST_EXP_WRITE_FILE(errno);
+        throw persistent_file_error("Failed to write file.", errno);
     }
     close(fd);
 
     // STEP 3: atomically update the meta file
     if(rename(swpFile.c_str(), this->m_sMetaFile.c_str()) != 0) {
-        throw PERSIST_EXP_RENAME_FILE(errno);
+        throw persistent_file_error("Failed to rename file.", errno);
     }
 
     // STEP 4: update the persisted header in memory
@@ -928,11 +916,11 @@ size_t FilePersistLog::mergeLogEntryFromByteArray(const uint8_t* ba) {
     // 1) do we have space to merge it?
     if(NUM_FREE_SLOTS == 0) {
         dbg_default_trace("{0} failed to merge log entry, we don't empty log entry.", __func__);
-        throw PERSIST_EXP_NOSPACE_LOG;
+        throw persistent_log_full("No free log entries");
     }
     if(NUM_FREE_BYTES < cple->fields.sdlen) {
         dbg_default_trace("{0} failed to merge log entry, we need {1} bytes data space, but we have only {2} bytes.", __func__, cple->fields.sdlen, NUM_FREE_BYTES);
-        throw PERSIST_EXP_NOSPACE_DATA;
+        throw persistent_log_full("Insufficient space for log data");
     }
     // 2) merge it!
     memcpy(NEXT_DATA, (const void*)(ba + sizeof(LogEntry)), cple->fields.sdlen);
@@ -947,49 +935,7 @@ size_t FilePersistLog::mergeLogEntryFromByteArray(const uint8_t* ba) {
 //////////////////////////
 // invisible to outside //
 //////////////////////////
-/* -- moved to util.hpp
-  void checkOrCreateDir(const string & dirPath)
-  {
-    struct stat sb;
-    if (stat(dirPath.c_str(),&sb) == 0) {
-      if (! S_ISDIR(sb.st_mode)) {
-        throw PERSIST_EXP_INV_PATH;
-      }
-    } else {
-      // create it
-      if (mkdir(dirPath.c_str(),0700) != 0) {
-        throw PERSIST_EXP_CREATE_PATH(errno);
-      }
-    }
-  }
 
-  bool checkOrCreateFileWithSize(const string & file, uint64_t size)
-  {
-    bool bCreate = false;
-    struct stat sb;
-    int fd;
-
-    if (stat(file.c_str(),&sb) == 0) {
-      if(! S_ISREG(sb.st_mode)) {
-        throw PERSIST_EXP_INV_FILE;
-      }
-    } else {
-      // create it
-      bCreate = true;
-    }
-
-    fd = open(file.c_str(), O_RDWR|O_CREAT,S_IWUSR|S_IRUSR|S_IRGRP|S_IWGRP|S_IROTH);
-    if (fd < 0) {
-      throw PERSIST_EXP_CREATE_FILE(errno);
-    }
-
-    if (ftruncate(fd,size) != 0) {
-      throw PERSIST_EXP_TRUNCATE_FILE(errno);
-    }
-    close(fd);
-    return bCreate;
-  }
-*/
 bool FilePersistLog::checkOrCreateMetaFile() {
     return checkOrCreateFileWithSize(this->m_sMetaFile, META_SIZE);
 }
@@ -1032,10 +978,10 @@ void FilePersistLog::truncate(version_t ver) {
     FPL_PERS_LOCK;
     try {
         persistMetaHeaderAtomically(&m_currMetaHeader);
-    } catch(uint64_t e) {
+    } catch(std::exception& e) {
         FPL_PERS_UNLOCK;
         FPL_UNLOCK;
-        throw e;
+        throw;
     }
     FPL_PERS_UNLOCK;
     FPL_UNLOCK;

--- a/src/persistent/Persistent.cpp
+++ b/src/persistent/Persistent.cpp
@@ -148,7 +148,7 @@ version_t PersistentRegistry::persist(version_t latest_version) {
     version_t min = INVALID_VERSION;
     for(auto& entry : m_registry) {
         version_t ver = entry.second->persist(latest_version);
-        if (min == INVALID_VERSION || 
+        if (min == INVALID_VERSION ||
             min > ver) {
             min = ver;
         }
@@ -231,7 +231,7 @@ std::string PersistentRegistry::generate_prefix(
         sha256.hash_bytes(subgroup_type_name, strlen(subgroup_type_name), subgroup_type_name_digest);
     } catch(openssl::openssl_error& ex) {
         dbg_default_error("{}:{} Unable to compute SHA256 of subgroup type name. OpenSSL error: {}", __FILE__, __func__, ex.what());
-        throw PERSIST_EXP_SHA256_HASH(errno);
+        throw;
     }
 
     // char prefix[strlen(subgroup_type_name) * 2 + 32];


### PR DESCRIPTION
This is a fix for the weird inconsistency between the rest of Derecho, which throws exceptions derived from std::exception, and Persistent, which throws plain integers that are bit-packed with error codes generated by macros like PERSIST_EXP_INV_VERSION. I created a hierarchy of exception types that derive from std::runtime_error to replace the various macros in PersistException.hpp, trying to reflect the same division of error types that the macros had without creating too many exception classes. I did a basic test with mixed_persistence_test and everything seems to run fine.