### PR TITLE
Fix crash in total restart caused by issue #252

### DIFF
--- a/include/derecho/core/detail/restart_state.hpp
+++ b/include/derecho/core/detail/restart_state.hpp
@@ -139,8 +139,10 @@ private:
      * logged_ragged_trim if the joiner has newer information.
      * @param joiner_id The ID of the rejoining node
      * @param client_socket The TCP socket connected to the rejoining node
+     * @return True if the logs were received successfully, false if the client
+     * disconnected (crashed) while sending them
      */
-    void receive_joiner_logs(const node_id_t& joiner_id, tcp::socket& client_socket);
+    bool receive_joiner_logs(const node_id_t& joiner_id, tcp::socket& client_socket);
 
     /**
      * Recomputes the restart view based on the current set of nodes that have

--- a/include/derecho/persistent/detail/PersistNoLog_impl.hpp
+++ b/include/derecho/persistent/detail/PersistNoLog_impl.hpp
@@ -21,7 +21,7 @@ void saveNoLogObjectInFile(
     // 2 - serialize
     auto size = mutils::bytes_size(obj);
     uint8_t* buf = new uint8_t[size];
-    bzero(buf, size);
+    memset(buf, 0, size);
     mutils::to_bytes(obj, buf);
     // 3 - write to tmp file
     int fd = open(tmpfilepath, O_RDWR | O_CREAT, S_IWUSR | S_IRUSR | S_IRGRP | S_IWGRP | S_IROTH);

--- a/include/derecho/persistent/detail/Persistent_impl.hpp
+++ b/include/derecho/persistent/detail/Persistent_impl.hpp
@@ -544,7 +544,7 @@ void Persistent<ObjectType, storageType>::set(ObjectType& v, version_t ver, cons
         // ObjectType does not support Delta, logging the whole current state.
         auto size = mutils::bytes_size(v);
         uint8_t* buf = new uint8_t[size];
-        bzero(buf, size);
+        memset(buf, 0, size);
         mutils::to_bytes(v, buf);
         this->m_pLog->append((void*)buf, size, ver, mhlc);
         delete[] buf;

--- a/include/derecho/sst/sst.hpp
+++ b/include/derecho/sst/sst.hpp
@@ -170,8 +170,8 @@ private:
     void init_SSTFields(Fields&... fields) {
         rowLen = 0;
         compute_rowLen(rowLen, fields...);
-	void* mem_ptr = new uint8_t[rowLen * num_members];
-	bzero(mem_ptr,rowLen * num_members);
+        void* mem_ptr = new uint8_t[rowLen * num_members];
+        memset(mem_ptr, 0, rowLen * num_members);
         rows = (volatile uint8_t*)mem_ptr;
         // snapshot = new uint8_t[rowLen * num_members];
         volatile uint8_t* base = rows;

--- a/include/derecho/tcp/tcp.hpp
+++ b/include/derecho/tcp/tcp.hpp
@@ -57,7 +57,7 @@ struct incomplete_read_error : public socket_error {
  * errno value ECONNRESET.
  */
 struct connection_reset_error : public socket_io_error {
-    connection_reset_error(const std::string& message = "") : socket_io_error(ECONNRESET, message) {};
+    connection_reset_error(const std::string& message = "") : socket_io_error(ECONNRESET, message){};
 };
 
 /**
@@ -67,7 +67,7 @@ struct connection_reset_error : public socket_io_error {
  * of socket_io_error with the errno value EPIPE.
  */
 struct remote_closed_connection_error : public socket_io_error {
-    remote_closed_connection_error(const std::string& message = "") : socket_io_error(EPIPE, message) {};
+    remote_closed_connection_error(const std::string& message = "") : socket_io_error(EPIPE, message){};
 };
 
 class socket {
@@ -88,12 +88,15 @@ public:
      */
     socket() : sock(-1), remote_ip(), remote_port(0) {}
     /**
-     * Constructs a socket connected to the specified address and port,
-     * blocking until the connection succeeds.
+     * Constructs a socket connected to the specified address and port
      * @param server_ip The IP address of the remote host, as a string
      * @param server_port The port to connect to on the remote host
+     * @param retry Whether to keep retrying until the connection succeeds.
+     * If false, throws connection_failure if the first attempt to connect
+     * does not succeed.
      * @throw connection_failure if local socket construction or IP address
-     * lookup fails.
+     * lookup fails, or if retry = false and there was an error connecting
+     * to the remote host.
      */
     socket(std::string server_ip, uint16_t server_port, bool retry = true);
     socket(socket&& s);
@@ -102,11 +105,25 @@ public:
     socket& operator=(socket&& s);
 
     ~socket();
-
-    bool is_empty() const;
-    std::string get_self_ip();
-    std::string get_remote_ip() const { return remote_ip; }
-    uint16_t get_remote_port() const { return remote_port; }
+    /**
+     * @return True if the socket is empty (not connected), false otherwise
+     */
+    bool is_empty() const noexcept;
+    /**
+     * @return The local IP address this socket is bound to.
+     * @throw socket_io_error if getsockname() fails.
+     */
+    std::string get_self_ip() const;
+    /**
+     * @return The IP address of the remote peer that this socket is connected
+     * to (or an empty string if this socket is unconnected).
+     */
+    std::string get_remote_ip() const noexcept { return remote_ip; }
+    /**
+     * @return The TCP port on the remote peer that this socket is connected to
+     * (or 0 if this socket is unconnected).
+     */
+    uint16_t get_remote_port() const noexcept { return remote_port; }
 
     /**
      * Attempts to connect the socket to the specified address and port, but
@@ -146,11 +163,12 @@ public:
      * the result of the read
      * @param max_size The number of bytes to attempt to read
      * @return The number of bytes actually read, or -1 if there was an error
+     * @throw socket_closed_error if the socket is closed.
      */
     ssize_t read_partial(uint8_t* buffer, size_t max_size);
 
     /** Returns true if there is any data available to be read from the socket. */
-    bool probe();
+    bool probe() const noexcept;
 
     /**
      * Writes size bytes from the given buffer to the socket.
@@ -168,9 +186,13 @@ public:
     /**
      * Convenience method for sending a single POD object (e.g. an int) over
      * the socket.
+     * @param obj A POD object that can be sent by simply copying its memory
+     * @throw A subclass of socket_error if there was an error while writing
+     * to the socket.
      */
     template <typename T>
     void write(const T& obj) {
+        static_assert(std::is_pod<T>::value, "Can't use simple socket::write on non-POD types");
         write(reinterpret_cast<const uint8_t*>(&obj), sizeof(obj));
     }
 
@@ -179,23 +201,31 @@ public:
      * writing it over a local value of that type. Hides the ugly cast to uint8_t*.
      * @param obj A local value of type T, which will be overwritten by a value
      * of the same size read from the socket.
+     * @throw A subclass of socket_error if there was an error while attempting
+     * to read from the socket.
      */
     template <typename T>
     void read(T& obj) {
+        static_assert(std::is_pod<T>::value, "Can't use simple socket::read on non-POD types");
         read(reinterpret_cast<uint8_t*>(&obj), sizeof(obj));
     }
 
+    /**
+     * Convenience method that combines a read of a POD-type object with a write
+     * of the same type. Used when exchanging ints or other simple values.
+     * @tparam T The type of POD that will be read and written
+     * @param local A local value of type T that will be sent over the socket
+     * @param remote A reference to a value of type T that will be overwritten
+     * by a read from the socket.
+     * @throw A subclass of socket_error if there was an error during either the
+     * read or the write
+     */
     template <class T>
     void exchange(T local, T& remote) {
-        static_assert(std::is_pod<T>::value,
-                      "Can't send non-pod type over TCP");
+        static_assert(std::is_pod<T>::value, "Can't use socket::exchange on non-POD types");
 
-        if(sock < 0) {
-            throw socket_closed_error("Attempted to write to closed socket");
-        }
-
-        write((uint8_t*)&local, sizeof(T));
-        read((uint8_t*)&remote, sizeof(T));
+        write(reinterpret_cast<uint8_t*>(&local), sizeof(T));
+        read(reinterpret_cast<uint8_t*>(&remote), sizeof(T));
     }
 };
 
@@ -213,12 +243,16 @@ public:
      */
     explicit connection_listener(uint16_t port, int queue_depth = 50);
 
-    uint16_t get_listening_port() const { return port; }
+    /**
+     * @return The local port that this connection listener is bound to.
+     */
+    uint16_t get_listening_port() const noexcept { return port; }
 
     /**
      * Blocks until a remote client makes a connection to this connection
      * listener, then returns a new socket connected to that client.
      * @return A socket connected to a remote client.
+     * @throw connection_failure if the socket's accept operation fails
      */
     socket accept();
 
@@ -231,6 +265,6 @@ public:
      * @return A socket connected to a remote client, or nullopt if the
      * timeout expired
      */
-    std::optional<socket> try_accept(int timeout_ms);
+    std::optional<socket> try_accept(int timeout_ms) noexcept;
 };
 }  // namespace tcp

--- a/src/applications/tests/performance_tests/persistent_latency_test.cpp
+++ b/src/applications/tests/performance_tests/persistent_latency_test.cpp
@@ -237,7 +237,7 @@ int main(int argc, char* argv[]) {
 
     if(is_sending) {
         uint8_t* bbuf = new uint8_t[msg_size];
-        bzero(bbuf, msg_size);
+        memset(bbuf, 0, msg_size);
         Bytes bs(bbuf, msg_size);
 
         try {

--- a/src/applications/tests/performance_tests/typed_subgroup_bw_test.cpp
+++ b/src/applications/tests/performance_tests/typed_subgroup_bw_test.cpp
@@ -168,7 +168,7 @@ int main(int argc, char* argv[]) {
 
     //std::string str_1k(max_msg_size, 'x');
     uint8_t* bbuf = (uint8_t*)malloc(max_msg_size);
-    bzero(bbuf, max_msg_size);
+    memset(bbuf, 0, max_msg_size);
     Bytes bytes(bbuf, max_msg_size);
 
     // this function sends all the messages

--- a/src/core/git_version.cpp
+++ b/src/core/git_version.cpp
@@ -13,8 +13,8 @@ namespace derecho {
 const int MAJOR_VERSION = 2;
 const int MINOR_VERSION = 3;
 const int PATCH_VERSION = 0;
-const int COMMITS_AHEAD_OF_VERSION = 85;
+const int COMMITS_AHEAD_OF_VERSION = 87;
 const char* VERSION_STRING = "2.3.0";
-const char* VERSION_STRING_PLUS_COMMITS = "2.3.0+85";
+const char* VERSION_STRING_PLUS_COMMITS = "2.3.0+87";
 
 }

--- a/src/core/git_version.cpp
+++ b/src/core/git_version.cpp
@@ -13,8 +13,8 @@ namespace derecho {
 const int MAJOR_VERSION = 2;
 const int MINOR_VERSION = 3;
 const int PATCH_VERSION = 0;
-const int COMMITS_AHEAD_OF_VERSION = 87;
+const int COMMITS_AHEAD_OF_VERSION = 88;
 const char* VERSION_STRING = "2.3.0";
-const char* VERSION_STRING_PLUS_COMMITS = "2.3.0+87";
+const char* VERSION_STRING_PLUS_COMMITS = "2.3.0+88";
 
 }

--- a/src/core/git_version.cpp
+++ b/src/core/git_version.cpp
@@ -13,8 +13,8 @@ namespace derecho {
 const int MAJOR_VERSION = 2;
 const int MINOR_VERSION = 3;
 const int PATCH_VERSION = 0;
-const int COMMITS_AHEAD_OF_VERSION = 88;
+const int COMMITS_AHEAD_OF_VERSION = 89;
 const char* VERSION_STRING = "2.3.0";
-const char* VERSION_STRING_PLUS_COMMITS = "2.3.0+88";
+const char* VERSION_STRING_PLUS_COMMITS = "2.3.0+89";
 
 }

--- a/src/rdmc/lf_helper.cpp
+++ b/src/rdmc/lf_helper.cpp
@@ -180,7 +180,7 @@ memory_region::memory_region(uint8_t* buf, size_t s) : buffer(buf), size(s) {
     const int mr_access = FI_WRITE | FI_REMOTE_READ | FI_REMOTE_WRITE;
 
     /** touch the memory region before register it, because some libfabric providers might not do that in fi_mr_reg **/
-    bzero(reinterpret_cast<void*>(buffer),size);
+    memset(reinterpret_cast<void*>(buffer), 0, size);
 
     /** Register the memory, use it to construct a smart pointer */
     fid_mr* raw_mr;

--- a/src/tcp/tcp.cpp
+++ b/src/tcp/tcp.cpp
@@ -33,8 +33,7 @@ socket::socket(std::string server_ip, uint16_t server_port, bool retry)
     memset(&serv_addr, 0, sizeof(serv_addr));
     serv_addr.sin_family = AF_INET;
     serv_addr.sin_port = htons(server_port);
-    bcopy((char*)server->h_addr, (char*)&serv_addr.sin_addr.s_addr,
-          server->h_length);
+    memcpy(&serv_addr.sin_addr.s_addr, server->h_addr, server->h_length);
 
     int optval = 1;
     if(setsockopt(sock, IPPROTO_TCP, TCP_NODELAY, &optval, sizeof(optval))) {
@@ -94,8 +93,7 @@ int socket::try_connect(std::string servername, uint16_t port, int timeout_ms) {
     memset(&serv_addr, 0, sizeof(serv_addr));
     serv_addr.sin_family = AF_INET;
     serv_addr.sin_port = htons(port);
-    bcopy((char*)server->h_addr, (char*)&serv_addr.sin_addr.s_addr,
-          server->h_length);
+    memcpy(&serv_addr.sin_addr.s_addr, server->h_addr, server->h_length);
 
     //Temporarily set socket to nonblocking in order to connect with a timeout
     int sock_flags = fcntl(sock, F_GETFL, 0);


### PR DESCRIPTION
This is a fix for the bug identified in #252. A node that thinks it is not in total-restart mode but gets a TOTAL_RESTART response from the leader will recover from the situation by creating an empty `curr_view` with VID -1, instead of crashing because it attempts to send a null `curr_view` to the leader. The restart leader will ignore this view, since it has an "older" VID than the leader's current view, and treat the new node as a very out-of-date node that was not in the last known view. Thus the new node can't contribute to achieving a restart quorum (which it shouldn't) but it can get added as a new member as soon as the restart finishes.

While fixing this, I realized that the restart leader would also crash when the non-restarting node crashed, because it didn't properly handle the node failing to send a view (it assumed that any node that successfully connected would at least be able to send its view). I added better error-handling code to RestartLeaderState so that joining node failures can't make the leader crash.