### PR TITLE
Fix bugs in our CMake dependency declarations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,11 @@ include(GetGitRevisionDescription)
 # libfabric_INCLUDE_DIRS
 # libfabric_LIBRARIES
 find_package(libfabric 1.12.1 REQUIRED)
+if(${libfabric_FOUND})
+    include_directories(${libfabric_INCLUDE_DIRS})
+else()
+    message(FATAL_ERROR "Required library LibFabric not found")
+endif()
 
 # These packages export their location information in the "new" way,
 # by providing an IMPORT-type CMake target that you can use as a

--- a/src/conf/CMakeLists.txt
+++ b/src/conf/CMakeLists.txt
@@ -2,13 +2,14 @@ add_library(conf OBJECT conf.cpp)
 target_include_directories(conf PRIVATE
     $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>
 )
+target_link_libraries(conf nlohmann_json::nlohmann_json)
 
 add_executable(conftst test.cpp conf.cpp)
 target_include_directories(conftst PRIVATE
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
     $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>
 )
-target_link_libraries(conftst pthread)
+target_link_libraries(conftst pthread nlohmann_json::nlohmann_json)
 
 install(FILES derecho-sample.cfg
     DESTINATION share/derecho/)

--- a/src/core/git_version.cpp
+++ b/src/core/git_version.cpp
@@ -13,8 +13,8 @@ namespace derecho {
 const int MAJOR_VERSION = 2;
 const int MINOR_VERSION = 3;
 const int PATCH_VERSION = 0;
-const int COMMITS_AHEAD_OF_VERSION = 85;
+const int COMMITS_AHEAD_OF_VERSION = 87;
 const char* VERSION_STRING = "2.3.0";
-const char* VERSION_STRING_PLUS_COMMITS = "2.3.0+85";
+const char* VERSION_STRING_PLUS_COMMITS = "2.3.0+87";
 
 }


### PR DESCRIPTION
Attempting to compile Derecho on a Fractus node where the LibFabrics and nlohmann-JSON libraries were not installed system-wide revealed two bugs in our CMake declarations:
1. The Conf module did not declare its dependency on nlohmann_json even though conf.cpp includes nlohmann/json.hpp 
2.  The top-level CMakeLists did not call include_directories() after calling find_package(libfabric), which is necessary for packages that do not export CMake targets (the "old way") - we need to both link `${libfabric_LIBRARIES}` **and** include `${libfabric_INCLUDE_DIRS}`.