### PR TITLE
Fix install scripts to remove temp directories

### DIFF
--- a/scripts/prerequisites/install-json.sh
+++ b/scripts/prerequisites/install-json.sh
@@ -16,3 +16,4 @@ git checkout v3.11.1
 cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=${INSTALL_PREFIX} .
 make -j `lscpu | grep "^CPU(" | awk '{print $2}'`
 make install
+rm -rf ${WORKPATH}

--- a/scripts/prerequisites/install-libfabric.sh
+++ b/scripts/prerequisites/install-libfabric.sh
@@ -22,3 +22,4 @@ libtoolize
 ./configure --prefix=${INSTALL_PREFIX} --disable-memhooks-monitor --disable-spinlock
 make -j `lscpu | grep "^CPU(" | awk '{print $2}'`
 make install
+rm -rf ${WORKPATH}

--- a/scripts/prerequisites/install-mutils-containers.sh
+++ b/scripts/prerequisites/install-mutils-containers.sh
@@ -22,3 +22,4 @@ cd build
 cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=${INSTALL_PREFIX} ..
 make -j `lscpu | grep "^CPU(" | awk '{print $2}'`
 make install
+rm -rf ${WORKPATH}

--- a/scripts/prerequisites/install-mutils.sh
+++ b/scripts/prerequisites/install-mutils.sh
@@ -21,3 +21,4 @@ cd build
 cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=${INSTALL_PREFIX} ..
 make -j `lscpu | grep "^CPU(" | awk '{print $2}'`
 make install
+rm -rf ${WORKPATH}

--- a/src/core/git_version.cpp
+++ b/src/core/git_version.cpp
@@ -13,8 +13,8 @@ namespace derecho {
 const int MAJOR_VERSION = 2;
 const int MINOR_VERSION = 3;
 const int PATCH_VERSION = 0;
-const int COMMITS_AHEAD_OF_VERSION = 85;
+const int COMMITS_AHEAD_OF_VERSION = 87;
 const char* VERSION_STRING = "2.3.0";
-const char* VERSION_STRING_PLUS_COMMITS = "2.3.0+85";
+const char* VERSION_STRING_PLUS_COMMITS = "2.3.0+87";
 
 }


### PR DESCRIPTION
According to Linux standards, the /var/tmp directory should be preserved across reboots and should not be deleted frequently by the OS, and many Linux distributions never delete files from /var/tmp. Installers and programs that use /var/tmp are supposed to clean up after themselves and delete the temporary directories they create in /var/tmp. Since our install scripts do not clean up after themselves, the Fractus nodes suffer from an ever-growing number of temporary directories in /var/tmp (each containing copies of libfabric, nlohmann_json, and mutils) that are not deleted automatically.

(See https://superuser.com/questions/168125, https://superuser.com/questions/499039/, and https://unix.stackexchange.com/questions/698677)