### PR TITLE
Create a more modular logging system

### DIFF
--- a/include/derecho/conf/conf.hpp
+++ b/include/derecho/conf/conf.hpp
@@ -66,6 +66,9 @@ private:
 #define CONF_PERS_PRIVATE_KEY_FILE "PERS/private_key_file"
 #define CONF_LOGGER_DEFAULT_LOG_NAME "LOGGER/default_log_name"
 #define CONF_LOGGER_DEFAULT_LOG_LEVEL "LOGGER/default_log_level"
+#define CONF_LOGGER_SST_LOG_LEVEL "LOGGER/sst_log_level"
+#define CONF_LOGGER_RPC_LOG_LEVEL "LOGGER/rpc_log_level"
+#define CONF_LOGGER_PERSISTENT_LOG_LEVEL "LOGGER/persistent_log_level"
 #define CONF_LOGGER_LOG_TO_TERMINAL "LOGGER/log_to_terminal"
 #define CONF_LOGGER_LOG_FILE_DEPTH "LOGGER/log_file_depth"
 

--- a/include/derecho/conf/conf.hpp
+++ b/include/derecho/conf/conf.hpp
@@ -68,7 +68,7 @@ private:
 #define CONF_LOGGER_DEFAULT_LOG_LEVEL "LOGGER/default_log_level"
 #define CONF_LOGGER_SST_LOG_LEVEL "LOGGER/sst_log_level"
 #define CONF_LOGGER_RPC_LOG_LEVEL "LOGGER/rpc_log_level"
-#define CONF_LOGGER_PERSISTENT_LOG_LEVEL "LOGGER/persistent_log_level"
+#define CONF_LOGGER_PERSISTENCE_LOG_LEVEL "LOGGER/persistence_log_level"
 #define CONF_LOGGER_LOG_TO_TERMINAL "LOGGER/log_to_terminal"
 #define CONF_LOGGER_LOG_FILE_DEPTH "LOGGER/log_file_depth"
 

--- a/include/derecho/conf/conf.hpp
+++ b/include/derecho/conf/conf.hpp
@@ -68,6 +68,7 @@ private:
 #define CONF_LOGGER_DEFAULT_LOG_LEVEL "LOGGER/default_log_level"
 #define CONF_LOGGER_SST_LOG_LEVEL "LOGGER/sst_log_level"
 #define CONF_LOGGER_RPC_LOG_LEVEL "LOGGER/rpc_log_level"
+#define CONF_LOGGER_VIEWMANAGER_LOG_LEVEL "LOGGER/viewmanager_log_level"
 #define CONF_LOGGER_PERSISTENCE_LOG_LEVEL "LOGGER/persistence_log_level"
 #define CONF_LOGGER_LOG_TO_TERMINAL "LOGGER/log_to_terminal"
 #define CONF_LOGGER_LOG_FILE_DEPTH "LOGGER/log_file_depth"

--- a/include/derecho/core/detail/p2p_connection.hpp
+++ b/include/derecho/core/detail/p2p_connection.hpp
@@ -50,6 +50,7 @@ class P2PConnection {
     const uint32_t my_node_id;
     const uint32_t remote_id;
     const ConnectionParams& connection_params;
+    std::shared_ptr<spdlog::logger> rpc_logger;
     std::unique_ptr<volatile uint8_t[]> incoming_p2p_buffer;
     std::unique_ptr<volatile uint8_t[]> outgoing_p2p_buffer;
     std::unique_ptr<resources> res;

--- a/include/derecho/core/detail/p2p_connection_manager.hpp
+++ b/include/derecho/core/detail/p2p_connection_manager.hpp
@@ -6,6 +6,7 @@
 #else
 #include "derecho/sst/detail/lf.hpp"
 #endif
+#include "derecho/utils/logger.hpp"
 
 #include <atomic>
 #include <functional>
@@ -40,7 +41,8 @@ struct MessagePointer {
 
 class P2PConnectionManager {
     const node_id_t my_node_id;
-
+    /** A pointer to the RPC-module logger (since these P2P connections are used for Derecho RPC) */
+    std::shared_ptr<spdlog::logger> rpc_logger;
     ConnectionParams request_params;
     /**
      * Contains one entry per possible Node ID; the vector index is the node ID.
@@ -132,9 +134,9 @@ public:
     void debug_print();
     /**
      * write to remote OOB memory
-     * @param remote_node       remote node id 
+     * @param remote_node       remote node id
      * @param iov               gather of local memory regions
-     * @param iovcnt            
+     * @param iovcnt
      * @param remote_dest_addr  the address of the remote memory region
      * @param rkey              the access key for remote memory
      * @param size              the size of the remote memory region
@@ -145,11 +147,11 @@ public:
      * read from remote OOB memory
      * @param remote_node       remote node id
      * @param iov               scatter of local memory regions
-     * @param iovcnt            
+     * @param iovcnt
      * @param remote_src_addr   the address of the remote memory region
      * @param rkey              the access key for remote memory
      * @param size              the size of the remote memory region
-     * @throw                   derecho::derecho_exception on error 
+     * @throw                   derecho::derecho_exception on error
      */
     void oob_remote_read(const node_id_t& remote_node, const struct iovec* iov, int iovcnt, uint64_t remote_srcaddr, uint64_t rkey, size_t size);
 };

--- a/include/derecho/core/detail/persistence_manager.hpp
+++ b/include/derecho/core/detail/persistence_manager.hpp
@@ -41,6 +41,8 @@ public:
     };
 
 private:
+    /** Pointer to the persistence-module logger */
+    std::shared_ptr<spdlog::logger> persistence_logger;
     /** Thread handle */
     std::thread persist_thread;
     /**

--- a/include/derecho/core/detail/restart_state.hpp
+++ b/include/derecho/core/detail/restart_state.hpp
@@ -100,6 +100,8 @@ struct RestartState {
 
 class RestartLeaderState {
 private:
+    /** Pointer to the ViewManager logger, which is created by ViewManager */
+    std::shared_ptr<spdlog::logger> vm_logger;
     /** Takes ownership of ViewManager's curr_view pointer, because
      * await_quroum() might replace curr_view with a newer view discovered
      * on a restarting node. */

--- a/include/derecho/core/detail/rpc_manager.hpp
+++ b/include/derecho/core/detail/rpc_manager.hpp
@@ -252,18 +252,7 @@ class RPCManager {
 
 public:
     RPCManager(ViewManager& group_view_manager,
-               const std::vector<DeserializationContext*>& deserialization_context)
-            : nid(getConfUInt32(CONF_DERECHO_LOCAL_ID)),
-              rpc_logger(LoggerFactory::createIfAbsent(LoggerFactory::RPC_LOGGER_NAME, getConfString(CONF_LOGGER_RPC_LOG_LEVEL))),
-              receivers(new std::decay_t<decltype(*receivers)>()),
-              view_manager(group_view_manager),
-              busy_wait_before_sleep_ms(getConfUInt64(CONF_DERECHO_P2P_LOOP_BUSY_WAIT_BEFORE_SLEEP_MS)) {
-        RpcLoggerPtr::initialize();
-        for(const auto& deserialization_context_ptr : deserialization_context) {
-            rdv.push_back(deserialization_context_ptr);
-        }
-        rpc_listener_thread = std::thread(&RPCManager::p2p_receive_loop, this);
-    }
+               const std::vector<DeserializationContext*>& deserialization_context);
 
     ~RPCManager();
 

--- a/include/derecho/core/detail/rpc_manager.hpp
+++ b/include/derecho/core/detail/rpc_manager.hpp
@@ -77,6 +77,8 @@ class RPCManager {
     static_assert(std::is_trivially_copyable<Opcode>::value, "Oh no! Opcode is not trivially copyable!");
     /** The ID of the node this RPCManager is running on. */
     const node_id_t nid;
+    /** A pointer to the logger for the RPC module, which lives in a global static registry. */
+    std::shared_ptr<spdlog::logger> rpc_logger;
     /** A map from FunctionIDs to RPC functions, either the "server" stubs that receive
      * remote calls to invoke functions, or the "client" stubs that receive responses
      * from the targets of an earlier remote call.
@@ -252,9 +254,11 @@ public:
     RPCManager(ViewManager& group_view_manager,
                const std::vector<DeserializationContext*>& deserialization_context)
             : nid(getConfUInt32(CONF_DERECHO_LOCAL_ID)),
+              rpc_logger(LoggerFactory::createIfAbsent(LoggerFactory::RPC_LOGGER_NAME, getConfString(CONF_LOGGER_RPC_LOG_LEVEL))),
               receivers(new std::decay_t<decltype(*receivers)>()),
               view_manager(group_view_manager),
               busy_wait_before_sleep_ms(getConfUInt64(CONF_DERECHO_P2P_LOOP_BUSY_WAIT_BEFORE_SLEEP_MS)) {
+        RpcLoggerPtr::initialize();
         for(const auto& deserialization_context_ptr : deserialization_context) {
             rdv.push_back(deserialization_context_ptr);
         }
@@ -415,7 +419,7 @@ public:
     static node_id_t get_rpc_caller_id();
     /**
      * write to remote OOB memory
-     * @param remote_node       remote node id 
+     * @param remote_node       remote node id
      * @param iov               gather of local memory regions
      * @param iovcnt
      * @param remote_dest_addr  the address of the remote memory region
@@ -432,7 +436,7 @@ public:
      * @param remote_src_addr   the address of the remote memory region
      * @param rkey              the access key for remote memory
      * @param size              the size of the remote memory region
-     * @throw                   derecho::derecho_exception on error 
+     * @throw                   derecho::derecho_exception on error
      */
     void oob_remote_read(const node_id_t& remote_node, const struct iovec* iov, int iovcnt, uint64_t remote_src_addr, uint64_t rkey, size_t size);
 };

--- a/include/derecho/core/detail/view_manager.hpp
+++ b/include/derecho/core/detail/view_manager.hpp
@@ -122,7 +122,8 @@ private:
     //Allow Replicated to access view_mutex and view_change_cv directly
     template <typename T>
     friend class Replicated;
-
+    /** The logger for the ViewManager module */
+    std::shared_ptr<spdlog::logger> vm_logger;
     /**
      * Mutex to protect the curr_view pointer. Non-SST-predicate threads that
      * access the current View through the pointer should acquire a shared_lock;

--- a/include/derecho/core/external_group.hpp
+++ b/include/derecho/core/external_group.hpp
@@ -151,6 +151,7 @@ private:
     void initialize_p2p_connections();
 
     /** ======================== copy/paste from rpc_manager ======================== **/
+    std::shared_ptr<spdlog::logger> rpc_logger;
     const uint64_t busy_wait_before_sleep_ms;
     sst::P2PBufferHandle get_sendbuffer_ptr(uint32_t dest_id, sst::MESSAGE_TYPE type);
     void send_p2p_message(node_id_t dest_id, subgroup_id_t dest_subgroup_id, uint64_t sequence_num, std::weak_ptr<AbstractPendingResults> pending_results_handle);

--- a/include/derecho/persistent/PersistNoLog.hpp
+++ b/include/derecho/persistent/PersistNoLog.hpp
@@ -14,7 +14,7 @@
 #include <stdio.h>
 #include <string>
 
-#include "derecho/utils/logger.hpp"
+#include "detail/logger.hpp"
 
 #if __GNUC__ > 7
 #include <filesystem>

--- a/include/derecho/persistent/Persistent.hpp
+++ b/include/derecho/persistent/Persistent.hpp
@@ -10,6 +10,7 @@
 #include "derecho/utils/logger.hpp"
 #include "detail/FilePersistLog.hpp"
 #include "detail/PersistLog.hpp"
+#include "detail/logger.hpp"
 
 #include <functional>
 #include <inttypes.h>
@@ -217,7 +218,7 @@ public:
         if(m_temporalQueryFrontierProvider != nullptr) {
 #ifndef NDEBUG
             const HLC r = m_temporalQueryFrontierProvider->getFrontier();
-            dbg_default_warn("temporal_query_frontier=HLC({},{})", r.m_rtc_us, r.m_logic);
+            dbg_warn(m_logger, "temporal_query_frontier=HLC({},{})", r.m_rtc_us, r.m_logic);
             return r;
 #else
             return m_temporalQueryFrontierProvider->getFrontier();
@@ -275,7 +276,10 @@ protected:
      * this appears in the first part of storage file for persistent<T>
      */
     const std::string m_subgroupPrefix;
-
+    /**
+     * Pointer to the persistence-module logger (created by the PersistLogger class)
+     */
+    std::shared_ptr<spdlog::logger> m_logger;
     /**
      * Pointer to an entity providing TemporalQueryFrontier service.
      */
@@ -1072,6 +1076,8 @@ protected:
     std::unique_ptr<PersistLog> m_pLog;
     // Persistence Registry
     PersistentRegistry* m_pRegistry;
+    // Pointer to the Persistence-module logger
+    std::shared_ptr<spdlog::logger> m_logger;
     // get the static name maker.
     static _NameMaker<ObjectType, storageType>& getNameMaker(const std::string& prefix = std::string(""));
 

--- a/include/derecho/persistent/detail/FilePersistLog.hpp
+++ b/include/derecho/persistent/detail/FilePersistLog.hpp
@@ -334,14 +334,14 @@ private:
     int64_t binarySearch(const KeyGetter& keyGetter, const TKey& key,
                          const int64_t& logHead, const int64_t& logTail) {
         if(logTail <= logHead) {
-            dbg_default_trace("binary Search failed...EMPTY LOG");
+            dbg_trace(m_logger, "binary Search failed...EMPTY LOG");
             return INVALID_INDEX;
         }
         int64_t head = logHead, tail = logTail - 1;
         int64_t pivot = 0;
         while(head <= tail) {
             pivot = (head + tail) / 2;
-            dbg_default_trace("Search range: {0}->[{1},{2}]", pivot, head, tail);
+            dbg_trace(m_logger, "Search range: {0}->[{1},{2}]", pivot, head, tail);
             const TKey p_key = keyGetter(LOG_ENTRY_AT(pivot));
             if(p_key == key) {
                 break;  // found
@@ -356,7 +356,7 @@ private:
             } else {  // search left
                 tail = pivot - 1;
                 if(head > tail) {
-                    dbg_default_trace("binary Search failed...Object does not exist.");
+                    dbg_trace(m_logger, "binary Search failed...Object does not exist.");
                     return INVALID_INDEX;
                 }
             }
@@ -375,10 +375,10 @@ private:
 #ifndef NDEBUG
     //dbg functions
     void dbgDumpMeta() {
-        dbg_default_trace("m_pData={0},m_pLog={1}", (void*)this->m_pData, (void*)this->m_pLog);
-        dbg_default_trace("META_HEADER:head={0},tail={1}", (int64_t)m_currMetaHeader.fields.head, (int64_t)m_currMetaHeader.fields.tail);
-        dbg_default_trace("META_HEADER_PERS:head={0},tail={1}", (int64_t)m_persMetaHeader.fields.head, (int64_t)m_persMetaHeader.fields.tail);
-        dbg_default_trace("NEXT_LOG_ENTRY={0},NEXT_LOG_ENTRY_PERS={1}", (void*)NEXT_LOG_ENTRY, (void*)NEXT_LOG_ENTRY_PERS);
+        dbg_trace(m_logger, "m_pData={0},m_pLog={1}", (void*)this->m_pData, (void*)this->m_pLog);
+        dbg_trace(m_logger, "META_HEADER:head={0},tail={1}", (int64_t)m_currMetaHeader.fields.head, (int64_t)m_currMetaHeader.fields.tail);
+        dbg_trace(m_logger, "META_HEADER_PERS:head={0},tail={1}", (int64_t)m_persMetaHeader.fields.head, (int64_t)m_persMetaHeader.fields.tail);
+        dbg_trace(m_logger, "NEXT_LOG_ENTRY={0},NEXT_LOG_ENTRY_PERS={1}", (void*)NEXT_LOG_ENTRY, (void*)NEXT_LOG_ENTRY_PERS);
     }
 #endif  // NDEBUG
 };

--- a/include/derecho/persistent/detail/FilePersistLog.hpp
+++ b/include/derecho/persistent/detail/FilePersistLog.hpp
@@ -3,7 +3,7 @@
 
 #include "PersistLog.hpp"
 #include "util.hpp"
-#include <derecho/utils/logger.hpp>
+#include "derecho/utils/logger.hpp"
 #include <pthread.h>
 #include <string>
 
@@ -113,6 +113,8 @@ protected:
     const uint64_t m_iMaxLogEntry;
     // max data size
     const uint64_t m_iMaxDataSize;
+    // pointer to the Persistence-module logger
+    std::shared_ptr<spdlog::logger> m_logger;
 
     // the log file descriptor
     int m_iLogFileDesc;

--- a/include/derecho/persistent/detail/PersistNoLog_impl.hpp
+++ b/include/derecho/persistent/detail/PersistNoLog_impl.hpp
@@ -53,7 +53,7 @@ std::unique_ptr<ObjectType> loadNoLogObjectFromFile(
     if(derecho::getConfBoolean(CONF_PERS_RESET)) {
         if(fs::exists(filepath)) {
             if(!fs::remove(filepath)) {
-                dbg_default_error("{} loadNoLogObjectFromFile failed to remove file {}.", _NOLOG_OBJECT_NAME_, filepath);
+                dbg_error(PersistLogger::get(), "{} loadNoLogObjectFromFile failed to remove file {}.", _NOLOG_OBJECT_NAME_, filepath);
                 throw PERSIST_EXP_REMOVE_FILE(errno);
             }
         }

--- a/include/derecho/persistent/detail/logger.hpp
+++ b/include/derecho/persistent/detail/logger.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "derecho/utils/logger.hpp"
+
+#include <memory>
+#include <atomic>
+
+namespace persistent {
+
+/**
+ * A static class that atomically initializes and holds a reference to the
+ * Persistence module logger. Depends on LoggerFactory, and works similarly.
+ * This is for debug logging, and has nothing to do with PersistLog.
+ */
+class PersistLogger {
+    static std::shared_ptr<spdlog::logger> logger;
+    static std::atomic<uint32_t> initialize_state;
+    static void initialize();
+public:
+    static std::shared_ptr<spdlog::logger>& get();
+};
+
+
+}

--- a/include/derecho/sst/detail/lf.hpp
+++ b/include/derecho/sst/detail/lf.hpp
@@ -58,6 +58,8 @@ private:
     int init_endpoint(struct fi_info* fi);
 
 protected:
+    /** Pointer to the SST-module logger, which lives in a global static registry */
+    std::shared_ptr<spdlog::logger> sst_logger;
     std::atomic<bool> remote_failed;
     /**
      * post read/write request
@@ -142,7 +144,7 @@ public:
      * @throw   derecho::derecho_exception if not found.
      */
     static uint64_t get_oob_mr_key(void* addr);
-    
+
     /**
      * Register oob memory
      * @param addr  the address of the OOB memory
@@ -328,7 +330,7 @@ void filter_external_to(const std::vector<node_id_t>& live_nodes_list);
 void lf_initialize(const std::map<uint32_t, std::pair<ip_addr_t, uint16_t>>& internal_ip_addrs_and_ports,
                    const std::map<uint32_t, std::pair<ip_addr_t, uint16_t>>& external_ip_addrs_and_ports,
                    uint32_t node_id);
-/** Polls for completion of a single posted remote write. 
+/** Polls for completion of a single posted remote write.
  * @return a pair: <completion_entry_index,<remote_id,result(1/0)>>
  */
 std::pair<uint32_t, std::pair<int32_t, int32_t>> lf_poll_completion();

--- a/include/derecho/sst/sst.hpp
+++ b/include/derecho/sst/sst.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "derecho/conf/conf.hpp"
+#include "derecho/utils/logger.hpp"
 #include "predicates.hpp"
 
 #ifdef USE_VERBS_API

--- a/include/derecho/utils/logger.hpp
+++ b/include/derecho/utils/logger.hpp
@@ -71,6 +71,7 @@ public:
     static const std::string PERSISTENT_LOGGER_NAME;
     static const std::string SST_LOGGER_NAME;
     static const std::string RPC_LOGGER_NAME;
+    static const std::string VIEWMANAGER_LOGGER_NAME;
 };
 
 #ifndef NOLOG

--- a/include/derecho/utils/logger.hpp
+++ b/include/derecho/utils/logger.hpp
@@ -7,6 +7,8 @@
 #include <atomic>
 #include <spdlog/spdlog.h>
 #include <spdlog/fmt/ostr.h>
+#include <spdlog/sinks/rotating_file_sink.h>
+#include <spdlog/sinks/stdout_color_sinks.h>
 
 #ifndef NDEBUG
 #undef NOLOG
@@ -17,24 +19,58 @@ private:
     static std::atomic<uint32_t> _initialize_state;
     static std::shared_ptr<spdlog::details::thread_pool> _thread_pool_holder;
     static std::shared_ptr<spdlog::logger> _default_logger;
+    static std::shared_ptr<spdlog::sinks::rotating_file_sink_mt> _file_sink;
+    static std::shared_ptr<spdlog::sinks::stdout_color_sink_mt> _stdout_sink;
+    // mutex for the createIfAbsent method
+    static std::mutex get_create_mutex;
     static void _initialize();
     static std::shared_ptr<spdlog::logger> _create_logger(
-        const std::string &logger_name,
-        spdlog::level::level_enum log_level);
+            const std::string& logger_name,
+            spdlog::level::level_enum log_level);
+
 public:
-    // create the logger
-    // @PARAM logger_name
-    //     Name of the logger. The log file would be created as
-    //     "<logger_name>.log"
-    // @PARAM log_level
-    //     The level of the logger.
-    // @RETURN
-    //     The created logger.
+    /** create a logger
+     * @PARAM logger_name
+     *     Name of the logger. This name can be used in later calls to spdlog::get().
+     * @PARAM log_level
+     *     The level of the logger.
+     * @RETURN
+     *     The created logger.
+     */
     static std::shared_ptr<spdlog::logger> createLogger(
-        const std::string &logger_name,
-        spdlog::level::level_enum log_level = spdlog::level::info);
-    // get the default logger
+            const std::string& logger_name,
+            spdlog::level::level_enum log_level = spdlog::level::info);
+    /**
+     * Create a logger using a string instead of a level_enum
+     *
+     * @param logger_name Name of the logger. This name can be used in later calls to spdlog::get().
+     * @param log_level_string String representation of the log level, which will be parsed by
+     * spdlog::level::from_str().
+     * @return The created logger.
+     */
+    static std::shared_ptr<spdlog::logger> createLogger(
+            const std::string& logger_name,
+            const std::string& log_level_string);
+    /**
+     * Thread-safe method that creates a logger only if it is not already present
+     * in spdlog's global registry. This uses a mutex to make a call to spdlog::get()
+     * atomic with a call to createLogger().
+     *
+     * @param logger_name Name of the logger. This name can be used in later calls to spdlog::get().
+     * @param log_level_string String representation of the log level, which will be parsed by
+     * spdlog::level::from_str().
+     * @return The created logger, or a pointer to the existing logger if it exists.
+     */
+    static std::shared_ptr<spdlog::logger> createIfAbsent(
+            const std::string& logger_name,
+            const std::string& log_level_string);
+    /** get the default logger */
     static std::shared_ptr<spdlog::logger>& getDefaultLogger();
+
+    //String constants for the names of sub-module loggers
+    static const std::string PERSISTENT_LOGGER_NAME;
+    static const std::string SST_LOGGER_NAME;
+    static const std::string RPC_LOGGER_NAME;
 };
 
 #ifndef NOLOG

--- a/src/conf/conf.cpp
+++ b/src/conf/conf.cpp
@@ -80,6 +80,7 @@ struct option Conf::long_options[] = {
         MAKE_LONG_OPT_ENTRY(CONF_LOGGER_DEFAULT_LOG_LEVEL),
         MAKE_LONG_OPT_ENTRY(CONF_LOGGER_SST_LOG_LEVEL),
         MAKE_LONG_OPT_ENTRY(CONF_LOGGER_RPC_LOG_LEVEL),
+        MAKE_LONG_OPT_ENTRY(CONF_LOGGER_VIEWMANAGER_LOG_LEVEL),
         MAKE_LONG_OPT_ENTRY(CONF_LOGGER_PERSISTENCE_LOG_LEVEL),
         {0, 0, 0, 0}};
 
@@ -115,6 +116,7 @@ void Conf::initialize(int argc, char* argv[], const char* conf_file) {
         const std::string& default_log_level = Conf::singleton->getString(CONF_LOGGER_DEFAULT_LOG_LEVEL);
         Conf::singleton->config.try_emplace(CONF_LOGGER_SST_LOG_LEVEL, default_log_level);
         Conf::singleton->config.try_emplace(CONF_LOGGER_RPC_LOG_LEVEL, default_log_level);
+        Conf::singleton->config.try_emplace(CONF_LOGGER_VIEWMANAGER_LOG_LEVEL, default_log_level);
         Conf::singleton->config.try_emplace(CONF_LOGGER_PERSISTENCE_LOG_LEVEL, default_log_level);
 
         // 4 - set the flag to initialized

--- a/src/conf/conf.cpp
+++ b/src/conf/conf.cpp
@@ -80,7 +80,7 @@ struct option Conf::long_options[] = {
         MAKE_LONG_OPT_ENTRY(CONF_LOGGER_DEFAULT_LOG_LEVEL),
         MAKE_LONG_OPT_ENTRY(CONF_LOGGER_SST_LOG_LEVEL),
         MAKE_LONG_OPT_ENTRY(CONF_LOGGER_RPC_LOG_LEVEL),
-        MAKE_LONG_OPT_ENTRY(CONF_LOGGER_PERSISTENT_LOG_LEVEL),
+        MAKE_LONG_OPT_ENTRY(CONF_LOGGER_PERSISTENCE_LOG_LEVEL),
         {0, 0, 0, 0}};
 
 void Conf::initialize(int argc, char* argv[], const char* conf_file) {
@@ -115,7 +115,7 @@ void Conf::initialize(int argc, char* argv[], const char* conf_file) {
         const std::string& default_log_level = Conf::singleton->getString(CONF_LOGGER_DEFAULT_LOG_LEVEL);
         Conf::singleton->config.try_emplace(CONF_LOGGER_SST_LOG_LEVEL, default_log_level);
         Conf::singleton->config.try_emplace(CONF_LOGGER_RPC_LOG_LEVEL, default_log_level);
-        Conf::singleton->config.try_emplace(CONF_LOGGER_PERSISTENT_LOG_LEVEL, default_log_level);
+        Conf::singleton->config.try_emplace(CONF_LOGGER_PERSISTENCE_LOG_LEVEL, default_log_level);
 
         // 4 - set the flag to initialized
         Conf::singleton_initialized_flag.store(CONF_INITIALIZED, std::memory_order_acq_rel);

--- a/src/conf/derecho-sample.cfg
+++ b/src/conf/derecho-sample.cfg
@@ -31,7 +31,7 @@ external_port = 32645
 # saves memory.
 max_node_id = 1024
 # When the system is idle, the p2p event loop goes to 'napping' mode, in which it sleeps for a short period of time
-# periodically between checking incoming messages. Before etting into the 'napping' mode, it has to wait for 
+# periodically between checking incoming messages. Before etting into the 'napping' mode, it has to wait for
 # 'p2p_loop_busy_wait_before_sleep_ms' milliseconds. The default value is 250 ms. Pick a value to balance between CPU
 # utilization and application latency.
 p2p_loop_busy_wait_before_sleep_ms = 250
@@ -175,12 +175,18 @@ private_key_file = private_key.pem
 
 # Logger configurations
 [LOGGER]
-# default log name
+# Default log name. This determines the file name of log files.
 default_log_name = derecho_debug
 # default log level
 # Available options:
 # trace, debug, info, warning, error, critical, off
 default_log_level = info
+# RPC module log level. Defaults to default_log_level if not set.
+rpc_log_level = info
+# SST module log level. Defaults to default_log_level if not set.
+sst_log_level = info
+# Persistence module log level. Defaults to default_log_level if not set.
+persistence_log_level = info
 # Whether logs should be printed to the terminal as well as saved to files (default is true)
 log_to_terminal = true
 # The number of older log files to save. Log files are rotated automatically

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -10,6 +10,7 @@ add_library(core OBJECT
     persistence_manager.cpp
     restart_state.cpp
     rpc_manager.cpp
+    rpc_utils.cpp
     subgroup_functions.cpp
     version_code.cpp
     view.cpp

--- a/src/core/git_version.cpp
+++ b/src/core/git_version.cpp
@@ -13,8 +13,8 @@ namespace derecho {
 const int MAJOR_VERSION = 2;
 const int MINOR_VERSION = 3;
 const int PATCH_VERSION = 0;
-const int COMMITS_AHEAD_OF_VERSION = 68;
+const int COMMITS_AHEAD_OF_VERSION = 69;
 const char* VERSION_STRING = "2.3.0";
-const char* VERSION_STRING_PLUS_COMMITS = "2.3.0+68";
+const char* VERSION_STRING_PLUS_COMMITS = "2.3.0+69";
 
 }

--- a/src/core/git_version.cpp
+++ b/src/core/git_version.cpp
@@ -13,8 +13,8 @@ namespace derecho {
 const int MAJOR_VERSION = 2;
 const int MINOR_VERSION = 3;
 const int PATCH_VERSION = 0;
-const int COMMITS_AHEAD_OF_VERSION = 69;
+const int COMMITS_AHEAD_OF_VERSION = 70;
 const char* VERSION_STRING = "2.3.0";
-const char* VERSION_STRING_PLUS_COMMITS = "2.3.0+69";
+const char* VERSION_STRING_PLUS_COMMITS = "2.3.0+70";
 
 }

--- a/src/core/git_version.cpp
+++ b/src/core/git_version.cpp
@@ -13,8 +13,8 @@ namespace derecho {
 const int MAJOR_VERSION = 2;
 const int MINOR_VERSION = 3;
 const int PATCH_VERSION = 0;
-const int COMMITS_AHEAD_OF_VERSION = 72;
+const int COMMITS_AHEAD_OF_VERSION = 73;
 const char* VERSION_STRING = "2.3.0";
-const char* VERSION_STRING_PLUS_COMMITS = "2.3.0+72";
+const char* VERSION_STRING_PLUS_COMMITS = "2.3.0+73";
 
 }

--- a/src/core/git_version.cpp
+++ b/src/core/git_version.cpp
@@ -13,8 +13,8 @@ namespace derecho {
 const int MAJOR_VERSION = 2;
 const int MINOR_VERSION = 3;
 const int PATCH_VERSION = 0;
-const int COMMITS_AHEAD_OF_VERSION = 71;
+const int COMMITS_AHEAD_OF_VERSION = 72;
 const char* VERSION_STRING = "2.3.0";
-const char* VERSION_STRING_PLUS_COMMITS = "2.3.0+71";
+const char* VERSION_STRING_PLUS_COMMITS = "2.3.0+72";
 
 }

--- a/src/core/git_version.cpp
+++ b/src/core/git_version.cpp
@@ -13,8 +13,8 @@ namespace derecho {
 const int MAJOR_VERSION = 2;
 const int MINOR_VERSION = 3;
 const int PATCH_VERSION = 0;
-const int COMMITS_AHEAD_OF_VERSION = 70;
+const int COMMITS_AHEAD_OF_VERSION = 71;
 const char* VERSION_STRING = "2.3.0";
-const char* VERSION_STRING_PLUS_COMMITS = "2.3.0+70";
+const char* VERSION_STRING_PLUS_COMMITS = "2.3.0+71";
 
 }

--- a/src/core/p2p_connection_manager.cpp
+++ b/src/core/p2p_connection_manager.cpp
@@ -17,6 +17,7 @@
 namespace sst {
 P2PConnectionManager::P2PConnectionManager(const P2PParams params)
         : my_node_id(params.my_node_id),
+          rpc_logger(spdlog::get(LoggerFactory::RPC_LOGGER_NAME)),
           p2p_connections(derecho::getConfUInt32(CONF_DERECHO_MAX_NODE_ID)),
           active_p2p_connections(new char[derecho::getConfUInt32(CONF_DERECHO_MAX_NODE_ID)]),
           failure_upcall(params.failure_upcall) {
@@ -122,7 +123,7 @@ std::optional<MessagePointer> P2PConnectionManager::probe_all() {
         } else if(buf_type_pair) {
             // this means that we have a null reply
             // we don't need to process it, but we still want to increment the seq num
-            dbg_default_trace("Got a null reply from node {} for a void P2P call", node_id);
+            dbg_trace(rpc_logger, "Got a null reply from node {} for a void P2P call", node_id);
             p2p_connections[node_id].second->increment_incoming_seq_num(buf_type_pair->second);
             return MessagePointer{INVALID_NODE_ID, nullptr, MESSAGE_TYPE::P2P_REPLY};
         }

--- a/src/core/p2p_connection_manager.cpp
+++ b/src/core/p2p_connection_manager.cpp
@@ -249,7 +249,7 @@ void P2PConnectionManager::check_failures_loop() {
         util::polling_data.reset_waiting(tid);
 
         for(auto nid : failed_node_indexes) {
-            dbg_default_debug("p2p_connection_manager detected failure/timeout on node {}", nid);
+            dbg_debug(rpc_logger, "p2p_connection_manager detected failure/timeout on node {}", nid);
             {
                 std::lock_guard<std::mutex> connection_lock(p2p_connections[nid].first);
                 if(p2p_connections[nid].second) {

--- a/src/core/persistence_manager.cpp
+++ b/src/core/persistence_manager.cpp
@@ -7,6 +7,7 @@
 
 #include "derecho/core/detail/view_manager.hpp"
 #include "derecho/openssl/signature.hpp"
+#include "derecho/persistent/detail/logger.hpp"
 
 #include <map>
 #include <string>
@@ -18,7 +19,8 @@ PersistenceManager::PersistenceManager(
         std::map<subgroup_id_t, ReplicatedObject*>& objects_map,
         bool any_signed_objects,
         const persistence_callback_t& user_persistence_callback)
-        : thread_shutdown(false),
+        : persistence_logger(persistent::PersistLogger::get()),
+          thread_shutdown(false),
           signature_size(0),
           persistence_callbacks{user_persistence_callback},
           objects_by_subgroup_id(objects_map) {
@@ -56,7 +58,7 @@ void PersistenceManager::start() {
     //Start the thread
     this->persist_thread = std::thread{[this]() {
         pthread_setname_np(pthread_self(), "persist");
-        dbg_default_debug("PersistenceManager thread started");
+        dbg_debug(persistence_logger, "PersistenceManager thread started");
         do {
             // wait for semaphore
             sem_wait(&persistence_request_sem);
@@ -93,7 +95,7 @@ void PersistenceManager::start() {
 }
 
 void PersistenceManager::handle_persist_request(subgroup_id_t subgroup_id, persistent::version_t version) {
-    dbg_default_debug("PersistenceManager: handling persist request for subgroup {} version {}", subgroup_id, version);
+    dbg_debug(persistence_logger, "PersistenceManager: handling persist request for subgroup {} version {}", subgroup_id, version);
     //If a previous request already persisted a later version (due to batching), don't do anything
     if(last_persisted_version[subgroup_id] >= version) {
         return;
@@ -122,7 +124,7 @@ void PersistenceManager::handle_persist_request(subgroup_id_t subgroup_id, persi
         }
         // read lock the view
         SharedLockedReference<View> view_and_lock = view_manager->get_current_view();
-        dbg_default_debug("PersistenceManager: updating subgroup {} persisted_num to {}", subgroup_id, persisted_version);
+        dbg_debug(persistence_logger, "PersistenceManager: updating subgroup {} persisted_num to {}", subgroup_id, persisted_version);
         // update the signature and persisted_num in SST
         View& Vc = view_and_lock.get();
         if(object_has_signature) {
@@ -138,13 +140,13 @@ void PersistenceManager::handle_persist_request(subgroup_id_t subgroup_id, persi
                        subgroup_id);
         last_persisted_version[subgroup_id] = persisted_version;
     } catch(uint64_t exp) {
-        dbg_default_debug("exception on persist():subgroup={},ver={},exp={}.", subgroup_id, version, exp);
+        dbg_debug(persistence_logger, "exception on persist():subgroup={},ver={},exp={}.", subgroup_id, version, exp);
         std::cout << "exception on persistent:subgroup=" << subgroup_id << ",ver=" << version << "exception=0x" << std::hex << exp << std::endl;
     }
 }
 
 void PersistenceManager::handle_verify_request(subgroup_id_t subgroup_id, persistent::version_t version) {
-    dbg_default_debug("PersistenceManager: handling verify request for subgroup {} version {}", subgroup_id, version);
+    dbg_debug(persistence_logger, "PersistenceManager: handling verify request for subgroup {} version {}", subgroup_id, version);
     auto search = objects_by_subgroup_id.find(subgroup_id);
     if(search != objects_by_subgroup_id.end()) {
         ReplicatedObject* subgroup_object = search->second;
@@ -180,7 +182,7 @@ void PersistenceManager::handle_verify_request(subgroup_id_t subgroup_id, persis
             if(verification_success) {
                 minimum_verified_version = std::min(minimum_verified_version, other_signed_version);
             } else {
-                dbg_default_warn("Verification of version {} from node {} failed! {}", other_signed_version, Vc.members[shard_member_rank], openssl::get_error_string(ERR_get_error(), "OpenSSL error"));
+                dbg_warn(persistence_logger, "Verification of version {} from node {} failed! {}", other_signed_version, Vc.members[shard_member_rank], openssl::get_error_string(ERR_get_error(), "OpenSSL error"));
             }
         }
         //Update verified_num to the lowest version number that successfully verified across all shard members
@@ -229,7 +231,7 @@ void PersistenceManager::make_version(const subgroup_id_t& subgroup_id,
 void PersistenceManager::shutdown(bool wait) {
     // if(replicated_objects == nullptr) return;  //skip for raw subgroups - NO DON'T
 
-    dbg_default_debug("PersistenceManager thread shutting down");
+    dbg_debug(persistence_logger, "PersistenceManager thread shutting down");
     thread_shutdown = true;
     sem_post(&persistence_request_sem);  // kick the persistence thread in case it is sleeping
 

--- a/src/core/rpc_manager.cpp
+++ b/src/core/rpc_manager.cpp
@@ -34,7 +34,7 @@ void RPCManager::report_failure(const node_id_t who) {
     //Simultaneously test if the ID is in external_client_ids and, if so, erase it
     if(external_client_ids.erase(who) != 0) {
         // external client
-        dbg_default_debug("External client with id {} failed, doing cleanup", who);
+        dbg_debug(rpc_logger, "External client with id {} failed, doing cleanup", who);
         connections->remove_connections({who});
         sst::remove_node(who);
     } else {
@@ -99,8 +99,8 @@ std::exception_ptr RPCManager::receive_message(
     assert(payload_size);
     auto receiver_function_entry = receivers->find(indx);
     if(receiver_function_entry == receivers->end()) {
-        dbg_default_error("Received an RPC message with an invalid RPC opcode! Opcode was ({}, {}, {}, {}).",
-                          indx.class_id, indx.subgroup_id, indx.function_id, indx.is_reply);
+        dbg_error(rpc_logger, "Received an RPC message with an invalid RPC opcode! Opcode was ({}, {}, {}, {}).",
+                  indx.class_id, indx.subgroup_id, indx.function_id, indx.is_reply);
         //TODO: We should reply with some kind of "no such method" error in this case
         return std::exception_ptr{};
     }
@@ -166,7 +166,7 @@ void RPCManager::rpc_message_handler(subgroup_id_t subgroup_id, node_id_t sender
         const uint32_t my_shard = view_manager.unsafe_get_current_view().my_subgroups.at(subgroup_id);
         {
             whenlog(int32_t msg_seq_num = persistent::unpack_version<int32_t>(version).second);
-            dbg_default_trace("RPCManager got a self-receive for message {}", msg_seq_num);
+            dbg_trace(rpc_logger, "RPCManager got a self-receive for message {}", msg_seq_num);
             std::unique_lock<std::mutex> lock(pending_results_mutex);
             // because of a race condition, pending_results_to_fulfill can genuinely be empty
             // so before accessing it we should sleep on a condition variable and let the main
@@ -188,7 +188,7 @@ void RPCManager::rpc_message_handler(subgroup_id_t subgroup_id, node_id_t sender
                     completed_pending_results[subgroup_id].emplace_back(pending_results_to_fulfill[subgroup_id].front());
                 }
             } else {
-                dbg_default_debug("Did not fulfill the PendingResults for message {} because it was already gone", msg_seq_num);
+                dbg_debug(rpc_logger, "Did not fulfill the PendingResults for message {} because it was already gone", msg_seq_num);
             }
             //Regardless of whether the weak_ptr was valid, delete the entry because we're done with it
             pending_results_to_fulfill[subgroup_id].pop();
@@ -220,8 +220,8 @@ void RPCManager::p2p_message_handler(node_id_t sender_id, uint8_t* msg_buf) {
     node_id_t received_from;
     uint32_t flags;
     retrieve_header(nullptr, msg_buf, payload_size, indx, received_from, flags);
-    dbg_default_trace("Handling a P2P message: function_id = {}, is_reply = {}, received_from = {}, payload_size = {}, invocation_id = {}",
-                      indx.function_id, indx.is_reply, received_from, payload_size, ((long*)(msg_buf + header_size))[0]);
+    dbg_trace(rpc_logger, "Handling a P2P message: function_id = {}, is_reply = {}, received_from = {}, payload_size = {}, invocation_id = {}",
+              indx.function_id, indx.is_reply, received_from, payload_size, ((long*)(msg_buf + header_size))[0]);
     if(indx.is_reply) {
         // REPLYs can be handled here because they do not block.
         receive_message(indx, received_from, msg_buf + header_size, payload_size,
@@ -245,7 +245,7 @@ void RPCManager::p2p_message_handler(node_id_t sender_id, uint8_t* msg_buf) {
 void RPCManager::new_view_callback(const View& new_view) {
     connections->remove_connections(new_view.departed);
     connections->add_connections(new_view.members);
-    dbg_default_debug("Created new connections among the new view members");
+    dbg_debug(rpc_logger, "Created new connections among the new view members");
     std::lock_guard<std::mutex> lock(pending_results_mutex);
     for(auto& fulfilled_pending_results_pair : results_awaiting_local_persistence) {
         const subgroup_id_t subgroup_id = fulfilled_pending_results_pair.first;
@@ -262,7 +262,7 @@ void RPCManager::new_view_callback(const View& new_view) {
                         for(auto removed_id : new_view.subgroup_shard_views[subgroup_id][shard_num].departed) {
                             //This will do nothing if removed_id was never in the
                             //shard this PendingResult corresponds to
-                            dbg_default_debug("Setting exception for removed node {} on PendingResults for subgroup {}, shard {}", removed_id, subgroup_id, shard_num);
+                            dbg_debug(rpc_logger, "Setting exception for removed node {} on PendingResults for subgroup {}, shard {}", removed_id, subgroup_id, shard_num);
                             live_pending_results->set_exception_for_removed_node(removed_id);
                         }
                     }
@@ -271,7 +271,7 @@ void RPCManager::new_view_callback(const View& new_view) {
                     //If so, we need to delete RemoteInvoker's heap-allocated shared_ptr here,
                     //since RemoteInvoker won't get any more replies and won't get a chance to delete it
                     if(live_pending_results->all_responded()) {
-                        dbg_default_trace("In new_view_callback, calling delete_self_ptr on PendingResults for version {}", pending_results_iter->first);
+                        dbg_trace(rpc_logger, "In new_view_callback, calling delete_self_ptr on PendingResults for version {}", pending_results_iter->first);
                         live_pending_results->delete_self_ptr();
                     }
                 }
@@ -294,12 +294,12 @@ void RPCManager::new_view_callback(const View& new_view) {
                         shard_num < new_view.subgroup_shard_views[subgroup_id].size();
                         ++shard_num) {
                         for(auto removed_id : new_view.subgroup_shard_views[subgroup_id][shard_num].departed) {
-                            dbg_default_debug("Setting exception for removed node {} on PendingResults for subgroup {}, shard {}", removed_id, subgroup_id, shard_num);
+                            dbg_debug(rpc_logger, "Setting exception for removed node {} on PendingResults for subgroup {}, shard {}", removed_id, subgroup_id, shard_num);
                             live_pending_results->set_exception_for_removed_node(removed_id);
                         }
                     }
                     if(live_pending_results->all_responded()) {
-                        dbg_default_trace("In new_view_callback, calling delete_self_ptr on PendingResults for version {}", pending_results_iter->first);
+                        dbg_trace(rpc_logger, "In new_view_callback, calling delete_self_ptr on PendingResults for version {}", pending_results_iter->first);
                         live_pending_results->delete_self_ptr();
                     }
                 }
@@ -326,12 +326,12 @@ void RPCManager::new_view_callback(const View& new_view) {
                     for(auto removed_id : new_view.subgroup_shard_views[subgroup_id][shard_num].departed) {
                         //This will do nothing if removed_id was never in the
                         //shard this PendingResult corresponds to
-                        dbg_default_debug("Setting exception for removed node {} on PendingResults for subgroup {}, shard {}", removed_id, subgroup_id, shard_num);
+                        dbg_debug(rpc_logger, "Setting exception for removed node {} on PendingResults for subgroup {}, shard {}", removed_id, subgroup_id, shard_num);
                         live_pending_results->set_exception_for_removed_node(removed_id);
                     }
                 }
                 if(live_pending_results->all_responded()) {
-                    dbg_default_trace("In new_view_callback, calling delete_self_ptr on a completed PendingResults for subgroup {}", subgroup_id);
+                    dbg_trace(rpc_logger, "In new_view_callback, calling delete_self_ptr on a completed PendingResults for subgroup {}", subgroup_id);
                     live_pending_results->delete_self_ptr();
                 }
                 pending_results_iter++;
@@ -344,13 +344,13 @@ void RPCManager::new_view_callback(const View& new_view) {
 }
 
 void RPCManager::notify_persistence_finished(subgroup_id_t subgroup_id, persistent::version_t version) {
-    dbg_default_trace("RPCManager: Got a local persistence callback for version {}", version);
+    dbg_trace(rpc_logger, "RPCManager: Got a local persistence callback for version {}", version);
     std::lock_guard<std::mutex> lock(pending_results_mutex);
     //PendingResults in each per-subgroup map are ordered by version number, so all entries before
     //the argument version number have been persisted and need to be notified
     for(auto pending_results_iter = results_awaiting_local_persistence[subgroup_id].begin();
         pending_results_iter != results_awaiting_local_persistence[subgroup_id].upper_bound(version);) {
-        dbg_default_trace("RPCManager: Setting local persistence on version {}", pending_results_iter->first);
+        dbg_trace(rpc_logger, "RPCManager: Setting local persistence on version {}", pending_results_iter->first);
         std::shared_ptr<AbstractPendingResults> live_pending_results = pending_results_iter->second.lock();
         if(live_pending_results) {
             live_pending_results->set_local_persistence();
@@ -362,13 +362,13 @@ void RPCManager::notify_persistence_finished(subgroup_id_t subgroup_id, persiste
 }
 
 void RPCManager::notify_global_persistence_finished(subgroup_id_t subgroup_id, persistent::version_t version) {
-    dbg_default_trace("RPCManager: Got a global persistence callback for version {}", version);
+    dbg_trace(rpc_logger, "RPCManager: Got a global persistence callback for version {}", version);
     std::lock_guard<std::mutex> lock(pending_results_mutex);
     //PendingResults in each per-subgroup map are ordered by version number, so all entries before
     //the argument version number have been persisted and need to be notified
     for(auto pending_results_iter = results_awaiting_global_persistence[subgroup_id].begin();
         pending_results_iter != results_awaiting_global_persistence[subgroup_id].upper_bound(version);) {
-        dbg_default_trace("RPCManager: Setting global persistence on version {}", pending_results_iter->first);
+        dbg_trace(rpc_logger, "RPCManager: Setting global persistence on version {}", pending_results_iter->first);
         std::shared_ptr<AbstractPendingResults> live_pending_results = pending_results_iter->second.lock();
         if(live_pending_results) {
             live_pending_results->set_global_persistence();
@@ -384,11 +384,11 @@ void RPCManager::notify_global_persistence_finished(subgroup_id_t subgroup_id, p
 }
 
 void RPCManager::notify_verification_finished(subgroup_id_t subgroup_id, persistent::version_t version) {
-    dbg_default_trace("RPCManager: Got a global verification callback for version {}", version);
+    dbg_trace(rpc_logger, "RPCManager: Got a global verification callback for version {}", version);
     std::lock_guard<std::mutex> lock(pending_results_mutex);
     for(auto pending_results_iter = results_awaiting_signature[subgroup_id].begin();
         pending_results_iter != results_awaiting_signature[subgroup_id].upper_bound(version);) {
-        dbg_default_trace("RPCManager: Setting signature verification on version {}", pending_results_iter->first);
+        dbg_trace(rpc_logger, "RPCManager: Setting signature verification on version {}", pending_results_iter->first);
         std::shared_ptr<AbstractPendingResults> live_pending_results = pending_results_iter->second.lock();
         if(live_pending_results) {
             live_pending_results->set_signature_verified();
@@ -475,8 +475,8 @@ void RPCManager::p2p_request_worker() {
         }
         retrieve_header(nullptr, request.msg_buf, payload_size, indx, received_from, flags);
         if(indx.is_reply || RPC_HEADER_FLAG_TST(flags, CASCADE)) {
-            dbg_default_error("Invalid rpc message in fifo queue: is_reply={}, is_cascading={}",
-                              indx.is_reply, RPC_HEADER_FLAG_TST(flags, CASCADE));
+            dbg_error(rpc_logger, "Invalid rpc message in fifo queue: is_reply={}, is_cascading={}",
+                      indx.is_reply, RPC_HEADER_FLAG_TST(flags, CASCADE));
             throw derecho::derecho_exception("invalid rpc message in fifo queue...crash.");
         }
         reply_size = 0;
@@ -497,14 +497,14 @@ void RPCManager::p2p_request_worker() {
                             }
                         });
         if(reply_size > 0) {
-            dbg_default_trace("Sending a P2P reply to node {} for invocation ID {} of function {}",
-                              request.sender_id, ((long*)(request.msg_buf + header_size))[0], indx.function_id);
+            dbg_trace(rpc_logger, "Sending a P2P reply to node {} for invocation ID {} of function {}",
+                      request.sender_id, ((long*)(request.msg_buf + header_size))[0], indx.function_id);
             connections->send(request.sender_id, sst::MESSAGE_TYPE::P2P_REPLY, reply_seq_num);
         } else {
             // hack for now to "simulate" a reply for p2p_sends to functions that do not generate a reply
             auto buffer_handle = connections->get_sendbuffer_ptr(request.sender_id, sst::MESSAGE_TYPE::P2P_REPLY);
             if(buffer_handle) {
-                dbg_default_trace("Sending a null reply to node {} for a void P2P call", request.sender_id);
+                dbg_trace(rpc_logger, "Sending a null reply to node {} for a void P2P call", request.sender_id);
                 reinterpret_cast<size_t*>(buffer_handle->buf_ptr)[0] = 0;
                 connections->send(request.sender_id, sst::MESSAGE_TYPE::P2P_REPLY, buffer_handle->seq_num);
             }
@@ -522,7 +522,7 @@ void RPCManager::p2p_receive_loop() {
         std::unique_lock<std::mutex> lock(thread_start_mutex);
         thread_start_cv.wait(lock, [this]() { return thread_start; });
     }
-    dbg_default_debug("P2P listening thread started");
+    dbg_debug(rpc_logger, "P2P listening thread started");
     // start the fifo worker thread
     request_worker_thread = std::thread(&RPCManager::p2p_request_worker, this);
 
@@ -543,7 +543,7 @@ void RPCManager::p2p_receive_loop() {
                 auto message_handle = optional_message.value();
                 // Invalid ID means the message was empty (a null reply)
                 if(message_handle.sender_id != INVALID_NODE_ID) {
-                    dbg_default_trace("P2P thread detected a message from {}", message_handle.sender_id);
+                    dbg_trace(rpc_logger, "P2P thread detected a message from {}", message_handle.sender_id);
                     p2p_message_handler(message_handle.sender_id, message_handle.buf);
                     connections->increment_incoming_seq_num(message_handle.sender_id, message_handle.type);
                 }
@@ -573,11 +573,11 @@ node_id_t RPCManager::get_rpc_caller_id() {
 }
 
 void RPCManager::oob_remote_write(const node_id_t& remote_node, const struct iovec* iov, int iovcnt, uint64_t remote_dest_addr, uint64_t rkey, size_t size) {
-    connections->oob_remote_write(remote_node,iov,iovcnt,remote_dest_addr,rkey,size);
+    connections->oob_remote_write(remote_node, iov, iovcnt, remote_dest_addr, rkey, size);
 }
 
 void RPCManager::oob_remote_read(const node_id_t& remote_node, const struct iovec* iov, int iovcnt, uint64_t remote_src_addr, uint64_t rkey, size_t size) {
-    connections->oob_remote_read(remote_node,iov,iovcnt,remote_src_addr,rkey,size);
+    connections->oob_remote_read(remote_node, iov, iovcnt, remote_src_addr, rkey, size);
 }
 bool in_rpc_handler() {
     return _in_rpc_handler;

--- a/src/core/rpc_utils.cpp
+++ b/src/core/rpc_utils.cpp
@@ -8,7 +8,6 @@ std::shared_ptr<spdlog::logger> RpcLoggerPtr::logger;
 
 void RpcLoggerPtr::initialize() {
     logger = spdlog::get(LoggerFactory::RPC_LOGGER_NAME);
-    std::cout << "In RpcLoggerPtr::initialize(), logger = " << std::hex << logger.get() << std::endl;
     // This function must be called after RPC_LOGGER_NAME is already in the registry
     assert(logger);
 }

--- a/src/core/rpc_utils.cpp
+++ b/src/core/rpc_utils.cpp
@@ -1,0 +1,20 @@
+#include "derecho/core/detail/rpc_utils.hpp"
+#include "derecho/utils/logger.hpp"
+
+namespace derecho {
+namespace rpc {
+
+std::shared_ptr<spdlog::logger> RpcLoggerPtr::logger;
+
+void RpcLoggerPtr::initialize() {
+    logger = spdlog::get(LoggerFactory::RPC_LOGGER_NAME);
+    // This function must be called after RPC_LOGGER_NAME is already in the registry
+    assert(logger);
+}
+
+std::shared_ptr<spdlog::logger>& RpcLoggerPtr::get() {
+    return logger;
+}
+
+}  //namespace rpc
+}  //namespace derecho

--- a/src/core/rpc_utils.cpp
+++ b/src/core/rpc_utils.cpp
@@ -8,6 +8,7 @@ std::shared_ptr<spdlog::logger> RpcLoggerPtr::logger;
 
 void RpcLoggerPtr::initialize() {
     logger = spdlog::get(LoggerFactory::RPC_LOGGER_NAME);
+    std::cout << "In RpcLoggerPtr::initialize(), logger = " << std::hex << logger.get() << std::endl;
     // This function must be called after RPC_LOGGER_NAME is already in the registry
     assert(logger);
 }

--- a/src/persistent/CMakeLists.txt
+++ b/src/persistent/CMakeLists.txt
@@ -4,7 +4,7 @@ set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE}")
 set(CMAKE_CXX_FLAGS_DEBUG   "${CMAKE_CXX_FLAGS_DEBUG}  -O0 -ggdb -gdwarf-3")
 set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} -ggdb -gdwarf-3 -D_PERFORMANCE_DEBUG")
 
-add_library(persistent OBJECT Persistent.cpp PersistLog.cpp FilePersistLog.cpp HLC.cpp)
+add_library(persistent OBJECT Persistent.cpp PersistLog.cpp FilePersistLog.cpp HLC.cpp logger.cpp)
 target_include_directories(persistent PRIVATE
     $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>
 )

--- a/src/persistent/PersistLog.cpp
+++ b/src/persistent/PersistLog.cpp
@@ -2,7 +2,7 @@
 
 #include "derecho/openssl/signature.hpp"
 #include "derecho/persistent/detail/util.hpp"
-#include "derecho/utils/logger.hpp"
+#include "derecho/persistent/detail/logger.hpp"
 
 namespace persistent {
 
@@ -18,9 +18,9 @@ PersistLog::~PersistLog() noexcept(true) {
 
 #ifndef NDEBUG
 void PersistLog::dump_hidx() {
-    dbg_default_trace("number of entry in hidx:{}.log_len={}.", hidx.size(), getLength());
+    dbg_trace(PersistLogger::get(), "number of entry in hidx:{}.log_len={}.", hidx.size(), getLength());
     for(auto itr = hidx.cbegin(); itr != hidx.cend(); itr++) {
-        dbg_default_trace("hlc({0},{1})->idx({2})", itr->hlc.m_rtc_us, itr->hlc.m_logic, itr->log_idx);
+        dbg_trace(PersistLogger::get(), "hlc({0},{1})->idx({2})", itr->hlc.m_rtc_us, itr->hlc.m_logic, itr->log_idx);
     }
 }
 #endif  //DERECHO_DEBUG

--- a/src/persistent/Persistent.cpp
+++ b/src/persistent/Persistent.cpp
@@ -1,5 +1,6 @@
 #include "derecho/persistent/Persistent.hpp"
 
+#include "derecho/persistent/detail/logger.hpp"
 #include "derecho/openssl/hash.hpp"
 #include "derecho/openssl/signature.hpp"
 
@@ -16,6 +17,7 @@ PersistentRegistry::PersistentRegistry(
         const std::type_index& subgroup_type,
         uint32_t subgroup_index,
         uint32_t shard_num) : m_subgroupPrefix(generate_prefix(subgroup_type, subgroup_index, shard_num)),
+                              m_logger(PersistLogger::get()),
                               m_temporalQueryFrontierProvider(tqfp),
                               m_lastSignedVersion(INVALID_VERSION) {
 }
@@ -72,9 +74,9 @@ void PersistentRegistry::initializeLastSignature(version_t version,
 
 void PersistentRegistry::sign(version_t latest_version, openssl::Signer& signer, uint8_t* signature_buffer) {
     version_t cur_nonempty_version = getMinimumVersionAfter(m_lastSignedVersion);
-    dbg_default_debug("PersistentRegistry: sign() called with lastSignedVersion = {}, latest_version = {}. First version to sign = {}", m_lastSignedVersion, latest_version, cur_nonempty_version);
+    dbg_debug(m_logger, "PersistentRegistry: sign() called with lastSignedVersion = {}, latest_version = {}. First version to sign = {}", m_lastSignedVersion, latest_version, cur_nonempty_version);
     while(cur_nonempty_version != INVALID_VERSION && cur_nonempty_version <= latest_version) {
-        dbg_default_trace("PersistentRegistry: Attempting to sign version {} out of {}", cur_nonempty_version, latest_version);
+        dbg_trace(m_logger, "PersistentRegistry: Attempting to sign version {} out of {}", cur_nonempty_version, latest_version);
         signer.init();
         std::size_t bytes_signed = 0;
         for(auto& field : m_registry) {
@@ -82,7 +84,7 @@ void PersistentRegistry::sign(version_t latest_version, openssl::Signer& signer,
         }
         if(bytes_signed == 0) {
             // That version did not exist in any field, so there was nothing to sign. This should not happen with getMinimumVersionAfter().
-            dbg_default_warn("Logic error in PersistentRegistry: Version {} was returned by getMinimumVersionAfter(), but it did not exist in any field", cur_nonempty_version);
+            dbg_warn(m_logger, "Logic error in PersistentRegistry: Version {} was returned by getMinimumVersionAfter(), but it did not exist in any field", cur_nonempty_version);
             cur_nonempty_version = getMinimumVersionAfter(cur_nonempty_version);
             continue;
         }
@@ -90,7 +92,7 @@ void PersistentRegistry::sign(version_t latest_version, openssl::Signer& signer,
         signer.finalize(signature_buffer);
         // After computing a signature over all fields of the object, go back and
         // tell each field to add that signature to its log.
-        dbg_default_debug("PersistentRegistry: Adding signature to log in version {}, setting its previous signed version to {}", cur_nonempty_version, m_lastSignedVersion);
+        dbg_debug(m_logger, "PersistentRegistry: Adding signature to log in version {}, setting its previous signed version to {}", cur_nonempty_version, m_lastSignedVersion);
         for(auto& field : m_registry) {
             field.second->addSignature(cur_nonempty_version, signature_buffer, m_lastSignedVersion);
         }
@@ -116,7 +118,7 @@ bool PersistentRegistry::verify(version_t version, openssl::Verifier& verifier, 
     if(m_registry.empty()) {
         return true;
     }
-    dbg_default_debug("PersistentRegistry: Verifying signature on version {}", version);
+    dbg_debug(m_logger, "PersistentRegistry: Verifying signature on version {}", version);
     verifier.init();
     for(auto& field : m_registry) {
         field.second->updateVerifier(version, verifier);
@@ -148,7 +150,7 @@ version_t PersistentRegistry::persist(version_t latest_version) {
     version_t min = INVALID_VERSION;
     for(auto& entry : m_registry) {
         version_t ver = entry.second->persist(latest_version);
-        if (min == INVALID_VERSION || 
+        if (min == INVALID_VERSION ||
             min > ver) {
             min = ver;
         }
@@ -230,7 +232,7 @@ std::string PersistentRegistry::generate_prefix(
     try {
         sha256.hash_bytes(subgroup_type_name, strlen(subgroup_type_name), subgroup_type_name_digest);
     } catch(openssl::openssl_error& ex) {
-        dbg_default_error("{}:{} Unable to compute SHA256 of subgroup type name. OpenSSL error: {}", __FILE__, __func__, ex.what());
+        dbg_error(PersistLogger::get(), "{}:{} Unable to compute SHA256 of subgroup type name. OpenSSL error: {}", __FILE__, __func__, ex.what());
         throw PERSIST_EXP_SHA256_HASH(errno);
     }
 

--- a/src/persistent/logger.cpp
+++ b/src/persistent/logger.cpp
@@ -1,0 +1,33 @@
+#include "derecho/persistent/detail/logger.hpp"
+#include "derecho/conf/conf.hpp"
+
+#include <atomic>
+#include <cstdint>
+#include <memory>
+
+namespace persistent {
+
+constexpr uint32_t logger_uninitialized = 0;
+constexpr uint32_t logger_initializing = 1;
+constexpr uint32_t logger_initialized = 2;
+
+std::atomic<uint32_t> PersistLogger::initialize_state = logger_uninitialized;
+std::shared_ptr<spdlog::logger> PersistLogger::logger;
+
+void PersistLogger::initialize() {
+    uint32_t expected = logger_uninitialized;
+    if(initialize_state.compare_exchange_strong(expected, logger_initializing, std::memory_order_acq_rel)) {
+        logger = LoggerFactory::createLogger(LoggerFactory::PERSISTENT_LOGGER_NAME,
+                                             derecho::getConfString(CONF_LOGGER_PERSISTENCE_LOG_LEVEL));
+        initialize_state.store(logger_initialized, std::memory_order_acq_rel);
+    }
+    while(initialize_state.load(std::memory_order_acquire) != logger_initialized) {
+    }
+}
+
+std::shared_ptr<spdlog::logger>& PersistLogger::get() {
+    initialize();
+    return logger;
+}
+
+}  //namespace persistent

--- a/src/rdmc/CMakeLists.txt
+++ b/src/rdmc/CMakeLists.txt
@@ -6,6 +6,7 @@ endif()
 target_include_directories(rdmc PRIVATE
     $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>
 )
+target_link_libraries(rdmc spdlog::spdlog)
 
 #find_library(SLURM_FOUND slurm)
 #if (SLURM_FOUND)

--- a/src/sst/CMakeLists.txt
+++ b/src/sst/CMakeLists.txt
@@ -6,3 +6,4 @@ endif()
 target_include_directories(sst PRIVATE
     $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>
 )
+target_link_libraries(sst spdlog::spdlog)

--- a/src/sst/lf.cpp
+++ b/src/sst/lf.cpp
@@ -88,6 +88,8 @@ public:
     // configuration resources
     struct fi_eq_attr eq_attr;  // event queue attributes
     struct fi_cq_attr cq_attr;  // completion queue attributes
+    // logger pointer
+    std::shared_ptr<spdlog::logger> sst_logger;
     virtual ~lf_ctxt() {
         lf_destroy();
     }
@@ -130,14 +132,16 @@ static void default_context() {
     g_ctxt.cq_attr.wait_obj = FI_WAIT_UNSPEC;
 
     g_ctxt.pep_addr_len = max_lf_addr_size;
+
+    g_ctxt.sst_logger = spdlog::get(LoggerFactory::PERSISTENT_LOGGER_NAME);
 }
 
 /** load RDMA device configurations from file */
 static void load_configuration() {
     if(!g_ctxt.hints) {
-        dbg_default_error("lf.cpp: load_configuration error: hints is not initialized.");
+        dbg_error(g_ctxt.sst_logger, "lf.cpp: load_configuration error: hints is not initialized.");
         std::cerr << "lf.cpp: load_configuration error: hints is not initialized." << std::endl;
-        dbg_default_flush();
+        dbg_flush(g_ctxt.sst_logger) ;
         exit(-1);
     }
 
@@ -188,12 +192,12 @@ int _resources::init_endpoint(struct fi_info* fi) {
                                           fi_endpoint, g_ctxt.domain, fi, &(this->ep), nullptr);
 
     if(ret) return ret;
-    dbg_default_debug("{}:{} init_endpoint:ep->fid={}", __FILE__, __func__, (void*)&this->ep->fid);
+    dbg_debug(sst_logger, "{}:{} init_endpoint:ep->fid={}", __FILE__, __func__, (void*)&this->ep->fid);
 
     // 2.5 - open an event queue.
     fail_if_nonzero_retry_on_eagain("open the event queue for rdma transmission.", CRASH_ON_FAILURE,
                                     fi_eq_open, g_ctxt.fabric, &g_ctxt.eq_attr, &this->eq, nullptr);
-    dbg_default_debug("{}:{} event_queue opened={}", __FILE__, __func__, (void*)&this->eq->fid);
+    dbg_debug(sst_logger, "{}:{} event_queue opened={}", __FILE__, __func__, (void*)&this->eq->fid);
 
     // 3 - bind them and global event queue together
     ret = fail_if_nonzero_retry_on_eagain("bind endpoint and event queue", REPORT_ON_FAILURE,
@@ -208,11 +212,11 @@ int _resources::init_endpoint(struct fi_info* fi) {
 }
 
 void _resources::connect_endpoint(bool is_lf_server) {
-    dbg_default_trace("preparing connection to remote node(id={})...\n", this->remote_id);
+    dbg_trace(sst_logger, "preparing connection to remote node(id={})...\n", this->remote_id);
     struct cm_con_data_t local_cm_data, remote_cm_data;
 
     // STEP 1 exchange CM info
-    dbg_default_trace("Exchanging connection management info.");
+    dbg_trace(sst_logger, "Exchanging connection management info.");
     local_cm_data.pep_addr_len = (uint32_t)htonl((uint32_t)g_ctxt.pep_addr_len);
     memcpy((void*)&local_cm_data.pep_addr, &g_ctxt.pep_addr, g_ctxt.pep_addr_len);
     local_cm_data.mr_key = (uint64_t)htonll(this->mr_lwkey);
@@ -224,32 +228,32 @@ void _resources::connect_endpoint(bool is_lf_server) {
         } else if(external_client_connections->contains_node(this->remote_id)) {
             external_client_connections->exchange(this->remote_id, local_cm_data, remote_cm_data);
         } else {
-            dbg_default_error("No TCP connection exists with node {}, cannot exchange connection info", this->remote_id);
+            dbg_error(sst_logger, "No TCP connection exists with node {}, cannot exchange connection info", this->remote_id);
             crash_with_message("No TCP connection exists with node %d, cannot exchange connection info\n", this->remote_id);
         }
     } catch(tcp::socket_error&) {
-        dbg_default_error("Failed to exchange connection management info with node {}", this->remote_id);
+        dbg_error(sst_logger, "Failed to exchange connection management info with node {}", this->remote_id);
         crash_with_message("Failed to exchange connection management info with node %d\n", this->remote_id);
     }
 
     remote_cm_data.pep_addr_len = (uint32_t)ntohl(remote_cm_data.pep_addr_len);
     this->mr_rwkey = (uint64_t)ntohll(remote_cm_data.mr_key);
     this->remote_fi_addr = (fi_addr_t)ntohll(remote_cm_data.vaddr);
-    dbg_default_trace("Exchanging connection management info succeeds.");
+    dbg_trace(sst_logger, "Exchanging connection management info succeeds.");
 
     // STEP 2 connect to remote
-    dbg_default_trace("connect to remote node.");
+    dbg_trace(sst_logger, "connect to remote node.");
     ssize_t nRead;
     struct fi_eq_cm_entry entry;
     uint32_t event;
 
     if(is_lf_server) {
-        dbg_default_trace("connecting as a server.");
-        dbg_default_trace("waiting for connection.");
+        dbg_trace(sst_logger, "connecting as a server.");
+        dbg_trace(sst_logger, "waiting for connection.");
 
         nRead = fi_eq_sread(g_ctxt.peq, &event, &entry, sizeof(entry), -1, 0);
         if(nRead != sizeof(entry)) {
-            dbg_default_error("failed to get connection from remote.");
+            dbg_error(sst_logger, "failed to get connection from remote.");
             crash_with_message("failed to get connection from remote. nRead=%ld\n", nRead);
         }
         if(init_endpoint(entry.info)) {
@@ -264,10 +268,10 @@ void _resources::connect_endpoint(bool is_lf_server) {
         }
         nRead = fi_eq_sread(this->eq, &event, &entry, sizeof(entry), -1, 0);
         if(nRead != sizeof(entry)) {
-            dbg_default_error("server failed to connect remote.");
+            dbg_error(sst_logger, "server failed to connect remote.");
             crash_with_message("server failed to connect remote. nRead=%ld.\n", nRead);
         }
-        dbg_default_debug("{}:{} entry.fid={},this->ep->fid={}", __FILE__, __func__, (void*)entry.fid, (void*)&(this->ep->fid));
+        dbg_debug(sst_logger, "{}:{} entry.fid={},this->ep->fid={}", __FILE__, __func__, (void*)entry.fid, (void*)&(this->ep->fid));
         if(event != FI_CONNECTED || entry.fid != &(this->ep->fid)) {
             fi_freeinfo(entry.info);
             crash_with_message("SST: Unexpected CM event: %d.\n", event);
@@ -276,8 +280,8 @@ void _resources::connect_endpoint(bool is_lf_server) {
         fi_freeinfo(entry.info);
     } else {
         // libfabric connection client
-        dbg_default_trace("connecting as a client.\n");
-        dbg_default_trace("initiating a connection.\n");
+        dbg_trace(sst_logger, "connecting as a client.\n");
+        dbg_trace(sst_logger, "initiating a connection.\n");
 
         struct fi_info* client_hints = fi_dupinfo(g_ctxt.hints);
         struct fi_info* client_info = NULL;
@@ -299,14 +303,14 @@ void _resources::connect_endpoint(bool is_lf_server) {
 
         nRead = fi_eq_sread(this->eq, &event, &entry, sizeof(entry), -1, 0);
         if(nRead != sizeof(entry)) {
-            dbg_default_error("failed to connect remote.");
+            dbg_error(sst_logger, "failed to connect remote.");
             crash_with_message("failed to connect remote. nRead=%ld.\n", nRead);
         }
-        dbg_default_debug("{}:{} entry.fid={},this->ep->fid={}", __FILE__, __func__, (void*)entry.fid, (void*)&(this->ep->fid));
+        dbg_debug(sst_logger, "{}:{} entry.fid={},this->ep->fid={}", __FILE__, __func__, (void*)entry.fid, (void*)&(this->ep->fid));
         if(event != FI_CONNECTED || entry.fid != &(this->ep->fid)) {
             fi_freeinfo(client_hints);
             fi_freeinfo(client_info);
-            dbg_default_flush();
+            dbg_flush(sst_logger) ;
             crash_with_message("SST: Unexpected CM event: %d.\n", event);
         }
 
@@ -326,18 +330,19 @@ _resources::_resources(
         int size_w,
         int size_r,
         int is_lf_server)
-        : remote_failed(false),
+        : sst_logger(spdlog::get(LoggerFactory::SST_LOGGER_NAME)),
+          remote_failed(false),
           remote_id(r_id),
           write_buf(write_addr),
           read_buf(read_addr) {
-    dbg_default_trace("resources constructor: this={}", (void*)this);
+    dbg_trace(sst_logger, "resources constructor: this={}", (void*)this);
 
     if(!write_addr) {
-        dbg_default_warn("{}:{} called with NULL write_addr!", __FILE__, __func__);
+        dbg_warn(sst_logger, "{}:{} called with NULL write_addr!", __FILE__, __func__);
     }
 
     if(!read_addr) {
-        dbg_default_warn("{}:{} called with NULL read_addr!", __FILE__, __func__);
+        dbg_warn(sst_logger, "{}:{} called with NULL read_addr!", __FILE__, __func__);
     }
 
 #define LF_RMR_KEY(rid) (((uint64_t)0xf0000000) << 32 | (uint64_t)(rid))
@@ -347,20 +352,20 @@ _resources::_resources(
                                     fi_mr_reg, g_ctxt.domain, write_buf, size_w,
                                     FI_SEND | FI_RECV | FI_READ | FI_WRITE | FI_REMOTE_READ | FI_REMOTE_WRITE,
                                     0, 0, 0, &this->write_mr, nullptr);
-    dbg_default_trace("{}:{} registered memory for remote write: {}:{}", __FILE__, __func__, (void*)write_addr, size_w);
+    dbg_trace(sst_logger, "{}:{} registered memory for remote write: {}:{}", __FILE__, __func__, (void*)write_addr, size_w);
     // register the read buffer
     fail_if_nonzero_retry_on_eagain("register memory buffer for read", CRASH_ON_FAILURE,
                                     fi_mr_reg, g_ctxt.domain, read_buf, size_r,
                                     FI_SEND | FI_RECV | FI_READ | FI_WRITE | FI_REMOTE_READ | FI_REMOTE_WRITE,
                                     0, 0, 0, &this->read_mr, nullptr);
-    dbg_default_trace("{}:{} registered memory for remote read: {}:{}", __FILE__, __func__, (void*)read_addr, size_r);
+    dbg_trace(sst_logger, "{}:{} registered memory for remote read: {}:{}", __FILE__, __func__, (void*)read_addr, size_r);
 
     this->mr_lrkey = fi_mr_key(this->read_mr);
     if(this->mr_lrkey == FI_KEY_NOTAVAIL) {
         crash_with_message("fail to get read memory key.");
     }
     this->mr_lwkey = fi_mr_key(this->write_mr);
-    dbg_default_trace("{}:{} local write key:{}, local read key:{}", __FILE__, __func__, (uint64_t)this->mr_lwkey, (uint64_t)this->mr_lrkey);
+    dbg_trace(sst_logger, "{}:{} local write key:{}, local read key:{}", __FILE__, __func__, (uint64_t)this->mr_lwkey, (uint64_t)this->mr_lrkey);
     if(this->mr_lwkey == FI_KEY_NOTAVAIL) {
         crash_with_message("fail to get write memory key.");
     }
@@ -369,7 +374,7 @@ _resources::_resources(
 }
 
 _resources::~_resources() {
-    dbg_default_trace("resources destructor:this={}", (void*)this);
+    dbg_trace(sst_logger, "resources destructor:this={}", (void*)this);
     if(this->ep) {
         fail_if_nonzero_retry_on_eagain("close endpoint", REPORT_ON_FAILURE,
                                         fi_close, &this->ep->fid);
@@ -392,15 +397,15 @@ int _resources::post_remote_send(
         const long long int size,
         const int op,
         const bool completion) {
-    // dbg_default_trace("resources::post_remote_send(),this={}",(void*)this);
+    // dbg_trace(sst_logger, "resources::post_remote_send(),this={}",(void*)this);
     // #ifdef !NDEBUG
     // printf(YEL "resources::post_remote_send(),this=%p\n" RESET, this);
     // fflush(stdout);
     // #endif
-    // dbg_default_trace("resources::post_remote_send(ctxt=({},{}),offset={},size={},op={},completion={})",ctxt?ctxt->ce_idx:0,ctxt?ctxt->remote_id:0,offset,size,op,completion);
+    // dbg_trace(sst_logger, "resources::post_remote_send(ctxt=({},{}),offset={},size={},op={},completion={})",ctxt?ctxt->ce_idx:0,ctxt?ctxt->remote_id:0,offset,size,op,completion);
 
     if(remote_failed) {
-        dbg_default_warn("lf.cpp: remote has failed, post_remote_send() does nothing.");
+        dbg_warn(sst_logger, "lf.cpp: remote has failed, post_remote_send() does nothing.");
         return -EFAULT;
     }
     int ret = 0;
@@ -449,10 +454,10 @@ int _resources::post_remote_send(
         msg.context = (void*)ctxt;
         msg.data = 0l;  // not used
 
-        // dbg_default_trace("{}:{} calling fi_writemsg/fi_readmsg with",__FILE__,__func__);
-        // dbg_default_trace("remote addr = {} len = {} key = {}",(void*)rma_iov.addr,rma_iov.len,(uint64_t)this->mr_rwkey);
-        // dbg_default_trace("local addr = {} len = {} key = {}",(void*)msg_iov.iov_base,msg_iov.iov_len,(uint64_t)this->mr_lrkey);
-        // dbg_default_flush();
+        // dbg_trace(sst_logger, "{}:{} calling fi_writemsg/fi_readmsg with",__FILE__,__func__);
+        // dbg_trace(sst_logger, "remote addr = {} len = {} key = {}",(void*)rma_iov.addr,rma_iov.len,(uint64_t)this->mr_rwkey);
+        // dbg_trace(sst_logger, "local addr = {} len = {} key = {}",(void*)msg_iov.iov_base,msg_iov.iov_len,(uint64_t)this->mr_lrkey);
+        // dbg_flush(sst_logger) ;
 
         auto remote_has_failed = [this]() { return remote_failed.load(); };
         if(op == 1) {  //write
@@ -463,8 +468,8 @@ int _resources::post_remote_send(
                                          fi_readmsg, this->ep, &msg, (completion) ? FI_COMPLETION : 0);
         }
     }
-    // dbg_default_trace("post_remote_send return with ret={}",ret);
-    // dbg_default_flush();
+    // dbg_trace(sst_logger, "post_remote_send return with ret={}",ret);
+    // dbg_flush(sst_logger) ;
     // #ifdef !NDEBUG
     // printf(YEL "resources::post_remote_send return with ret=%d\n" RESET, ret);
     // fflush(stdout);
@@ -493,11 +498,11 @@ void _resources::register_oob_memory(void* addr, size_t size) {
     oob_mrs.emplace(reinterpret_cast<uint64_t>(addr),mr);
 
     dbg_default_warn("OOB memory registered with \n"
-                      "\taddr = {:p}\n"
-                      "\tsize = {:x}\n"
-                      "\tdesc = {:x}\n"
-                      "\trkey = {:x}\n",
-                      addr,size,reinterpret_cast<uint64_t>(fi_mr_desc(oob_mr)),fi_mr_key(oob_mr));
+                     "\taddr = {:p}\n"
+                     "\tsize = {:x}\n"
+                     "\tdesc = {:x}\n"
+                     "\trkey = {:x}\n",
+                     addr, size, reinterpret_cast<uint64_t>(fi_mr_desc(oob_mr)), fi_mr_key(oob_mr));
 }
 
 void _resources::unregister_oob_memory(void* addr) {
@@ -584,30 +589,28 @@ void _resources::oob_remote_op(uint32_t op, const struct iovec* iov, int iovcnt,
     sctxt.set_remote_id(remote_id);
     sctxt.set_ce_idx(ce_idx);
     msg.context = (void*)&sctxt;
-    dbg_default_trace("{}: op = {:d}, msg.context = {:p}",__func__,op,static_cast<void*>(&sctxt));
+    dbg_trace(sst_logger, "{}: op = {:d}, msg.context = {:p}",__func__,op,static_cast<void*>(&sctxt));
 
-    dbg_default_warn("{}: op = {:d}, msg.context = {:p}\n"
-                     "\tmsg.msg_iov.iov_base     = {:p}\n"
-                     "\tmsg.msg_iov.iov_len      = {:x}\n"
-                     "\tmsg.iov_count            = {}\n"
-                     "\tmsg.desc[0]              = {:x}\n"
-                     "\tmsg.rma_iov->addr        = {:x}\n"
-                     "\tmsg.rma_iov->len         = {:x}\n"
-                     "\tmsg.rma_iov->key         = {:x}\n"
-                     "\tmsg.rma_iov_count        = {}\n"
-                     "\tmsg.data                 = {}\n"
-                     ,
-                     __func__,op,static_cast<void*>(&sctxt),
-                     msg.msg_iov->iov_base,
-                     msg.msg_iov->iov_len,
-                     msg.iov_count,
-                     reinterpret_cast<uint64_t>(msg.desc[0]),
-                     msg.rma_iov->addr,
-                     msg.rma_iov->len,
-                     msg.rma_iov->key,
-                     msg.rma_iov_count,
-                     msg.data
-            );
+    dbg_warn(sst_logger, "{}: op = {:d}, msg.context = {:p}\n"
+                         "\tmsg.msg_iov.iov_base     = {:p}\n"
+                         "\tmsg.msg_iov.iov_len      = {:x}\n"
+                         "\tmsg.iov_count            = {}\n"
+                         "\tmsg.desc[0]              = {:x}\n"
+                         "\tmsg.rma_iov->addr        = {:x}\n"
+                         "\tmsg.rma_iov->len         = {:x}\n"
+                         "\tmsg.rma_iov->key         = {:x}\n"
+                         "\tmsg.rma_iov_count        = {}\n"
+                         "\tmsg.data                 = {}\n",
+             __func__, op, static_cast<void*>(&sctxt),
+             msg.msg_iov->iov_base,
+             msg.msg_iov->iov_len,
+             msg.iov_count,
+             reinterpret_cast<uint64_t>(msg.desc[0]),
+             msg.rma_iov->addr,
+             msg.rma_iov->len,
+             msg.rma_iov->key,
+             msg.rma_iov_count,
+             msg.data);
 
     int ret = -1;
     if (op == OOB_OP_WRITE) {
@@ -696,7 +699,7 @@ void resources::report_failure() {
 void resources::post_remote_read(const long long int size) {
     int return_code = post_remote_send(NULL, 0, size, 0, false);
     if(return_code != 0) {
-        dbg_default_error("post_remote_read(1) failed with return code {}", return_code);
+        dbg_error(sst_logger, "post_remote_read(1) failed with return code {}", return_code);
         std::cerr << "post_remote_read(1) failed with return code " << return_code << std::endl;
     }
 }
@@ -704,7 +707,7 @@ void resources::post_remote_read(const long long int size) {
 void resources::post_remote_read(const long long int offset, const long long int size) {
     int return_code = post_remote_send(NULL, offset, size, 0, false);
     if(return_code != 0) {
-        dbg_default_error("post_remote_read(2) failed with return code {}", return_code);
+        dbg_error(sst_logger, "post_remote_read(2) failed with return code {}", return_code);
         std::cerr << "post_remote_read(2) failed with return code " << return_code << std::endl;
     }
 }
@@ -712,7 +715,7 @@ void resources::post_remote_read(const long long int offset, const long long int
 void resources::post_remote_write(const long long int size) {
     int return_code = post_remote_send(NULL, 0, size, 1, false);
     if(return_code != 0) {
-        dbg_default_error("post_remote_write(1) failed with return code {}", return_code);
+        dbg_error(sst_logger, "post_remote_write(1) failed with return code {}", return_code);
         std::cerr << "post_remote_write(1) failed with return code " << return_code << std::endl;
     }
 }
@@ -720,7 +723,7 @@ void resources::post_remote_write(const long long int size) {
 void resources::post_remote_write(const long long int offset, long long int size) {
     int return_code = post_remote_send(NULL, offset, size, 1, false);
     if(return_code != 0) {
-        dbg_default_error("post_remote_write(2) failed with return code {}", return_code);
+        dbg_error(sst_logger, "post_remote_write(2) failed with return code {}", return_code);
         std::cerr << "post_remote_write(2) failed with return code " << return_code << std::endl;
     }
 }
@@ -728,7 +731,7 @@ void resources::post_remote_write(const long long int offset, long long int size
 void resources::post_remote_write_with_completion(lf_sender_ctxt* ctxt, const long long int size) {
     int return_code = post_remote_send(ctxt, 0, size, 1, true);
     if(return_code != 0) {
-        dbg_default_error("post_remote_write(3) failed with return code {}", return_code);
+        dbg_error(sst_logger, "post_remote_write(3) failed with return code {}", return_code);
         std::cerr << "post_remote_write(3) failed with return code " << return_code << std::endl;
     }
 }
@@ -736,7 +739,7 @@ void resources::post_remote_write_with_completion(lf_sender_ctxt* ctxt, const lo
 void resources::post_remote_write_with_completion(lf_sender_ctxt* ctxt, const long long int offset, const long long int size) {
     int return_code = post_remote_send(ctxt, offset, size, 1, true);
     if(return_code != 0) {
-        dbg_default_error("post_remote_write(4) failed with return code {}", return_code);
+        dbg_error(sst_logger, "post_remote_write(4) failed with return code {}", return_code);
         std::cerr << "post_remote_write(4) failed with return code " << return_code << std::endl;
     }
 }
@@ -856,7 +859,8 @@ void filter_external_to(const std::vector<node_id_t>& live_nodes_list) {
 
 void polling_loop() {
     pthread_setname_np(pthread_self(), "sst_poll");
-    dbg_default_trace("Polling thread starting.");
+    auto sst_logger = spdlog::get(LoggerFactory::SST_LOGGER_NAME);
+    dbg_trace(sst_logger, "Polling thread starting.");
 
     struct timespec last_time, cur_time;
     clock_gettime(CLOCK_REALTIME, &last_time);
@@ -882,7 +886,7 @@ void polling_loop() {
             }
         }
     }
-    dbg_default_trace("Polling thread ending.");
+    dbg_trace(sst_logger, "Polling thread ending.");
 }
 
 /**
@@ -929,14 +933,14 @@ std::pair<uint32_t, std::pair<int32_t, int32_t>> lf_poll_completion() {
         struct fi_cq_err_entry eentry;
         fi_cq_readerr(g_ctxt.cq, &eentry, 0);
 
-        dbg_default_error("fi_cq_readerr() read the following error entry:");
+        dbg_error(g_ctxt.sst_logger, "fi_cq_readerr() read the following error entry:");
         if(eentry.op_context == NULL) {
-            dbg_default_error("\top_context:NULL");
+            dbg_error(g_ctxt.sst_logger, "\top_context:NULL");
         } else {
 #ifndef NOLOG
             lf_sender_ctxt* sctxt = (lf_sender_ctxt*)eentry.op_context;
 #endif
-            dbg_default_error("\top_context:ce_idx={},remote_id={}", sctxt->ce_idx(), sctxt->remote_id());
+            dbg_error(g_ctxt.sst_logger, "\top_context:ce_idx={},remote_id={}", sctxt->ce_idx(), sctxt->remote_id());
         }
 #ifdef DEBUG_FOR_RELEASE
         printf("\tflags=%x\n", eentry.flags);
@@ -947,24 +951,24 @@ std::pair<uint32_t, std::pair<int32_t, int32_t>> lf_poll_completion() {
         printf("\tolen=0x%x\n", eentry.olen);
         printf("\terr=0x%x\n", eentry.err);
 #endif  //DEBUG_FOR_RELEASE
-        dbg_default_error("\tflags={}", eentry.flags);
-        dbg_default_error("\tlen={}", eentry.len);
-        dbg_default_error("\tbuf={}", eentry.buf);
-        dbg_default_error("\tdata={}", eentry.data);
-        dbg_default_error("\ttag={}", eentry.tag);
-        dbg_default_error("\tolen={}", eentry.olen);
-        dbg_default_error("\terr={}", eentry.err);
+        dbg_error(g_ctxt.sst_logger, "\tflags={}", eentry.flags);
+        dbg_error(g_ctxt.sst_logger, "\tlen={}", eentry.len);
+        dbg_error(g_ctxt.sst_logger, "\tbuf={}", eentry.buf);
+        dbg_error(g_ctxt.sst_logger, "\tdata={}", eentry.data);
+        dbg_error(g_ctxt.sst_logger, "\ttag={}", eentry.tag);
+        dbg_error(g_ctxt.sst_logger, "\tolen={}", eentry.olen);
+        dbg_error(g_ctxt.sst_logger, "\terr={}", eentry.err);
 #ifndef NOLOG
         char errbuf[1024];
 #endif
-        dbg_default_error("\tprov_errno={}:{}", eentry.prov_errno,
+        dbg_error(g_ctxt.sst_logger, "\tprov_errno={}:{}", eentry.prov_errno,
                           fi_cq_strerror(g_ctxt.cq, eentry.prov_errno, eentry.err_data, errbuf, 1024));
 #ifdef DEBUG_FOR_RELEASE
         printf("\tproverr=0x%x,%s\n", eentry.prov_errno,
                fi_cq_strerror(g_ctxt.cq, eentry.prov_errno, eentry.err_data, errbuf, 1024));
 #endif  //DEBUG_FOR_RELEASE
-        dbg_default_error("\terr_data={}", eentry.err_data);
-        dbg_default_error("\terr_data_size={}", eentry.err_data_size);
+        dbg_error(g_ctxt.sst_logger, "\terr_data={}", eentry.err_data);
+        dbg_error(g_ctxt.sst_logger, "\terr_data_size={}", eentry.err_data_size);
 #ifdef DEBUG_FOR_RELEASE
         printf("\terr_data_size=%d\n", eentry.err_data_size);
 #endif  //DEBUG_FOR_RELEASE
@@ -974,20 +978,20 @@ std::pair<uint32_t, std::pair<int32_t, int32_t>> lf_poll_completion() {
             lf_sender_ctxt* sctxt = (lf_sender_ctxt*)eentry.op_context;
             return {sctxt->ce_idx(), {sctxt->remote_id(), -1}};
         } else {
-            dbg_default_error("\tFailed polling the completion queue");
+            dbg_error(g_ctxt.sst_logger, "\tFailed polling the completion queue");
             fprintf(stderr, "Failed polling the completion queue");
             return {(uint32_t)0xFFFFFFFF, {0, -1}};  // we don't know who sent the message.
         }*/
-        dbg_default_error("\tFailed polling the completion queue");
+        dbg_error(g_ctxt.sst_logger, "\tFailed polling the completion queue");
         return {(uint32_t)0xFFFFFFFF, {0, -1}};  // we don't know who sent the message.
     }
     if(!shutdown) {
         lf_sender_ctxt* sctxt = (lf_sender_ctxt*)entry.op_context;
         if(sctxt == NULL) {
-            dbg_default_debug("WEIRD: we get an entry with op_context = NULL.");
+            dbg_debug(g_ctxt.sst_logger, "WEIRD: we get an entry with op_context = NULL.");
             return {0xFFFFFFFFu, {0, 0}};  // return a bad entry: weird!!!!
         } else {
-            //dbg_default_trace("Normal: we get an entry with op_context = {}.",(long long unsigned)sctxt);
+            //dbg_trace(sst_logger, "Normal: we get an entry with op_context = {}.",(long long unsigned)sctxt);
             return {sctxt->ce_idx(), {sctxt->remote_id(), 1}};
         }
     } else {  // shutdown return a bad entry
@@ -998,6 +1002,10 @@ std::pair<uint32_t, std::pair<int32_t, int32_t>> lf_poll_completion() {
 void lf_initialize(const std::map<node_id_t, std::pair<ip_addr_t, uint16_t>>& internal_ip_addrs_and_ports,
                    const std::map<node_id_t, std::pair<ip_addr_t, uint16_t>>& external_ip_addrs_and_ports,
                    uint32_t node_id) {
+    // Create SST logger, which must be done exactly once before any SST functions are called
+    auto logger = LoggerFactory::createLogger(LoggerFactory::SST_LOGGER_NAME,
+                                              derecho::getConfString(CONF_LOGGER_SST_LOG_LEVEL));
+
     // initialize derecho connection manager
     // May there be a better design?
     if(internal_ip_addrs_and_ports.empty()) {
@@ -1007,9 +1015,9 @@ void lf_initialize(const std::map<node_id_t, std::pair<ip_addr_t, uint16_t>>& in
         sst_connections = new tcp::tcp_connections(node_id, my_port);
         for(const auto& node_entry : internal_ip_addrs_and_ports) {
             if(node_entry.first != node_id
-            && !sst_connections->add_node(node_entry.first, node_entry.second)) {
+               && !sst_connections->add_node(node_entry.first, node_entry.second)) {
                 // Following the rest of lf_initialize, crash immediately on an error instead of reporting it
-                dbg_default_error("lf_initialize could not establish a TCP connection to node {} at {}:{}", node_entry.first, node_entry.second.first, node_entry.second.second);
+                dbg_error(logger, "lf_initialize could not establish a TCP connection to node {} at {}:{}", node_entry.first, node_entry.second.first, node_entry.second.second);
                 crash_with_message("Failure in LibFabric setup! Could not establish a TCP connection to %s:%u\n", node_entry.second.first.c_str(), node_entry.second.second);
             }
         }
@@ -1022,7 +1030,7 @@ void lf_initialize(const std::map<node_id_t, std::pair<ip_addr_t, uint16_t>>& in
         for(const auto& node_entry : external_ip_addrs_and_ports) {
             if(node_entry.first != node_id
                && !external_client_connections->add_node(node_entry.first, node_entry.second)) {
-                dbg_default_error("lf_initialize could not establish a TCP connection to node {} at {}:{}", node_entry.first, node_entry.second.first, node_entry.second.second);
+                dbg_error(logger, "lf_initialize could not establish a TCP connection to node {} at {}:{}", node_entry.first, node_entry.second.first, node_entry.second.second);
                 crash_with_message("Failure in LibFabric setup! Could not establish a TCP connection to %s:%u\n", node_entry.second.first.c_str(), node_entry.second.second);
             }
         }
@@ -1037,7 +1045,7 @@ void lf_initialize(const std::map<node_id_t, std::pair<ip_addr_t, uint16_t>>& in
     // STEP 2: initialize fabric, domain, and completion queue
     fail_if_nonzero_retry_on_eagain("fi_getinfo()", CRASH_ON_FAILURE,
                                     fi_getinfo, LF_VERSION, nullptr, nullptr, 0, g_ctxt.hints, &(g_ctxt.fi));
-    dbg_default_trace("going to use virtual address?{}", LF_USE_VADDR);
+    dbg_trace(logger, "going to use virtual address?{}", LF_USE_VADDR);
     fail_if_nonzero_retry_on_eagain("fi_fabric()", CRASH_ON_FAILURE,
                                     fi_fabric, g_ctxt.fi->fabric_attr, &(g_ctxt.fabric), nullptr);
     fail_if_nonzero_retry_on_eagain("fi_domain()", CRASH_ON_FAILURE,

--- a/src/sst/lf.cpp
+++ b/src/sst/lf.cpp
@@ -133,7 +133,7 @@ static void default_context() {
 
     g_ctxt.pep_addr_len = max_lf_addr_size;
 
-    g_ctxt.sst_logger = spdlog::get(LoggerFactory::PERSISTENT_LOGGER_NAME);
+    g_ctxt.sst_logger = spdlog::get(LoggerFactory::SST_LOGGER_NAME);
 }
 
 /** load RDMA device configurations from file */
@@ -991,7 +991,7 @@ std::pair<uint32_t, std::pair<int32_t, int32_t>> lf_poll_completion() {
             dbg_debug(g_ctxt.sst_logger, "WEIRD: we get an entry with op_context = NULL.");
             return {0xFFFFFFFFu, {0, 0}};  // return a bad entry: weird!!!!
         } else {
-            //dbg_trace(sst_logger, "Normal: we get an entry with op_context = {}.",(long long unsigned)sctxt);
+            //dbg_trace(g_ctxt.sst_logger, "Normal: we get an entry with op_context = {}.",(long long unsigned)sctxt);
             return {sctxt->ce_idx(), {sctxt->remote_id(), 1}};
         }
     } else {  // shutdown return a bad entry

--- a/src/utils/logger.cpp
+++ b/src/utils/logger.cpp
@@ -38,9 +38,11 @@ std::shared_ptr<spdlog::logger> LoggerFactory::_create_logger(
         log_sinks.end(),
         _thread_pool_holder,
         spdlog::async_overflow_policy::block);
-    spdlog::register_logger(log);
     log->set_pattern("[%H:%M:%S.%f] [%n] [Thread %t] [%^%l%$] %v");
     log->set_level(log_level);
+    spdlog::register_logger(log);
+    // Sanity check: Can I get the logger I just registered?
+    assert(spdlog::get(logger_name));
     return log;
 }
 

--- a/src/utils/logger.cpp
+++ b/src/utils/logger.cpp
@@ -14,19 +14,23 @@
 #define LOGGER_FACTORY_INITIALIZING	(1)
 #define LOGGER_FACTORY_INITIALIZED	(2)
 
+const std::string LoggerFactory::PERSISTENT_LOGGER_NAME = "persistent";
+const std::string LoggerFactory::SST_LOGGER_NAME = "derecho_sst";
+const std::string LoggerFactory::RPC_LOGGER_NAME = "derecho_rpc";
 std::atomic<uint32_t> LoggerFactory::_initialize_state = LOGGER_FACTORY_UNINITIALIZED;
 std::shared_ptr<spdlog::details::thread_pool> LoggerFactory::_thread_pool_holder;
 std::shared_ptr<spdlog::logger> LoggerFactory::_default_logger;
-
+std::shared_ptr<spdlog::sinks::rotating_file_sink_mt> LoggerFactory::_file_sink;
+std::shared_ptr<spdlog::sinks::stdout_color_sink_mt> LoggerFactory::_stdout_sink;
+std::mutex LoggerFactory::get_create_mutex;
 
 std::shared_ptr<spdlog::logger> LoggerFactory::_create_logger(
     const std::string &logger_name,
     spdlog::level::level_enum log_level) {
     std::vector<spdlog::sink_ptr> log_sinks;
-    log_sinks.push_back(std::make_shared<spdlog::sinks::rotating_file_sink_mt>(
-        logger_name + ".log",1L<<20, derecho::getConfUInt32(CONF_LOGGER_LOG_FILE_DEPTH)));
+    log_sinks.push_back(_file_sink);
     if(derecho::getConfBoolean(CONF_LOGGER_LOG_TO_TERMINAL)) {
-        log_sinks.push_back(std::make_shared<spdlog::sinks::stdout_color_sink_mt>());
+        log_sinks.push_back(_stdout_sink);
     }
     std::shared_ptr<spdlog::logger> log = std::make_shared<spdlog::async_logger>(
         logger_name,
@@ -49,8 +53,12 @@ void LoggerFactory::_initialize() {
         // 1 - initialize the thread pool
         spdlog::init_thread_pool(1L<<20, 1); // 1MB buffer, 1 thread
         _thread_pool_holder = spdlog::thread_pool();
-        // 2 - initialize the default Logger
+        // 2 - initialize the sink objects that will be shared by all loggers
         std::string default_logger_name = derecho::getConfString(CONF_LOGGER_DEFAULT_LOG_NAME);
+        _file_sink = std::make_shared<spdlog::sinks::rotating_file_sink_mt>(
+            default_logger_name + ".log", 1L<<20, derecho::getConfUInt32(CONF_LOGGER_LOG_FILE_DEPTH));
+        _stdout_sink = std::make_shared<spdlog::sinks::stdout_color_sink_mt>();
+        // 3 - initialize the default Logger
         std::string default_log_level = derecho::getConfString(CONF_LOGGER_DEFAULT_LOG_LEVEL);
         _default_logger = _create_logger(default_logger_name,
             spdlog::level::from_str(default_log_level));
@@ -66,10 +74,29 @@ void LoggerFactory::_initialize() {
 }
 
 std::shared_ptr<spdlog::logger> LoggerFactory::createLogger(
-    const std::string &logger_name,
-    spdlog::level::level_enum log_level) {
+        const std::string& logger_name,
+        spdlog::level::level_enum log_level) {
     _initialize();
-    return _create_logger(logger_name,log_level);
+    return _create_logger(logger_name, log_level);
+}
+
+std::shared_ptr<spdlog::logger> LoggerFactory::createLogger(
+        const std::string& logger_name,
+        const std::string& log_level_string) {
+    return createLogger(logger_name, spdlog::level::from_str(log_level_string));
+}
+
+std::shared_ptr<spdlog::logger> LoggerFactory::createIfAbsent(
+        const std::string& logger_name,
+        const std::string& log_level_string) {
+    _initialize();
+    std::lock_guard get_check_lock(get_create_mutex);
+    auto log_ptr = spdlog::get(logger_name);
+    if(log_ptr) {
+        return log_ptr;
+    } else {
+        return _create_logger(logger_name, spdlog::level::from_str(log_level_string));
+    }
 }
 
 std::shared_ptr<spdlog::logger>& LoggerFactory::getDefaultLogger() {

--- a/src/utils/logger.cpp
+++ b/src/utils/logger.cpp
@@ -17,6 +17,7 @@
 const std::string LoggerFactory::PERSISTENT_LOGGER_NAME = "persistent";
 const std::string LoggerFactory::SST_LOGGER_NAME = "derecho_sst";
 const std::string LoggerFactory::RPC_LOGGER_NAME = "derecho_rpc";
+const std::string LoggerFactory::VIEWMANAGER_LOGGER_NAME = "viewmanager";
 std::atomic<uint32_t> LoggerFactory::_initialize_state = LOGGER_FACTORY_UNINITIALIZED;
 std::shared_ptr<spdlog::details::thread_pool> LoggerFactory::_thread_pool_holder;
 std::shared_ptr<spdlog::logger> LoggerFactory::_default_logger;


### PR DESCRIPTION
Currently all debug-logging messages in Derecho (and Cascade) go to one global instance of spdlog::logger, whose logging level is set by the configuration parameter default_log_level. The "debug" and "trace" levels are getting very verbose because of all the different components that can generate log messages (e.g. SST, message-delivery, RPC, view-management, persistence), and there is no good way to filter the messages to just the component you're trying to debug. It would be nice if the logging messages were separated by logical modules, and the spdlog library is already designed with this in mind: You can create multiple logger objects that all output to the same "sink" (log file or the terminal), and each logger can have its level set separately. 

I changed our LoggerFactory class so that  all logger objects created with createLogger() will share the same file-output sink (so all the log messages still go to one file). I then added code to create and use separate logger objects for several sub-components of Derecho: SST, RPC, ViewManager, and Persistence. Each of these has a fixed logger name, defined by a string constant in LoggerFactory, but their log levels are configured by the new config file options sst_log_level, rpc_log_level, viewmanager_log_level, and persistence_log_level. If the log level for a module logger is not set in the config file, it will default to the same log level set in the default_log_level option (this is backward-compatible with the old behavior).