### PR TITLE
Replace macros with string constants in Conf

### DIFF
--- a/include/derecho/conf/conf.hpp
+++ b/include/derecho/conf/conf.hpp
@@ -17,120 +17,125 @@ namespace derecho {
 // It's declared here so that it can be compared to the supplied config options
 constexpr std::size_t DERECHO_MIN_RPC_RESPONSE_SIZE = 128;
 
-#define CONF_ENTRY_INTEGER(name, section, string)
-
 /** The single configuration file for derecho **/
 class Conf {
-private:
+public:
     //String constants for config options
-#define CONF_DERECHO_LEADER_IP "DERECHO/leader_ip"
-#define CONF_DERECHO_LEADER_GMS_PORT "DERECHO/leader_gms_port"
-#define CONF_DERECHO_LEADER_EXTERNAL_PORT "DERECHO/leader_external_port"
-#define CONF_DERECHO_RESTART_LEADERS "DERECHO/restart_leaders"
-#define CONF_DERECHO_RESTART_LEADER_PORTS "DERECHO/restart_leader_ports"
-#define CONF_DERECHO_LOCAL_ID "DERECHO/local_id"
-#define CONF_DERECHO_LOCAL_IP "DERECHO/local_ip"
-#define CONF_DERECHO_GMS_PORT "DERECHO/gms_port"
-#define CONF_DERECHO_STATE_TRANSFER_PORT "DERECHO/state_transfer_port"
-#define CONF_DERECHO_SST_PORT "DERECHO/sst_port"
-#define CONF_DERECHO_RDMC_PORT "DERECHO/rdmc_port"
-#define CONF_DERECHO_EXTERNAL_PORT "DERECHO/external_port"
-#define CONF_DERECHO_HEARTBEAT_MS "DERECHO/heartbeat_ms"
-#define CONF_DERECHO_P2P_LOOP_BUSY_WAIT_BEFORE_SLEEP_MS "DERECHO/p2p_loop_busy_wait_before_sleep_ms"
-#define CONF_DERECHO_SST_POLL_CQ_TIMEOUT_MS "DERECHO/sst_poll_cq_timeout_ms"
-#define CONF_DERECHO_RESTART_TIMEOUT_MS "DERECHO/restart_timeout_ms"
-#define CONF_DERECHO_ENABLE_BACKUP_RESTART_LEADERS "DERECHO/enable_backup_restart_leaders"
-#define CONF_DERECHO_DISABLE_PARTITIONING_SAFETY "DERECHO/disable_partitioning_safety"
-#define CONF_DERECHO_MAX_NODE_ID "DERECHO/max_node_id"
+    static constexpr const char* DERECHO_LEADER_IP = "DERECHO/leader_ip";
+    static constexpr const char* DERECHO_LEADER_GMS_PORT = "DERECHO/leader_gms_port";
+    static constexpr const char* DERECHO_LEADER_EXTERNAL_PORT = "DERECHO/leader_external_port";
+    static constexpr const char* DERECHO_RESTART_LEADERS = "DERECHO/restart_leaders";
+    static constexpr const char* DERECHO_RESTART_LEADER_PORTS = "DERECHO/restart_leader_ports";
+    static constexpr const char* DERECHO_LOCAL_ID = "DERECHO/local_id";
+    static constexpr const char* DERECHO_LOCAL_IP = "DERECHO/local_ip";
+    static constexpr const char* DERECHO_GMS_PORT = "DERECHO/gms_port";
+    static constexpr const char* DERECHO_STATE_TRANSFER_PORT = "DERECHO/state_transfer_port";
+    static constexpr const char* DERECHO_SST_PORT = "DERECHO/sst_port";
+    static constexpr const char* DERECHO_RDMC_PORT = "DERECHO/rdmc_port";
+    static constexpr const char* DERECHO_EXTERNAL_PORT = "DERECHO/external_port";
+    static constexpr const char* DERECHO_HEARTBEAT_MS = "DERECHO/heartbeat_ms";
+    static constexpr const char* DERECHO_P2P_LOOP_BUSY_WAIT_BEFORE_SLEEP_MS = "DERECHO/p2p_loop_busy_wait_before_sleep_ms";
+    static constexpr const char* DERECHO_SST_POLL_CQ_TIMEOUT_MS = "DERECHO/sst_poll_cq_timeout_ms";
+    static constexpr const char* DERECHO_RESTART_TIMEOUT_MS = "DERECHO/restart_timeout_ms";
+    static constexpr const char* DERECHO_ENABLE_BACKUP_RESTART_LEADERS = "DERECHO/enable_backup_restart_leaders";
+    static constexpr const char* DERECHO_DISABLE_PARTITIONING_SAFETY = "DERECHO/disable_partitioning_safety";
+    static constexpr const char* DERECHO_MAX_NODE_ID = "DERECHO/max_node_id";
 
-#define CONF_DERECHO_MAX_P2P_REQUEST_PAYLOAD_SIZE "DERECHO/max_p2p_request_payload_size"
-#define CONF_DERECHO_MAX_P2P_REPLY_PAYLOAD_SIZE "DERECHO/max_p2p_reply_payload_size"
-#define CONF_DERECHO_P2P_WINDOW_SIZE "DERECHO/p2p_window_size"
+    static constexpr const char* DERECHO_MAX_P2P_REQUEST_PAYLOAD_SIZE = "DERECHO/max_p2p_request_payload_size";
+    static constexpr const char* DERECHO_MAX_P2P_REPLY_PAYLOAD_SIZE = "DERECHO/max_p2p_reply_payload_size";
+    static constexpr const char* DERECHO_P2P_WINDOW_SIZE = "DERECHO/p2p_window_size";
 
-#define CONF_SUBGROUP_DEFAULT_MAX_PAYLOAD_SIZE "SUBGROUP/DEFAULT/max_payload_size"
-#define CONF_SUBGROUP_DEFAULT_MAX_REPLY_PAYLOAD_SIZE "SUBGROUP/DEFAULT/max_reply_payload_size"
-#define CONF_SUBGROUP_DEFAULT_MAX_SMC_PAYLOAD_SIZE "SUBGROUP/DEFAULT/max_smc_payload_size"
-#define CONF_SUBGROUP_DEFAULT_BLOCK_SIZE "SUBGROUP/DEFAULT/block_size"
-#define CONF_SUBGROUP_DEFAULT_WINDOW_SIZE "SUBGROUP/DEFAULT/window_size"
-#define CONF_SUBGROUP_DEFAULT_RDMC_SEND_ALGORITHM "SUBGROUP/DEFAULT/rdmc_send_algorithm"
+    static constexpr const char* SUBGROUP_DEFAULT_MAX_PAYLOAD_SIZE = "SUBGROUP/DEFAULT/max_payload_size";
+    static constexpr const char* SUBGROUP_DEFAULT_MAX_REPLY_PAYLOAD_SIZE = "SUBGROUP/DEFAULT/max_reply_payload_size";
+    static constexpr const char* SUBGROUP_DEFAULT_MAX_SMC_PAYLOAD_SIZE = "SUBGROUP/DEFAULT/max_smc_payload_size";
+    static constexpr const char* SUBGROUP_DEFAULT_BLOCK_SIZE = "SUBGROUP/DEFAULT/block_size";
+    static constexpr const char* SUBGROUP_DEFAULT_WINDOW_SIZE = "SUBGROUP/DEFAULT/window_size";
+    static constexpr const char* SUBGROUP_DEFAULT_RDMC_SEND_ALGORITHM = "SUBGROUP/DEFAULT/rdmc_send_algorithm";
 
-#define CONF_RDMA_PROVIDER "RDMA/provider"
-#define CONF_RDMA_DOMAIN "RDMA/domain"
-#define CONF_RDMA_TX_DEPTH "RDMA/tx_depth"
-#define CONF_RDMA_RX_DEPTH "RDMA/rx_depth"
-#define CONF_PERS_FILE_PATH "PERS/file_path"
-#define CONF_PERS_RAMDISK_PATH "PERS/ramdisk_path"
-#define CONF_PERS_RESET "PERS/reset"
-#define CONF_PERS_MAX_LOG_ENTRY "PERS/max_log_entry"
-#define CONF_PERS_MAX_DATA_SIZE "PERS/max_data_size"
-#define CONF_PERS_PRIVATE_KEY_FILE "PERS/private_key_file"
-#define CONF_LOGGER_DEFAULT_LOG_NAME "LOGGER/default_log_name"
-#define CONF_LOGGER_DEFAULT_LOG_LEVEL "LOGGER/default_log_level"
-#define CONF_LOGGER_SST_LOG_LEVEL "LOGGER/sst_log_level"
-#define CONF_LOGGER_RPC_LOG_LEVEL "LOGGER/rpc_log_level"
-#define CONF_LOGGER_VIEWMANAGER_LOG_LEVEL "LOGGER/viewmanager_log_level"
-#define CONF_LOGGER_PERSISTENCE_LOG_LEVEL "LOGGER/persistence_log_level"
-#define CONF_LOGGER_LOG_TO_TERMINAL "LOGGER/log_to_terminal"
-#define CONF_LOGGER_LOG_FILE_DEPTH "LOGGER/log_file_depth"
+    static constexpr const char* RDMA_PROVIDER = "RDMA/provider";
+    static constexpr const char* RDMA_DOMAIN = "RDMA/domain";
+    static constexpr const char* RDMA_TX_DEPTH = "RDMA/tx_depth";
+    static constexpr const char* RDMA_RX_DEPTH = "RDMA/rx_depth";
+    static constexpr const char* PERS_FILE_PATH = "PERS/file_path";
+    static constexpr const char* PERS_RAMDISK_PATH = "PERS/ramdisk_path";
+    static constexpr const char* PERS_RESET = "PERS/reset";
+    static constexpr const char* PERS_MAX_LOG_ENTRY = "PERS/max_log_entry";
+    static constexpr const char* PERS_MAX_DATA_SIZE = "PERS/max_data_size";
+    static constexpr const char* PERS_PRIVATE_KEY_FILE = "PERS/private_key_file";
+    static constexpr const char* LOGGER_DEFAULT_LOG_NAME = "LOGGER/default_log_name";
+    static constexpr const char* LOGGER_DEFAULT_LOG_LEVEL = "LOGGER/default_log_level";
+    static constexpr const char* LOGGER_SST_LOG_LEVEL = "LOGGER/sst_log_level";
+    static constexpr const char* LOGGER_RPC_LOG_LEVEL = "LOGGER/rpc_log_level";
+    static constexpr const char* LOGGER_VIEWMANAGER_LOG_LEVEL = "LOGGER/viewmanager_log_level";
+    static constexpr const char* LOGGER_PERSISTENCE_LOG_LEVEL = "LOGGER/persistence_log_level";
+    static constexpr const char* LOGGER_LOG_TO_TERMINAL = "LOGGER/log_to_terminal";
+    static constexpr const char* LOGGER_LOG_FILE_DEPTH = "LOGGER/log_file_depth";
 
-#define CONF_LAYOUT_JSON_LAYOUT "LAYOUT/json_layout"
-#define CONF_LAYOUT_JSON_LAYOUT_FILE "LAYOUT/json_layout_file"
+    static constexpr const char* LAYOUT_JSON_LAYOUT = "LAYOUT/json_layout";
+    static constexpr const char* LAYOUT_JSON_LAYOUT_FILE = "LAYOUT/json_layout_file";
+
+private:
     // Configuration Table:
     // config name --> default value
     std::map<const std::string, std::string> config = {
             // [DERECHO]
-            {CONF_DERECHO_LEADER_IP, "127.0.0.1"},
-            {CONF_DERECHO_LEADER_GMS_PORT, "23580"},
-            {CONF_DERECHO_LEADER_EXTERNAL_PORT, "32645"},
-            {CONF_DERECHO_RESTART_LEADERS, "127.0.0.1"},
-            {CONF_DERECHO_RESTART_LEADER_PORTS, "23580"},
-            {CONF_DERECHO_LOCAL_ID, "0"},
-            {CONF_DERECHO_LOCAL_IP, "127.0.0.1"},
-            {CONF_DERECHO_GMS_PORT, "23580"},
-            {CONF_DERECHO_STATE_TRANSFER_PORT, "28366"},
-            {CONF_DERECHO_SST_PORT, "37683"},
-            {CONF_DERECHO_RDMC_PORT, "31675"},
-            {CONF_DERECHO_EXTERNAL_PORT, "32645"},
-            {CONF_SUBGROUP_DEFAULT_RDMC_SEND_ALGORITHM, "binomial_send"},
-            {CONF_DERECHO_P2P_LOOP_BUSY_WAIT_BEFORE_SLEEP_MS, "250"},
-            {CONF_DERECHO_SST_POLL_CQ_TIMEOUT_MS, "2000"},
-            {CONF_DERECHO_RESTART_TIMEOUT_MS, "2000"},
-            {CONF_DERECHO_DISABLE_PARTITIONING_SAFETY, "true"},
-            {CONF_DERECHO_ENABLE_BACKUP_RESTART_LEADERS, "false"},
-            {CONF_DERECHO_MAX_P2P_REQUEST_PAYLOAD_SIZE, "10240"},
-            {CONF_DERECHO_MAX_P2P_REPLY_PAYLOAD_SIZE, "10240"},
-            {CONF_DERECHO_P2P_WINDOW_SIZE, "16"},
-            {CONF_DERECHO_MAX_NODE_ID, "1024"},
+            {DERECHO_LEADER_IP, "127.0.0.1"},
+            {DERECHO_LEADER_GMS_PORT, "23580"},
+            {DERECHO_LEADER_EXTERNAL_PORT, "32645"},
+            {DERECHO_RESTART_LEADERS, "127.0.0.1"},
+            {DERECHO_RESTART_LEADER_PORTS, "23580"},
+            {DERECHO_LOCAL_ID, "0"},
+            {DERECHO_LOCAL_IP, "127.0.0.1"},
+            {DERECHO_GMS_PORT, "23580"},
+            {DERECHO_STATE_TRANSFER_PORT, "28366"},
+            {DERECHO_SST_PORT, "37683"},
+            {DERECHO_RDMC_PORT, "31675"},
+            {DERECHO_EXTERNAL_PORT, "32645"},
+            {SUBGROUP_DEFAULT_RDMC_SEND_ALGORITHM, "binomial_send"},
+            {DERECHO_P2P_LOOP_BUSY_WAIT_BEFORE_SLEEP_MS, "250"},
+            {DERECHO_SST_POLL_CQ_TIMEOUT_MS, "2000"},
+            {DERECHO_RESTART_TIMEOUT_MS, "2000"},
+            {DERECHO_DISABLE_PARTITIONING_SAFETY, "true"},
+            {DERECHO_ENABLE_BACKUP_RESTART_LEADERS, "false"},
+            {DERECHO_MAX_P2P_REQUEST_PAYLOAD_SIZE, "10240"},
+            {DERECHO_MAX_P2P_REPLY_PAYLOAD_SIZE, "10240"},
+            {DERECHO_P2P_WINDOW_SIZE, "16"},
+            {DERECHO_MAX_NODE_ID, "1024"},
             // [SUBGROUP/<subgroupname>]
-            {CONF_SUBGROUP_DEFAULT_MAX_PAYLOAD_SIZE, "10240"},
-            {CONF_SUBGROUP_DEFAULT_MAX_REPLY_PAYLOAD_SIZE, "10240"},
-            {CONF_SUBGROUP_DEFAULT_MAX_SMC_PAYLOAD_SIZE, "10240"},
-            {CONF_SUBGROUP_DEFAULT_BLOCK_SIZE, "1048576"},
-            {CONF_SUBGROUP_DEFAULT_WINDOW_SIZE, "16"},
-            {CONF_DERECHO_HEARTBEAT_MS, "1"},
+            {SUBGROUP_DEFAULT_MAX_PAYLOAD_SIZE, "10240"},
+            {SUBGROUP_DEFAULT_MAX_REPLY_PAYLOAD_SIZE, "10240"},
+            {SUBGROUP_DEFAULT_MAX_SMC_PAYLOAD_SIZE, "10240"},
+            {SUBGROUP_DEFAULT_BLOCK_SIZE, "1048576"},
+            {SUBGROUP_DEFAULT_WINDOW_SIZE, "16"},
+            {DERECHO_HEARTBEAT_MS, "1"},
             // [RDMA]
-            {CONF_RDMA_PROVIDER, "sockets"},
-            {CONF_RDMA_DOMAIN, "eth0"},
-            {CONF_RDMA_TX_DEPTH, "256"},
-            {CONF_RDMA_RX_DEPTH, "256"},
+            {RDMA_PROVIDER, "sockets"},
+            {RDMA_DOMAIN, "eth0"},
+            {RDMA_TX_DEPTH, "256"},
+            {RDMA_RX_DEPTH, "256"},
             // [PERS]
-            {CONF_PERS_FILE_PATH, ".plog"},
-            {CONF_PERS_RAMDISK_PATH, "/dev/shm/volatile_t"},
-            {CONF_PERS_RESET, "false"},
-            {CONF_PERS_MAX_LOG_ENTRY, "1048576"},       // 1M log entries.
-            {CONF_PERS_MAX_DATA_SIZE, "549755813888"},  // 512G total data size.
-            {CONF_PERS_PRIVATE_KEY_FILE, "private_key.pem"},
+            {PERS_FILE_PATH, ".plog"},
+            {PERS_RAMDISK_PATH, "/dev/shm/volatile_t"},
+            {PERS_RESET, "false"},
+            {PERS_MAX_LOG_ENTRY, "1048576"},       // 1M log entries.
+            {PERS_MAX_DATA_SIZE, "549755813888"},  // 512G total data size.
+            {PERS_PRIVATE_KEY_FILE, "private_key.pem"},
             // [LOGGER]
-            {CONF_LOGGER_DEFAULT_LOG_NAME, "derecho_debug"},
-            {CONF_LOGGER_DEFAULT_LOG_LEVEL, "info"},
-            {CONF_LOGGER_LOG_TO_TERMINAL, "true"},
-            {CONF_LOGGER_LOG_FILE_DEPTH, "3"}};
+            {LOGGER_DEFAULT_LOG_NAME, "derecho_debug"},
+            {LOGGER_DEFAULT_LOG_LEVEL, "info"},
+            {LOGGER_LOG_TO_TERMINAL, "true"},
+            {LOGGER_LOG_FILE_DEPTH, "3"}};
 
 public:
     // the option for parsing command line with getopt(not GetPot!!!)
     static struct option long_options[];
 
 public:
+    /**
+     * The name of the default configuration file that will be loaded if none is specified
+     */
+    static constexpr const char* default_conf_file = "derecho.cfg";
+
     /** Constructor:
    *  Conf can read configure from multiple sources
    *  - the command line argument has the highest priority, then,

--- a/include/derecho/conf/conf.hpp
+++ b/include/derecho/conf/conf.hpp
@@ -142,7 +142,7 @@ public:
    *  - the configuration files
    *  - the default values.
    **/
-    Conf(int argc, char* argv[], GetPot* getpotcfg = nullptr) noexcept(true) {
+    Conf(int argc, char* argv[], getpot::GetPot* getpotcfg = nullptr) noexcept(true) {
         // 1 - load configuration from configuration file
         if(getpotcfg != nullptr) {
             for(const std::string& key : getpotcfg->get_variable_names()) {

--- a/include/derecho/conf/getpot/GetPot.hpp
+++ b/include/derecho/conf/getpot/GetPot.hpp
@@ -43,7 +43,7 @@
     // GetPot in a particular namespace. Or, the definition of the macro
     // might also happen before including this file.
 
-    // #define GETPOT_SETTING_NAMESPACE GetPotSpace
+    #define GETPOT_SETTING_NAMESPACE getpot
 #endif
 
 /* Strings used by GetPot; Adaptation for Non-English may happen here. */

--- a/include/derecho/core/detail/group_impl.hpp
+++ b/include/derecho/core/detail/group_impl.hpp
@@ -173,7 +173,7 @@ Group<ReplicatedTypes...>::Group(const UserMessageCallbacks& callbacks,
                                  const std::vector<DeserializationContext*>& deserialization_context,
                                  std::vector<view_upcall_t> _view_upcalls,
                                  Factory<ReplicatedTypes>... factories)
-        : my_id(getConfUInt32(CONF_DERECHO_LOCAL_ID)),
+        : my_id(getConfUInt32(Conf::DERECHO_LOCAL_ID)),
           user_deserialization_context(deserialization_context),
           persistence_manager(objects_by_subgroup_id,
                               std::disjunction_v<has_signed_fields<ReplicatedTypes>...>,
@@ -230,7 +230,7 @@ Group<ReplicatedTypes...>::Group(const UserMessageCallbacks& callbacks,
             // This will wait for a new view to be sent if the view was aborted
             // It must be called even in the non-restart case, since the initial view could still be aborted
             view_manager.check_view_committed(initial_view_confirmed, restart_leader_failed);
-            if(restart_leader_failed && !(in_total_restart && getConfBoolean(CONF_DERECHO_ENABLE_BACKUP_RESTART_LEADERS))) {
+            if(restart_leader_failed && !(in_total_restart && getConfBoolean(Conf::DERECHO_ENABLE_BACKUP_RESTART_LEADERS))) {
                 throw derecho_exception("Leader crashed before it could send the initial View! Try joining again at the new leader.");
             }
         }

--- a/include/derecho/core/detail/multicast_group.hpp
+++ b/include/derecho/core/detail/multicast_group.hpp
@@ -148,9 +148,9 @@ struct DerechoParams : public mutils::ByteRepresentable {
         uint64_t max_smc_payload_size = getConfUInt64(prefix + Conf::subgroupProfileFields[2]);
         uint64_t block_size = getConfUInt64(prefix + Conf::subgroupProfileFields[3]);
         uint32_t window_size = getConfUInt32(prefix + Conf::subgroupProfileFields[4]);
-        uint32_t timeout_ms = getConfUInt32(CONF_DERECHO_HEARTBEAT_MS);
+        uint32_t timeout_ms = getConfUInt32(Conf::DERECHO_HEARTBEAT_MS);
         const std::string& algorithm = getConfString(prefix + Conf::subgroupProfileFields[5]);
-        uint32_t state_transfer_port = getConfUInt32(CONF_DERECHO_STATE_TRANSFER_PORT);
+        uint32_t state_transfer_port = getConfUInt32(Conf::DERECHO_STATE_TRANSFER_PORT);
 
         return DerechoParams{
                 max_payload_size,

--- a/include/derecho/core/detail/replicated_impl.hpp
+++ b/include/derecho/core/detail/replicated_impl.hpp
@@ -37,7 +37,7 @@ Replicated<T>::Replicated(subgroup_type_id_t type_id, node_id_t nid, subgroup_id
     if constexpr(has_signed_fields_v<T>) {
         // Attempt to load the private key and create a Signer
         // This will crash with a file_error if the private key doesn't actually exist
-        signer = std::make_unique<openssl::Signer>(openssl::EnvelopeKey::from_pem_private(getConfString(CONF_PERS_PRIVATE_KEY_FILE)),
+        signer = std::make_unique<openssl::Signer>(openssl::EnvelopeKey::from_pem_private(getConfString(Conf::PERS_PRIVATE_KEY_FILE)),
                                                    openssl::DigestAlgorithm::SHA256);
         signature_size = signer->get_max_signature_size();
     }
@@ -64,7 +64,7 @@ Replicated<T>::Replicated(subgroup_type_id_t type_id, node_id_t nid, subgroup_id
     if constexpr(has_signed_fields_v<T>) {
         // Attempt to load the private key and create a Signer
         // This will crash with a file_error if the private key doesn't actually exist
-        signer = std::make_unique<openssl::Signer>(openssl::EnvelopeKey::from_pem_private(getConfString(CONF_PERS_PRIVATE_KEY_FILE)),
+        signer = std::make_unique<openssl::Signer>(openssl::EnvelopeKey::from_pem_private(getConfString(Conf::PERS_PRIVATE_KEY_FILE)),
                                                    openssl::DigestAlgorithm::SHA256);
         signature_size = signer->get_max_signature_size();
     }
@@ -106,7 +106,7 @@ auto Replicated<T>::p2p_send(node_id_t dest_node, Args&&... args) const {
         auto return_pair = wrapped_this->template send<rpc::to_internal_tag<true>(tag)>(
                 // Invoke the sending function with a buffer-allocator that uses the P2P request buffers
                 [this, &dest_node, &message_seq_num](std::size_t size) -> uint8_t* {
-                    const std::size_t max_p2p_request_payload_size = getConfUInt64(CONF_DERECHO_MAX_P2P_REQUEST_PAYLOAD_SIZE);
+                    const std::size_t max_p2p_request_payload_size = getConfUInt64(Conf::DERECHO_MAX_P2P_REQUEST_PAYLOAD_SIZE);
                     if(size <= max_p2p_request_payload_size) {
                         auto buffer_handle = group_rpc_manager.get_sendbuffer_ptr(dest_node,
                                                                                   sst::MESSAGE_TYPE::P2P_REQUEST);
@@ -398,7 +398,7 @@ auto ExternalClientCallback<T>::p2p_send(node_id_t dest_node, Args&&... args) {
         uint64_t message_seq_num;
         auto return_pair = wrapped_this->template send<rpc::to_internal_tag<true>(tag)>(
                 [this, &dest_node, &message_seq_num](size_t size) -> uint8_t* {
-                    const std::size_t max_payload_size = getConfUInt64(CONF_DERECHO_MAX_P2P_REQUEST_PAYLOAD_SIZE);
+                    const std::size_t max_payload_size = getConfUInt64(Conf::DERECHO_MAX_P2P_REQUEST_PAYLOAD_SIZE);
                     if(size <= max_payload_size) {
                         auto buffer_handle = group_rpc_manager.get_sendbuffer_ptr(dest_node,
                                                                                   sst::MESSAGE_TYPE::P2P_REQUEST);

--- a/include/derecho/core/external_group.hpp
+++ b/include/derecho/core/external_group.hpp
@@ -138,7 +138,7 @@ private:
 
     /**
      * requests a new view from group member nid
-     * if nid is -1, then request a view from CONF_DERECHO_LEADER_IP
+     * if nid is -1, then request a view from Conf::DERECHO_LEADER_IP
      * defined in derecho.cfg
      */
     bool get_view(const node_id_t nid);

--- a/include/derecho/persistent/detail/FilePersistLog.hpp
+++ b/include/derecho/persistent/detail/FilePersistLog.hpp
@@ -56,8 +56,8 @@ union LogEntry {
 // Currently, we allow 1M(2^20-1) log entries and
 // 512GB data size. The max log entry and max size are
 // both from the configuration file:
-// CONF_PERS_MAX_LOG_ENTRY - "PERS/max_log_entry"
-// CONF_PERS_MAX_DATA_SIZE - "PERS/max_data_size"
+// Conf::PERS_MAX_LOG_ENTRY - "PERS/max_log_entry"
+// Conf::PERS_MAX_DATA_SIZE - "PERS/max_data_size"
 #define MAX_LOG_ENTRY (this->m_iMaxLogEntry)
 #define MAX_LOG_SIZE (sizeof(LogEntry) * MAX_LOG_ENTRY)
 #define MAX_DATA_SIZE (this->m_iMaxDataSize)

--- a/include/derecho/persistent/detail/PersistNoLog_impl.hpp
+++ b/include/derecho/persistent/detail/PersistNoLog_impl.hpp
@@ -50,7 +50,7 @@ std::unique_ptr<ObjectType> loadNoLogObjectFromFile(
     sprintf(filepath, "%s/%d-%s-nolog", _NOLOG_OBJECT_DIR_, storageType, _NOLOG_OBJECT_NAME_);
 
     // 0.5 - object file
-    if(derecho::getConfBoolean(CONF_PERS_RESET)) {
+    if(derecho::getConfBoolean(derecho::Conf::PERS_RESET)) {
         if(fs::exists(filepath)) {
             if(!fs::remove(filepath)) {
                 dbg_error(PersistLogger::get(), "{} loadNoLogObjectFromFile failed to remove file {}.", _NOLOG_OBJECT_NAME_, filepath);

--- a/include/derecho/persistent/detail/util.hpp
+++ b/include/derecho/persistent/detail/util.hpp
@@ -27,14 +27,14 @@
 // #define DEFAULT_FILE_PERSIST_PATH (".plog")
 // #define DEFAULT_RAMDISK_PATH ("/dev/shm/volatile_t")
 inline std::string getPersRamdiskPath() {
-    std::string path = derecho::getConfString(CONF_PERS_RAMDISK_PATH);
+    std::string path = derecho::getConfString(derecho::Conf::PERS_RAMDISK_PATH);
     std::stringstream pid_ss;
     pid_ss << getpid();
     return path + pid_ss.str();
 }
 
 inline std::string getPersFilePath() {
-    return std::string(derecho::getConfString(CONF_PERS_FILE_PATH));
+    return std::string(derecho::getConfString(derecho::Conf::PERS_FILE_PATH));
 }
 
 // verify the existence of a folder

--- a/include/derecho/sst/sst.hpp
+++ b/include/derecho/sst/sst.hpp
@@ -236,7 +236,7 @@ public:
     SST(DerivedSST* derived_class_pointer, const SSTParams& params)
             : derived_this(derived_class_pointer),
               thread_shutdown(false),
-              poll_cq_timeout_ms(derecho::getConfUInt32(CONF_DERECHO_SST_POLL_CQ_TIMEOUT_MS)),
+              poll_cq_timeout_ms(derecho::getConfUInt32(derecho::Conf::DERECHO_SST_POLL_CQ_TIMEOUT_MS)),
               members(params.members),
               num_members(members.size()),
               all_indices(num_members),

--- a/src/applications/archive/external_client_perf_test.cpp
+++ b/src/applications/archive/external_client_perf_test.cpp
@@ -38,7 +38,7 @@ int main(int argc, char** argv) {
     const uint is_external = std::stoi(argv[argc-4]);
     const uint is_sender = std::stoi(argv[argc-3]);
     int num_of_nodes = std::stoi(argv[argc-2]);
-    uint64_t max_msg_size = derecho::getConfUInt64(CONF_SUBGROUP_DEFAULT_MAX_PAYLOAD_SIZE);
+    uint64_t max_msg_size = derecho::getConfUInt64(derecho::Conf::SUBGROUP_DEFAULT_MAX_PAYLOAD_SIZE);
     const uint count = std::stoi(argv[argc-1]);
 
     if (!is_external) {

--- a/src/applications/archive/initialize.cpp
+++ b/src/applications/archive/initialize.cpp
@@ -24,13 +24,13 @@ std::string read_string(socket& s) {
 std::map<uint32_t, std::pair<ip_addr_t, uint16_t>> initialize(const uint32_t num_nodes) {
     // Get conf file parameters
     // Global information
-    const std::string leader_ip = getConfString(CONF_DERECHO_LEADER_IP);
-    const uint16_t leader_gms_port = getConfUInt16(CONF_DERECHO_LEADER_GMS_PORT);
+    const std::string leader_ip = getConfString(Conf::DERECHO_LEADER_IP);
+    const uint16_t leader_gms_port = getConfUInt16(Conf::DERECHO_LEADER_GMS_PORT);
     // Local information
-    const uint32_t local_id = getConfUInt32(CONF_DERECHO_LOCAL_ID);
-    const std::string local_ip = getConfString(CONF_DERECHO_LOCAL_IP);
-    const uint16_t sst_port = getConfUInt16(CONF_DERECHO_SST_PORT);
-    const uint16_t gms_port = getConfUInt16(CONF_DERECHO_GMS_PORT);
+    const uint32_t local_id = getConfUInt32(Conf::DERECHO_LOCAL_ID);
+    const std::string local_ip = getConfString(Conf::DERECHO_LOCAL_IP);
+    const uint16_t sst_port = getConfUInt16(Conf::DERECHO_SST_PORT);
+    const uint16_t gms_port = getConfUInt16(Conf::DERECHO_GMS_PORT);
 
     bool is_leader = (leader_ip == local_ip && leader_gms_port == gms_port);
 

--- a/src/applications/archive/long_subgroup_test.cpp
+++ b/src/applications/archive/long_subgroup_test.cpp
@@ -55,7 +55,7 @@ int main(int argc, char** argv) {
 
     cout << "Finished constructing/joining Group" << endl;
 
-    const uint32_t my_id = derecho::getConfUInt32(CONF_DERECHO_LOCAL_ID);
+    const uint32_t my_id = derecho::getConfUInt32(derecho::Conf::DERECHO_LOCAL_ID);
     std::vector<node_id_t> foo_members = group.get_subgroup_members<Foo>(0)[0];
     std::vector<node_id_t> cache_members = group.get_subgroup_members<Cache>(0)[0];
     auto find_in_foo_results = std::find(foo_members.begin(), foo_members.end(), my_id);

--- a/src/applications/archive/membership_tests.cpp
+++ b/src/applications/archive/membership_tests.cpp
@@ -194,7 +194,7 @@ int main(int argc, char* argv[]) {
     Conf::initialize(argc, argv);
 
     srand(time(NULL));
-    node_id_t my_id = getConfUInt32(CONF_DERECHO_LOCAL_ID);
+    node_id_t my_id = getConfUInt32(Conf::DERECHO_LOCAL_ID);
 
     auto state_membership_function = [&tests](
             const std::vector<std::type_index>& subgroup_type_order,

--- a/src/applications/archive/multicast_latency.cpp
+++ b/src/applications/archive/multicast_latency.cpp
@@ -36,7 +36,7 @@ int main(int argc, char* argv[]) {
     uint32_t num_nodes = atoi(argv[1]);
     uint32_t window_size = atoi(argv[2]);
     int num_senders_selector = atoi(argv[3]);
-    const uint32_t node_id = derecho::getConfUInt32(CONF_DERECHO_LOCAL_ID);
+    const uint32_t node_id = derecho::getConfUInt32(derecho::Conf::DERECHO_LOCAL_ID);
     const std::map<uint32_t, std::pair<ip_addr_t, uint16_t>> ip_addrs_and_ports = initialize(num_nodes);
 
     // initialize the rdma resources

--- a/src/applications/archive/multicast_throughput.cpp
+++ b/src/applications/archive/multicast_throughput.cpp
@@ -48,7 +48,7 @@ int main(int argc, char* argv[]) {
     uint32_t num_nodes = atoi(argv[1]);
     uint32_t window_size = atoi(argv[2]);
     int num_senders_selector = atoi(argv[3]);
-    const uint32_t node_id = derecho::getConfUInt32(CONF_DERECHO_LOCAL_ID);
+    const uint32_t node_id = derecho::getConfUInt32(derecho::Conf::DERECHO_LOCAL_ID);
     const std::map<uint32_t, std::pair<ip_addr_t, uint16_t>> ip_addrs_and_ports = initialize(num_nodes);
 
     // initialize the rdma resources

--- a/src/applications/archive/notification_test.cpp
+++ b/src/applications/archive/notification_test.cpp
@@ -55,9 +55,9 @@ int main(int argc, char** argv) {
     const uint is_external = std::stoi(argv[argc-4]);
     const uint is_sender = std::stoi(argv[argc-3]);
     int num_of_nodes = std::stoi(argv[argc-2]);
-    uint64_t max_msg_size = derecho::getConfUInt64(CONF_SUBGROUP_DEFAULT_MAX_PAYLOAD_SIZE);
+    uint64_t max_msg_size = derecho::getConfUInt64(derecho::Conf::SUBGROUP_DEFAULT_MAX_PAYLOAD_SIZE);
     const uint count = std::stoi(argv[argc-1]);
-    node_id_t my_id = derecho::getConfUInt64(CONF_DERECHO_LOCAL_ID);
+    node_id_t my_id = derecho::getConfUInt64(derecho::Conf::DERECHO_LOCAL_ID);
 
     if (!is_external) {
         derecho::SubgroupInfo subgroup_info{[num_of_nodes](

--- a/src/applications/archive/objstore.cpp
+++ b/src/applications/archive/objstore.cpp
@@ -179,8 +179,8 @@ public:
 typedef OSObject * POSObject;
 OSObject **g_objs = nullptr;
 void initialize_objects(uint32_t num_of_objs) {
-  uint64_t max_msg_size = derecho::getConfUInt64(CONF_SUBGROUP_DEFAULT_MAX_PAYLOAD_SIZE);
-  uint32_t node_id = derecho::getConfUInt32(CONF_DERECHO_LOCAL_ID);
+  uint64_t max_msg_size = derecho::getConfUInt64(derecho::Conf::SUBGROUP_DEFAULT_MAX_PAYLOAD_SIZE);
+  uint32_t node_id = derecho::getConfUInt32(derecho::Conf::DERECHO_LOCAL_ID);
   // We just reserved 128 bytes for the message header and serialization.
 #define VALUE_SIZE(x) ((x) - 128)
   uint8_t default_value[VALUE_SIZE(max_msg_size)];
@@ -207,7 +207,7 @@ int main(int argc, char* argv[]) {
     // create the key-value array
     initialize_objects(num_of_objs);
 
-    uint64_t max_msg_size = derecho::getConfUInt64(CONF_SUBGROUP_DEFAULT_MAX_PAYLOAD_SIZE);
+    uint64_t max_msg_size = derecho::getConfUInt64(derecho::Conf::SUBGROUP_DEFAULT_MAX_PAYLOAD_SIZE);
     uint64_t total_num_messages = num_of_nodes * num_of_objs;
     struct timespec t_start,t_end;
     std::atomic<bool> bReady = false;

--- a/src/applications/archive/persistent_rejoin_test.cpp
+++ b/src/applications/archive/persistent_rejoin_test.cpp
@@ -81,7 +81,7 @@ int main(int argc, char** argv) {
                                           thing_factory);
     std::cout << "Successfully joined group" << std::endl;
     Replicated<PersistentThing>& thing_handle = group.get_subgroup<PersistentThing>();
-    const uint32_t node_id = derecho::getConfUInt32(CONF_DERECHO_LOCAL_ID);
+    const uint32_t node_id = derecho::getConfUInt32(derecho::Conf::DERECHO_LOCAL_ID);
     //Node 3 will rejoin as node 4
     if(node_id == 4) {
         std::cout << "Printing initial Persistent log" << std::endl;

--- a/src/applications/archive/persistent_temporal_send_test.cpp
+++ b/src/applications/archive/persistent_temporal_send_test.cpp
@@ -173,7 +173,7 @@ int main(int argc, char* argv[]) {
     int qcnt = atoi(argv[5]);
     uint64_t si_us = (1000000l / ops_per_sec);
 
-    int msg_size = derecho::getConfUInt64(CONF_SUBGROUP_DEFAULT_MAX_PAYLOAD_SIZE);
+    int msg_size = derecho::getConfUInt64(derecho::Conf::SUBGROUP_DEFAULT_MAX_PAYLOAD_SIZE);
 
     derecho::SubgroupInfo subgroup_info{[shard_size, num_of_shards, num_of_nodes](
                                                 const std::vector<std::type_index>& subgroup_type_order,

--- a/src/applications/archive/persistent_temporal_stability_test.cpp
+++ b/src/applications/archive/persistent_temporal_stability_test.cpp
@@ -56,7 +56,7 @@ int main(int argc, char *argv[]) {
     int count = atoi(argv[3]);
     int max_ops = atoi(argv[4]);
     uint64_t si_us = (1000000l / max_ops);
-    int msg_size = derecho::getConfUInt64(CONF_SUBGROUP_DEFAULT_MAX_PAYLOAD_SIZE);
+    int msg_size = derecho::getConfUInt64(derecho::Conf::SUBGROUP_DEFAULT_MAX_PAYLOAD_SIZE);
 
     bool is_sending = true;
 

--- a/src/applications/archive/rdma_for_ml.cpp
+++ b/src/applications/archive/rdma_for_ml.cpp
@@ -51,7 +51,7 @@ int main(int argc, char* argv[]) {
     const uint32_t num_nodes = std::stoi(argv[1]);
     const uint32_t num_params = std::stoi(argv[1]);
 
-    uint32_t my_id = getConfUInt32(CONF_DERECHO_LOCAL_ID);
+    uint32_t my_id = getConfUInt32(Conf::DERECHO_LOCAL_ID);
 
     // input the ip addresses
     std::map<uint32_t, std::pair<std::string, uint16_t>> ip_addrs_and_ports;

--- a/src/applications/archive/subgroup_scaling_test.cpp
+++ b/src/applications/archive/subgroup_scaling_test.cpp
@@ -60,10 +60,10 @@ int main(int argc, char *argv[]) {
 
         Conf::initialize(argc, argv);
 
-        uint64_t max_msg_size = getConfUInt64(CONF_SUBGROUP_DEFAULT_MAX_PAYLOAD_SIZE);
+        uint64_t max_msg_size = getConfUInt64(derecho::Conf::SUBGROUP_DEFAULT_MAX_PAYLOAD_SIZE);
         uint32_t num_messages = ((max_msg_size < 20000) ? 10000 : 1000);
 
-        uint32_t node_id = getConfUInt32(CONF_DERECHO_LOCAL_ID);
+        uint32_t node_id = getConfUInt32(derecho::Conf::DERECHO_LOCAL_ID);
 
         // will resize it as and when convenient
         uint32_t subgroup_size = std::stoi(argv[2]);

--- a/src/applications/archive/subgroup_test.cpp
+++ b/src/applications/archive/subgroup_test.cpp
@@ -96,7 +96,7 @@ int main(int argc, char* argv[]) {
     }
 
     uint32_t my_subgroup_num;
-    const node_id_t node_id = derecho::getConfUInt32(CONF_DERECHO_LOCAL_ID);
+    const node_id_t node_id = derecho::getConfUInt32(derecho::Conf::DERECHO_LOCAL_ID);
     if(node_id < 3) {
         my_subgroup_num = 0;
     } else if(node_id >= 3 && node_id < 6) {
@@ -107,7 +107,7 @@ int main(int argc, char* argv[]) {
     // all are senders except node id's 1 and 2 in shard 0 and nodes >= 9
     if(node_id != 1 && node_id != 2 && node_id <= 8) {
         // random message size between 1 and 100
-        long long unsigned int max_msg_size = derecho::getConfUInt64(CONF_SUBGROUP_DEFAULT_MAX_PAYLOAD_SIZE);
+        long long unsigned int max_msg_size = derecho::getConfUInt64(derecho::Conf::SUBGROUP_DEFAULT_MAX_PAYLOAD_SIZE);
         unsigned int msg_size = (rand() % 7 + 2) * (max_msg_size / 10);
         derecho::Replicated<RawObject>& subgroup_handle = managed_group.get_subgroup<RawObject>(my_subgroup_num);
         for(int i = 0; i < num_messages; ++i) {

--- a/src/applications/archive/volatile_temporal_send_test.cpp
+++ b/src/applications/archive/volatile_temporal_send_test.cpp
@@ -173,7 +173,7 @@ int main(int argc, char *argv[]) {
     int min_dur_sec = atoi(argv[4]);
     int qcnt = atoi(argv[6]);
     uint64_t si_us = (1000000l / ops_per_sec);
-    int msg_size = derecho::getConfUInt64(CONF_SUBGROUP_DEFAULT_MAX_PAYLOAD_SIZE);
+    int msg_size = derecho::getConfUInt64(derecho::Conf::SUBGROUP_DEFAULT_MAX_PAYLOAD_SIZE);
 
     derecho::SubgroupInfo subgroup_info{[shard_size, num_of_shards, num_of_nodes](
             const std::vector<std::type_index>& subgroup_type_order,

--- a/src/applications/archive/volatile_temporal_stability_test.cpp
+++ b/src/applications/archive/volatile_temporal_stability_test.cpp
@@ -66,7 +66,7 @@ int main(int argc, char *argv[]) {
     if(strcmp(argv[1], "half") == 0) sender_selector = 1;
     if(strcmp(argv[1], "one") == 0) sender_selector = 2;
     int num_of_nodes = std::stoi(argv[2]);
-    int msg_size = derecho::getConfUInt64(CONF_SUBGROUP_DEFAULT_MAX_PAYLOAD_SIZE);
+    int msg_size = derecho::getConfUInt64(derecho::Conf::SUBGROUP_DEFAULT_MAX_PAYLOAD_SIZE);
     int count = std::stoi(argv[3]);
     int max_ops = std::stoi(argv[4]);
     uint64_t si_us = (1000000l / max_ops);

--- a/src/applications/archive/volatile_typed_subgroup_bw_test.cpp
+++ b/src/applications/archive/volatile_typed_subgroup_bw_test.cpp
@@ -57,7 +57,7 @@ int main(int argc, char* argv[]) {
     int count = atoi(argv[3]);
     struct timespec t1, t2, t3;
 
-    long long unsigned int max_msg_size = derecho::getConfUInt64(CONF_SUBGROUP_DEFAULT_MAX_PAYLOAD_SIZE) - 128;
+    long long unsigned int max_msg_size = derecho::getConfUInt64(derecho::Conf::SUBGROUP_DEFAULT_MAX_PAYLOAD_SIZE) - 128;
     bool is_sending = true;
     long total_num_messages;
     switch(sender_selector) {

--- a/src/applications/demos/overlapping_replicated_objects.cpp
+++ b/src/applications/demos/overlapping_replicated_objects.cpp
@@ -76,7 +76,7 @@ int main(int argc, char** argv) {
 
     cout << "Finished constructing/joining Group" << endl;
 
-    uint32_t my_id = derecho::getConfUInt32(CONF_DERECHO_LOCAL_ID);
+    uint32_t my_id = derecho::getConfUInt32(derecho::Conf::DERECHO_LOCAL_ID);
     //Now have each node send some updates to the Replicated objects
     //The code must be different depending on which subgroup this node is in,
     //which we can determine by attempting to locate its shard in each subgroup.

--- a/src/applications/demos/signed_store_mockup.cpp
+++ b/src/applications/demos/signed_store_mockup.cpp
@@ -244,7 +244,7 @@ int main(int argc, char** argv) {
     derecho::Conf::initialize(argc, argv);
     const std::size_t rpc_header_size = sizeof(std::size_t) + sizeof(std::size_t)
                                         + derecho::remote_invocation_utilities::header_space();
-    const std::size_t update_size = derecho::getConfUInt64(CONF_SUBGROUP_DEFAULT_MAX_PAYLOAD_SIZE) - rpc_header_size;
+    const std::size_t update_size = derecho::getConfUInt64(derecho::Conf::SUBGROUP_DEFAULT_MAX_PAYLOAD_SIZE) - rpc_header_size;
     //For generating random updates
     const std::string characters("abcdefghijklmnopqrstuvwxyz");
     std::mt19937 random_generator(getpid());
@@ -282,7 +282,7 @@ int main(int argc, char** argv) {
     int32_t my_client_shard = group.get_my_shard<ClientTier>();
     if(my_client_shard != -1) {
         std::cout << "Assigned the ClientTier role, in shard " << my_client_shard << std::endl;
-        uint32_t my_id = derecho::getConfUInt32(CONF_DERECHO_LOCAL_ID);
+        uint32_t my_id = derecho::getConfUInt32(derecho::Conf::DERECHO_LOCAL_ID);
         //Simulate getting a bunch of updates from a client and submitting them to the object store
         Blob test_update(nullptr, update_size);
         derecho::Replicated<ClientTier>& this_subgroup = group.get_subgroup<ClientTier>();

--- a/src/applications/demos/simple_replicated_objects.cpp
+++ b/src/applications/demos/simple_replicated_objects.cpp
@@ -47,7 +47,7 @@ int main(int argc, char** argv) {
 
     cout << "Finished constructing/joining Group" << endl;
 
-    uint32_t my_id = derecho::getConfUInt32(CONF_DERECHO_LOCAL_ID);
+    uint32_t my_id = derecho::getConfUInt32(derecho::Conf::DERECHO_LOCAL_ID);
     //Now have each node send some updates to the Replicated objects.
     //The code must be different depending on which subgroup this node is in,
     //which we can determine by attempting to locate its shard in each subgroup.

--- a/src/applications/demos/simple_replicated_objects_json.cpp
+++ b/src/applications/demos/simple_replicated_objects_json.cpp
@@ -49,7 +49,7 @@ int main(int argc, char** argv) {
 
     cout << "Finished constructing/joining Group" << endl;
 
-    uint32_t my_id = derecho::getConfUInt32(CONF_DERECHO_LOCAL_ID);
+    uint32_t my_id = derecho::getConfUInt32(derecho::Conf::DERECHO_LOCAL_ID);
     //Now have each node send some updates to the Replicated objects
     //The code must be different depending on which subgroup this node is in
     std::vector<uint32_t> my_foo_subgroups = group.get_my_subgroup_indexes<Foo>();

--- a/src/applications/demos/simple_replicated_objects_overlap.cpp
+++ b/src/applications/demos/simple_replicated_objects_overlap.cpp
@@ -24,7 +24,7 @@ int main(int argc, char** argv) {
     //This test assumes derecho.cfg specifies a JSON layout path to a file that allocates
     //Foo and Bar overlapping sets of node IDs.
     derecho::SubgroupInfo subgroup_function{derecho::make_subgroup_allocator<Foo, Bar>(
-            derecho::getConfString(CONF_LAYOUT_JSON_LAYOUT_FILE))};
+            derecho::getConfString(derecho::Conf::LAYOUT_JSON_LAYOUT_FILE))};
     //Each replicated type needs a factory; this can be used to supply constructor arguments
     //for the subgroup's initial state. These must take a PersistentRegistry* argument, but
     //in this case we ignore it because the replicated objects aren't persistent.
@@ -40,7 +40,7 @@ int main(int argc, char** argv) {
     //Now have each node send some updates to the Replicated objects
     //The code must be different depending on which subgroup this node is in,
     //which we can determine based on which membership list it appears in
-    uint32_t my_id = derecho::getConfUInt32(CONF_DERECHO_LOCAL_ID);
+    uint32_t my_id = derecho::getConfUInt32(derecho::Conf::DERECHO_LOCAL_ID);
     std::vector<node_id_t> foo_members = group.get_subgroup_members<Foo>(0)[0];
     std::vector<node_id_t> bar_members = group.get_subgroup_members<Bar>(0)[0];
     auto find_in_foo_results = std::find(foo_members.begin(), foo_members.end(), my_id);

--- a/src/applications/tests/performance_tests/bandwidth_test.cpp
+++ b/src/applications/tests/performance_tests/bandwidth_test.cpp
@@ -134,7 +134,7 @@ int main(int argc, char* argv[]) {
     auto members_order = group.get_members();
     uint32_t node_rank = group.get_my_rank();
 
-    long long unsigned int max_msg_size = getConfUInt64(CONF_SUBGROUP_DEFAULT_MAX_PAYLOAD_SIZE);
+    long long unsigned int max_msg_size = getConfUInt64(derecho::Conf::SUBGROUP_DEFAULT_MAX_PAYLOAD_SIZE);
 
     // this function sends all the messages
     auto send_all = [&]() {
@@ -180,7 +180,7 @@ int main(int argc, char* argv[]) {
     // log the result at the leader node
     if(node_rank == 0) {
         log_results(exp_result{num_nodes, num_senders_selector, max_msg_size,
-                               getConfUInt32(CONF_SUBGROUP_DEFAULT_WINDOW_SIZE), num_messages,
+                               getConfUInt32(derecho::Conf::SUBGROUP_DEFAULT_WINDOW_SIZE), num_messages,
                                delivery_mode, avg_bw},
                     "data_derecho_bw");
     }

--- a/src/applications/tests/performance_tests/deliver_predicate_delay.cpp
+++ b/src/applications/tests/performance_tests/deliver_predicate_delay.cpp
@@ -119,7 +119,7 @@ int main(int argc, char* argv[]) {
     auto members_order = group.get_members();
     uint32_t node_rank = group.get_my_rank();
 
-    long long unsigned int max_msg_size = getConfUInt64(CONF_SUBGROUP_DEFAULT_MAX_PAYLOAD_SIZE);
+    long long unsigned int max_msg_size = getConfUInt64(derecho::Conf::SUBGROUP_DEFAULT_MAX_PAYLOAD_SIZE);
 
     // this function sends all the messages
     auto send_all = [&]() {
@@ -154,7 +154,7 @@ int main(int argc, char* argv[]) {
     // log the result at the leader node
     if(node_rank == 0) {
         log_results(exp_result{num_nodes, wait_time, max_msg_size,
-                               getConfUInt32(CONF_SUBGROUP_DEFAULT_WINDOW_SIZE), num_messages,
+                               getConfUInt32(derecho::Conf::SUBGROUP_DEFAULT_WINDOW_SIZE), num_messages,
                                avg_bw},
                     "data_deliver_predicate_delay");
     }

--- a/src/applications/tests/performance_tests/latency_test.cpp
+++ b/src/applications/tests/performance_tests/latency_test.cpp
@@ -82,7 +82,7 @@ int main(int argc, char* argv[]) {
 
     // Read configurations from the command line options as well as the default config file
     Conf::initialize(argc, argv);
-    const uint64_t msg_size = getConfUInt64(CONF_SUBGROUP_DEFAULT_MAX_PAYLOAD_SIZE);
+    const uint64_t msg_size = getConfUInt64(Conf::SUBGROUP_DEFAULT_MAX_PAYLOAD_SIZE);
 
     // used by the sending nodes to track time of delivery of messages
     vector<struct timespec> start_times(num_messages), end_times(num_messages);
@@ -225,7 +225,7 @@ int main(int argc, char* argv[]) {
     // log the result at the leader node
     if(my_rank == 0) {
         log_results(exp_result{num_nodes, num_senders_selector, msg_size,
-                               getConfUInt32(CONF_SUBGROUP_DEFAULT_WINDOW_SIZE), num_messages,
+                               getConfUInt32(Conf::SUBGROUP_DEFAULT_WINDOW_SIZE), num_messages,
                                delivery_mode, avg_latency, avg_std_dev},
                     "data_latency");
     }

--- a/src/applications/tests/performance_tests/multiple_active_subgroups_test.cpp
+++ b/src/applications/tests/performance_tests/multiple_active_subgroups_test.cpp
@@ -102,7 +102,7 @@ int main(int argc, char* argv[]) {
     auto members_order = group.get_members();
     uint32_t node_rank = group.get_my_rank();
 
-    long long unsigned int max_msg_size = getConfUInt64(CONF_SUBGROUP_DEFAULT_MAX_PAYLOAD_SIZE);
+    long long unsigned int max_msg_size = getConfUInt64(Conf::SUBGROUP_DEFAULT_MAX_PAYLOAD_SIZE);
 
     // this function sends all the messages
     auto send_in_all_subgroups = [&]() {
@@ -136,7 +136,7 @@ int main(int argc, char* argv[]) {
     // log the result at the leader node
     if(node_rank == 0) {
         log_results(exp_result{num_nodes, max_msg_size,
-                               getConfUInt32(CONF_SUBGROUP_DEFAULT_WINDOW_SIZE),
+                               getConfUInt32(Conf::SUBGROUP_DEFAULT_WINDOW_SIZE),
                                num_messages,
                                num_subgroups,
                                avg_bw},

--- a/src/applications/tests/performance_tests/oob_perf.cpp
+++ b/src/applications/tests/performance_tests/oob_perf.cpp
@@ -1,7 +1,7 @@
 /**
  * @file oob_rdma.cpp
  *
- * This test creates one subgroup demonstrating OOB mechanism 
+ * This test creates one subgroup demonstrating OOB mechanism
  * - between external clients and a group member, and
  * - between derecho members
  */
@@ -66,7 +66,7 @@ public:
      * @param size          the size of the data
      *
      * @return true for success, otherwise false.
-     */ 
+     */
     bool get(const uint64_t& callee_addr, const uint64_t& caller_addr, const uint64_t rkey, const uint64_t size) const;
 
     /**
@@ -76,7 +76,7 @@ public:
     Bytes inband_get() const;
 
     // constructors
-    OOBRDMA(void* _oob_mr_ptr, size_t _oob_mr_size, size_t inband_data_size) : 
+    OOBRDMA(void* _oob_mr_ptr, size_t _oob_mr_size, size_t inband_data_size) :
         oob_mr_ptr(_oob_mr_ptr),
         oob_mr_size(_oob_mr_size) {
         uint8_t *buffer = new uint8_t[inband_data_size];
@@ -136,7 +136,7 @@ Bytes OOBRDMA::inband_get() const {
 
 bool OOBRDMA::get(const uint64_t& callee_addr, const uint64_t& caller_addr, const uint64_t rkey, const uint64_t size) const {
     // STEP 1 - validate the memory size
-    if( (callee_addr < reinterpret_cast<uint64_t>(oob_mr_ptr)) || 
+    if( (callee_addr < reinterpret_cast<uint64_t>(oob_mr_ptr)) ||
         ((callee_addr+size) > reinterpret_cast<uint64_t>(oob_mr_ptr) + oob_mr_size)) {
         std::cerr << "callee address:0x" << std::hex << callee_addr << " or size " << size << " is invalid." << std::dec << std::endl;
         return false;
@@ -153,11 +153,11 @@ bool OOBRDMA::get(const uint64_t& callee_addr, const uint64_t& caller_addr, cons
 template <typename P2PCaller>
 void perf_test (
         P2PCaller& p2p_caller,
-        node_id_t nid, 
-        uint64_t rkey, 
-        void* put_buffer_laddr, 
-        void* get_buffer_laddr, 
-        size_t oob_data_size, 
+        node_id_t nid,
+        uint64_t rkey,
+        void* put_buffer_laddr,
+        void* get_buffer_laddr,
+        size_t oob_data_size,
         size_t duration_sec,
         size_t nround = 1,
         bool   inband = false) {
@@ -169,8 +169,8 @@ void perf_test (
     uint64_t* ts_log = new uint64_t[MAX_OPS*duration_sec];
     const std::size_t rpc_header_size = sizeof(std::size_t) + sizeof(std::size_t) +
                                         derecho::remote_invocation_utilities::header_space();
-    const uint64_t max_rep_size = derecho::getConfUInt64(CONF_DERECHO_MAX_P2P_REPLY_PAYLOAD_SIZE) - rpc_header_size;
-    const uint64_t max_req_size   = derecho::getConfUInt64(CONF_DERECHO_MAX_P2P_REQUEST_PAYLOAD_SIZE) - rpc_header_size;
+    const uint64_t max_rep_size = derecho::getConfUInt64(derecho::Conf::DERECHO_MAX_P2P_REPLY_PAYLOAD_SIZE) - rpc_header_size;
+    const uint64_t max_req_size   = derecho::getConfUInt64(derecho::Conf::DERECHO_MAX_P2P_REQUEST_PAYLOAD_SIZE) - rpc_header_size;
     if (inband && (max_rep_size < oob_data_size)) {
         throw derecho::derecho_exception("max_reply_size (" + std::to_string(max_rep_size) + ") is smaller than data size(" + std::to_string(oob_data_size));
     }
@@ -348,23 +348,23 @@ int main(int argc, char** argv) {
     {
         // Read configurations from the command line options as well as the default config file
         derecho::Conf::initialize(argc, argv);
-    
+
         // Define subgroup member ship using the default subgroup allocator function.
         // When constructed using make_subgroup_allocator with no arguments, this will check the config file
         // for either the json_layout or json_layout_file options, and use whichever one is present to define
         // the mapping from types to subgroup allocation parameters.
         derecho::SubgroupInfo subgroup_function{derecho::make_subgroup_allocator<OOBRDMA>()};
-    
+
         // oobrdma_factory
         auto oobrdma_factory = [&oob_mr_ptr,&oob_mr_size,&oob_data_size](persistent::PersistentRegistry*, derecho::subgroup_id_t) {
             return std::make_unique<OOBRDMA>(oob_mr_ptr,oob_mr_size,oob_data_size);
         };
-    
+
         // group
-        derecho::Group<OOBRDMA> group(derecho::UserMessageCallbacks{}, subgroup_function, 
+        derecho::Group<OOBRDMA> group(derecho::UserMessageCallbacks{}, subgroup_function,
                                       {&dsm},
                                       std::vector<derecho::view_upcall_t>{}, oobrdma_factory);
-    
+
         std::cout << "Finished constructing/joining Group." << std::endl;
         memset(oob_mr_ptr,'A',oob_mr_size);
         group.register_oob_memory(oob_mr_ptr, oob_mr_size);

--- a/src/applications/tests/performance_tests/p2p_bw_test.cpp
+++ b/src/applications/tests/performance_tests/p2p_bw_test.cpp
@@ -82,7 +82,7 @@ int main(int argc, char* argv[]) {
                                         + derecho::remote_invocation_utilities::header_space();
 
     const uint32_t total_num_messages = std::stoi(argv[dashdash_pos + 1]);
-    const uint64_t max_msg_size = derecho::getConfUInt64(CONF_DERECHO_MAX_P2P_REPLY_PAYLOAD_SIZE) - rpc_header_size;
+    const uint64_t max_msg_size = derecho::getConfUInt64(derecho::Conf::DERECHO_MAX_P2P_REPLY_PAYLOAD_SIZE) - rpc_header_size;
 
     steady_clock::time_point begin_time, end_time;
 
@@ -131,7 +131,7 @@ int main(int argc, char* argv[]) {
         std::cout << std::flush;
 
         log_results(exp_result{max_msg_size,
-                               derecho::getConfUInt32(CONF_DERECHO_P2P_WINDOW_SIZE),
+                               derecho::getConfUInt32(derecho::Conf::DERECHO_P2P_WINDOW_SIZE),
                                total_num_messages,
                                msec, thp_gbps},
                     "data_derecho_p2p_bw");

--- a/src/applications/tests/performance_tests/persistent_bw_test.cpp
+++ b/src/applications/tests/performance_tests/persistent_bw_test.cpp
@@ -79,7 +79,7 @@ int main(int argc, char* argv[]) {
     if(strcmp(argv[dashdash_pos + 1], "half") == 0) sender_selector = PartialSendMode::HALF_SENDERS;
     if(strcmp(argv[dashdash_pos + 1], "one") == 0) sender_selector = PartialSendMode::ONE_SENDER;
     const int num_of_nodes = atoi(argv[dashdash_pos + 2]);
-    const int msg_size = derecho::getConfUInt64(CONF_SUBGROUP_DEFAULT_MAX_PAYLOAD_SIZE) - rpc_header_size;
+    const int msg_size = derecho::getConfUInt64(derecho::Conf::SUBGROUP_DEFAULT_MAX_PAYLOAD_SIZE) - rpc_header_size;
     const int num_msgs = atoi(argv[dashdash_pos + 3]);
 
     if((argc - dashdash_pos) > 4) {

--- a/src/applications/tests/performance_tests/persistent_latency_test.cpp
+++ b/src/applications/tests/performance_tests/persistent_latency_test.cpp
@@ -108,7 +108,7 @@ int main(int argc, char* argv[]) {
 
     const std::size_t rpc_header_size = sizeof(std::size_t) + sizeof(std::size_t)
                                         + derecho::remote_invocation_utilities::header_space();
-    uint64_t msg_size = derecho::getConfUInt64(CONF_SUBGROUP_DEFAULT_MAX_PAYLOAD_SIZE) - rpc_header_size;
+    uint64_t msg_size = derecho::getConfUInt64(derecho::Conf::SUBGROUP_DEFAULT_MAX_PAYLOAD_SIZE) - rpc_header_size;
 
     bool is_sending = true;
     uint32_t node_rank = -1;

--- a/src/applications/tests/performance_tests/sender_delay_test.cpp
+++ b/src/applications/tests/performance_tests/sender_delay_test.cpp
@@ -143,7 +143,7 @@ int main(int argc, char* argv[]) {
     auto members_order = group.get_members();
     uint32_t node_rank = group.get_my_rank();
 
-    long long unsigned int max_msg_size = getConfUInt64(CONF_SUBGROUP_DEFAULT_MAX_PAYLOAD_SIZE);
+    long long unsigned int max_msg_size = getConfUInt64(Conf::SUBGROUP_DEFAULT_MAX_PAYLOAD_SIZE);
 
     // this function sends all the messages
     auto send_fast = [&]() {
@@ -196,7 +196,7 @@ int main(int argc, char* argv[]) {
     // log the result at the leader node
     if(node_rank == 0) {
         log_results(exp_result{num_nodes, num_slow_senders_selector, max_msg_size,
-                               getConfUInt32(CONF_SUBGROUP_DEFAULT_WINDOW_SIZE), num_messages,
+                               getConfUInt32(Conf::SUBGROUP_DEFAULT_WINDOW_SIZE), num_messages,
                                wait_time, avg_bw},
                     "data_sender_delay_test");
     }

--- a/src/applications/tests/performance_tests/signed_bw_test.cpp
+++ b/src/applications/tests/performance_tests/signed_bw_test.cpp
@@ -85,7 +85,7 @@ int main(int argc, char* argv[]) {
     if(strcmp(argv[dashdash_pos + 1], "half") == 0) sender_selector = PartialSendMode::HALF_SENDERS;
     if(strcmp(argv[dashdash_pos + 1], "one") == 0) sender_selector = PartialSendMode::ONE_SENDER;
     const int num_of_nodes = atoi(argv[dashdash_pos + 2]);
-    const int msg_size = derecho::getConfUInt64(CONF_SUBGROUP_DEFAULT_MAX_PAYLOAD_SIZE) - rpc_header_size;
+    const int msg_size = derecho::getConfUInt64(derecho::Conf::SUBGROUP_DEFAULT_MAX_PAYLOAD_SIZE) - rpc_header_size;
     const int num_msgs = atoi(argv[dashdash_pos + 3]);
 
     if((argc - dashdash_pos) > 4) {

--- a/src/applications/tests/performance_tests/signed_store_test.cpp
+++ b/src/applications/tests/performance_tests/signed_store_test.cpp
@@ -350,7 +350,7 @@ int main(int argc, char** argv) {
     derecho::Conf::initialize(argc, argv);
     const std::size_t rpc_header_size = sizeof(std::size_t) + sizeof(std::size_t)
                                         + derecho::remote_invocation_utilities::header_space();
-    const std::size_t update_size = derecho::getConfUInt64(CONF_SUBGROUP_DEFAULT_MAX_PAYLOAD_SIZE) - rpc_header_size;
+    const std::size_t update_size = derecho::getConfUInt64(derecho::Conf::SUBGROUP_DEFAULT_MAX_PAYLOAD_SIZE) - rpc_header_size;
     steady_clock::time_point begin_time, batch_complete_time;
     //This atomic flag will be shared with the SignatureStore or ObjectStore subgroup,
     //if this node ends up in that group
@@ -386,7 +386,7 @@ int main(int argc, char** argv) {
             signature_subgroup_factory);
 
     //Figure out which subgroup this node got assigned to
-    uint32_t my_id = derecho::getConfUInt32(CONF_DERECHO_LOCAL_ID);
+    uint32_t my_id = derecho::getConfUInt32(derecho::Conf::DERECHO_LOCAL_ID);
     int32_t my_storage_shard = group.get_my_shard<ObjectStore>();
     int32_t my_signature_shard = group.get_my_shard<SignatureStore>();
     int32_t my_client_shard = group.get_my_shard<ClientTier>();

--- a/src/applications/tests/performance_tests/single_active_subgroup_test.cpp
+++ b/src/applications/tests/performance_tests/single_active_subgroup_test.cpp
@@ -97,7 +97,7 @@ int main(int argc, char* argv[]) {
     auto members_order = group.get_members();
     uint32_t node_rank = group.get_my_rank();
 
-    long long unsigned int max_msg_size = getConfUInt64(CONF_SUBGROUP_DEFAULT_MAX_PAYLOAD_SIZE);
+    long long unsigned int max_msg_size = getConfUInt64(Conf::SUBGROUP_DEFAULT_MAX_PAYLOAD_SIZE);
 
     // this function sends all the messages
     auto send_in_one_subgroup = [&]() {
@@ -128,7 +128,7 @@ int main(int argc, char* argv[]) {
     // log the result at the leader node
     if(node_rank == 0) {
         log_results(exp_result{num_nodes, max_msg_size,
-                               getConfUInt32(CONF_SUBGROUP_DEFAULT_WINDOW_SIZE),
+                               getConfUInt32(Conf::SUBGROUP_DEFAULT_WINDOW_SIZE),
                                num_messages,
                                num_subgroups,
                                avg_bw},

--- a/src/applications/tests/performance_tests/typed_subgroup_bw_test.cpp
+++ b/src/applications/tests/performance_tests/typed_subgroup_bw_test.cpp
@@ -83,7 +83,7 @@ int main(int argc, char* argv[]) {
                                         + derecho::remote_invocation_utilities::header_space();
 
     const int num_nodes = std::stoi(argv[dashdash_pos + 1]);
-    const uint64_t max_msg_size = derecho::getConfUInt64(CONF_SUBGROUP_DEFAULT_MAX_PAYLOAD_SIZE) - rpc_header_size;
+    const uint64_t max_msg_size = derecho::getConfUInt64(derecho::Conf::SUBGROUP_DEFAULT_MAX_PAYLOAD_SIZE) - rpc_header_size;
     const uint32_t count = std::stoi(argv[dashdash_pos + 2]);
     const uint32_t num_senders_selector = std::stoi(argv[dashdash_pos + 3]);
 
@@ -232,7 +232,7 @@ int main(int argc, char* argv[]) {
 
     if(node_rank == 0) {
         log_results(exp_result{num_nodes, num_senders_selector, max_msg_size,
-                               derecho::getConfUInt32(CONF_SUBGROUP_DEFAULT_WINDOW_SIZE), count,
+                               derecho::getConfUInt32(derecho::Conf::SUBGROUP_DEFAULT_WINDOW_SIZE), count,
                                avg_msec, avg_gbps},
                     "data_derecho_typed_subgroup_bw");
     }

--- a/src/applications/tests/unit_tests/client_callback_mockup.cpp
+++ b/src/applications/tests/unit_tests/client_callback_mockup.cpp
@@ -128,7 +128,7 @@ std::pair<persistent::version_t, uint64_t> InternalClientNode::submit_update(uin
     std::vector<std::vector<node_id_t>> storage_members = group->get_subgroup_members<StorageNode>();
 
     const node_id_t storage_node_to_contact = storage_members[0][0];
-    node_id_t my_id = derecho::getConfUInt32(CONF_DERECHO_LOCAL_ID);
+    node_id_t my_id = derecho::getConfUInt32(derecho::Conf::DERECHO_LOCAL_ID);
 
     //Submit the update to the chosen storage node
     dbg_default_debug("Submitting update number {} to node {}", update_counter, storage_node_to_contact);
@@ -392,7 +392,7 @@ int main(int argc, char** argv) {
     const std::size_t rpc_header_size = sizeof(std::size_t) + sizeof(std::size_t)
                                         + derecho::remote_invocation_utilities::header_space();
     //An update plus the two other parameters must fit in the available payload size
-    const std::size_t update_size = derecho::getConfUInt64(CONF_SUBGROUP_DEFAULT_MAX_PAYLOAD_SIZE)
+    const std::size_t update_size = derecho::getConfUInt64(derecho::Conf::SUBGROUP_DEFAULT_MAX_PAYLOAD_SIZE)
                                     - rpc_header_size - sizeof(node_id_t) - sizeof(uint32_t);
     //For generating random updates
     const std::string characters("abcdefghijklmnopqrstuvwxyz");
@@ -428,7 +428,7 @@ int main(int argc, char** argv) {
             storage_subgroup_factory);
 
     //Figure out which subgroup this node got assigned to
-    uint32_t my_id = derecho::getConfUInt32(CONF_DERECHO_LOCAL_ID);
+    uint32_t my_id = derecho::getConfUInt32(derecho::Conf::DERECHO_LOCAL_ID);
     std::vector<node_id_t> storage_members = group.get_subgroup_members<StorageNode>(0)[0];
     std::vector<std::vector<node_id_t>> client_tier_shards = group.get_subgroup_members<InternalClientNode>(0);
     if(member_of_shards(my_id, client_tier_shards)) {

--- a/src/applications/tests/unit_tests/cooked_send_test.cpp
+++ b/src/applications/tests/unit_tests/cooked_send_test.cpp
@@ -87,7 +87,7 @@ int main(int argc, char* argv[]) {
 
     cout << "Finished constructing/joining the group" << endl;
     auto group_members = group.get_members();
-    uint32_t my_id = getConfUInt32(CONF_DERECHO_LOCAL_ID);
+    uint32_t my_id = getConfUInt32(Conf::DERECHO_LOCAL_ID);
     uint32_t my_rank = -1;
     cout << "Members are" << endl;
     for(uint i = 0; i < group_members.size(); ++i) {
@@ -109,7 +109,7 @@ int main(int argc, char* argv[]) {
     while(!done) {
     }
     if(my_rank == 0) {
-        uint32_t max_msg_size = getConfUInt64(CONF_SUBGROUP_DEFAULT_MAX_PAYLOAD_SIZE);
+        uint32_t max_msg_size = getConfUInt64(Conf::SUBGROUP_DEFAULT_MAX_PAYLOAD_SIZE);
         uint32_t num_entries = max_msg_size / sizeof(pair<uint, uint>) - 50;
         if(num_entries < 0) {
             cout << "Error: Maximum message size too small!" << endl;

--- a/src/applications/tests/unit_tests/delivery_order_test.cpp
+++ b/src/applications/tests/unit_tests/delivery_order_test.cpp
@@ -33,7 +33,7 @@ int main(int argc, char* argv[]) {
 
     Conf::initialize(argc, argv);
 
-    uint32_t node_id = derecho::getConfUInt32(CONF_DERECHO_LOCAL_ID);
+    uint32_t node_id = derecho::getConfUInt32(Conf::DERECHO_LOCAL_ID);
 
     SubgroupInfo subgroup_info([num_nodes](const std::vector<std::type_index>& subgroup_type_order,
                                            const std::unique_ptr<derecho::View>& prev_view, derecho::View& curr_view) {
@@ -55,7 +55,7 @@ int main(int argc, char* argv[]) {
 
     std::unique_ptr<Group<RawObject>> group;
     uint32_t my_rank;
-    uint64_t max_msg_size = getConfUInt64(CONF_SUBGROUP_DEFAULT_MAX_PAYLOAD_SIZE);
+    uint64_t max_msg_size = getConfUInt64(Conf::SUBGROUP_DEFAULT_MAX_PAYLOAD_SIZE);
     volatile bool done = false;
     auto delivery_callback = [&, num_received_msgs_map = std::map<node_id_t, uint32_t>(),
                               received_msgs_index_map = std::map<node_id_t, uint32_t>(),

--- a/src/applications/tests/unit_tests/external_notification_test.cpp
+++ b/src/applications/tests/unit_tests/external_notification_test.cpp
@@ -87,8 +87,8 @@ bool TestPersistentObject::set_data(const std::string& new_data) const {
 }
 
 void run_nonpersistent_test(uint32_t external_node_id, int num_senders, int num_nodes, uint32_t num_messages) {
-    node_id_t my_id = derecho::getConfUInt64(CONF_DERECHO_LOCAL_ID);
-    uint64_t max_msg_size = derecho::getConfUInt64(CONF_SUBGROUP_DEFAULT_MAX_PAYLOAD_SIZE);
+    node_id_t my_id = derecho::getConfUInt64(derecho::Conf::DERECHO_LOCAL_ID);
+    uint64_t max_msg_size = derecho::getConfUInt64(derecho::Conf::SUBGROUP_DEFAULT_MAX_PAYLOAD_SIZE);
 
     if(external_node_id != my_id) {
         // Put each node in its own subgroup, which has 1 shard with 1 member
@@ -152,8 +152,8 @@ void run_nonpersistent_test(uint32_t external_node_id, int num_senders, int num_
 }
 
 void run_persistent_test(uint32_t external_node_id, int num_senders, int num_nodes, uint32_t num_messages) {
-    node_id_t my_id = derecho::getConfUInt64(CONF_DERECHO_LOCAL_ID);
-    uint64_t max_msg_size = derecho::getConfUInt64(CONF_SUBGROUP_DEFAULT_MAX_PAYLOAD_SIZE);
+    node_id_t my_id = derecho::getConfUInt64(derecho::Conf::DERECHO_LOCAL_ID);
+    uint64_t max_msg_size = derecho::getConfUInt64(derecho::Conf::SUBGROUP_DEFAULT_MAX_PAYLOAD_SIZE);
 
     if(external_node_id != my_id) {
         // Put each node in its own subgroup, which has 1 shard with 1 member

--- a/src/applications/tests/unit_tests/mixed_persistence_test.cpp
+++ b/src/applications/tests/unit_tests/mixed_persistence_test.cpp
@@ -137,7 +137,7 @@ int main(int argc, char** argv) {
         std::cout << "Last ordered_put got version " << last_version << ". Press enter to call to add_map_entry." << std::endl;
         std::cin.get();
         subgroup_handle.ordered_send<RPC_NAME(add_map_entry)>(
-                std::to_string(derecho::getConfUInt32(CONF_DERECHO_LOCAL_ID)) + "_last_version", last_version);
+                std::to_string(derecho::getConfUInt32(derecho::Conf::DERECHO_LOCAL_ID)) + "_last_version", last_version);
     }
     std::cout << "Press enter when finished with test." << std::endl;
     std::cin.get();

--- a/src/applications/tests/unit_tests/persistence_notification_test.cpp
+++ b/src/applications/tests/unit_tests/persistence_notification_test.cpp
@@ -207,7 +207,7 @@ int main(int argc, char** argv) {
     const std::size_t rpc_header_size = sizeof(std::size_t) + sizeof(std::size_t)
                                         + derecho::remote_invocation_utilities::header_space();
     //An update plus the two other parameters must fit in the available payload size
-    const std::size_t update_size = derecho::getConfUInt64(CONF_SUBGROUP_DEFAULT_MAX_PAYLOAD_SIZE)
+    const std::size_t update_size = derecho::getConfUInt64(derecho::Conf::SUBGROUP_DEFAULT_MAX_PAYLOAD_SIZE)
                                     - rpc_header_size - sizeof(node_id_t) - sizeof(uint32_t);
     //For generating random updates
     const std::string characters("abcdefghijklmnopqrstuvwxyz");
@@ -240,7 +240,7 @@ int main(int argc, char** argv) {
             {{std::type_index(typeid(StorageNode)),
               derecho::one_subgroup_policy(derecho::fixed_even_shards(1, num_storage_nodes))}}));
 
-    uint32_t my_id = derecho::getConfUInt32(CONF_DERECHO_LOCAL_ID);
+    uint32_t my_id = derecho::getConfUInt32(derecho::Conf::DERECHO_LOCAL_ID);
     if(external_node_id != my_id) {
         //Set up and join the group
         derecho::Group<StorageNode> group(subgroup_layout, storage_subgroup_factory);

--- a/src/applications/tests/unit_tests/rpc_function_types.cpp
+++ b/src/applications/tests/unit_tests/rpc_function_types.cpp
@@ -89,7 +89,7 @@ int main(int argc, char** argv) {
     derecho::Group<ConstTest, ReferenceTest, MapTest> group(derecho::UserMessageCallbacks{}, subgroup_function, {},
                                                             std::vector<derecho::view_upcall_t>{},
                                                             const_test_factory, reference_test_factory, map_test_factory);
-    int my_id = derecho::getConfInt32(CONF_DERECHO_LOCAL_ID);
+    int my_id = derecho::getConfInt32(derecho::Conf::DERECHO_LOCAL_ID);
     const std::vector<node_id_t> const_test_group_members = group.get_subgroup_members<ConstTest>()[0];
     bool in_const_test_group = std::find(const_test_group_members.begin(),
                                          const_test_group_members.end(), my_id)

--- a/src/applications/tests/unit_tests/rpc_reply_maps.cpp
+++ b/src/applications/tests/unit_tests/rpc_reply_maps.cpp
@@ -48,7 +48,7 @@ int main(int argc, char** argv) {
                                        std::vector<derecho::view_upcall_t>{},
                                        string_object_factory);
 
-    int my_id = derecho::getConfInt32(CONF_DERECHO_LOCAL_ID);
+    int my_id = derecho::getConfInt32(derecho::Conf::DERECHO_LOCAL_ID);
     derecho::Replicated<StringObject>& rpc_handle = group.get_subgroup<StringObject>();
 
     using namespace derecho::rpc;

--- a/src/applications/tests/unit_tests/signature_chain_test.cpp
+++ b/src/applications/tests/unit_tests/signature_chain_test.cpp
@@ -27,7 +27,7 @@ int main(int argc, char** argv) {
     Persistent<std::string> pers_field_1(std::make_unique<std::string>, "PersistentString", &registry, true);
     Persistent<int> pers_field_2(std::make_unique<int>, "PersistentInteger", &registry, true);
 
-    openssl::EnvelopeKey private_key = openssl::EnvelopeKey::from_pem_private(derecho::getConfString(CONF_PERS_PRIVATE_KEY_FILE));
+    openssl::EnvelopeKey private_key = openssl::EnvelopeKey::from_pem_private(derecho::getConfString(derecho::Conf::PERS_PRIVATE_KEY_FILE));
     openssl::Signer signer(private_key,openssl::DigestAlgorithm::SHA256);
     openssl::Verifier verifier(private_key, openssl::DigestAlgorithm::SHA256);
 

--- a/src/conf/conf.cpp
+++ b/src/conf/conf.cpp
@@ -103,9 +103,9 @@ void Conf::initialize(int argc, char* argv[], const char* conf_file) {
             real_conf_file.clear();
 
         // 2 - load configuration
-        GetPot* cfg = nullptr;
+        getpot::GetPot* cfg = nullptr;
         if(!real_conf_file.empty()) {
-            cfg = new GetPot(real_conf_file);
+            cfg = new getpot::GetPot(real_conf_file);
         }
         Conf::singleton = std::make_unique<Conf>(argc, argv, cfg);
         delete cfg;

--- a/src/conf/conf.cpp
+++ b/src/conf/conf.cpp
@@ -10,8 +10,6 @@
 
 namespace derecho {
 
-static const char* default_conf_file = "derecho.cfg";
-
 const std::vector<std::string> Conf::subgroupProfileFields = {
         "max_payload_size",
         "max_reply_payload_size",
@@ -31,57 +29,57 @@ std::atomic<uint32_t> Conf::singleton_initialized_flag = 0;
     { x, required_argument, 0, 0 }
 struct option Conf::long_options[] = {
         // [DERECHO]
-        MAKE_LONG_OPT_ENTRY(CONF_DERECHO_LEADER_IP),
-        MAKE_LONG_OPT_ENTRY(CONF_DERECHO_LEADER_GMS_PORT),
-        MAKE_LONG_OPT_ENTRY(CONF_DERECHO_LEADER_EXTERNAL_PORT),
-        MAKE_LONG_OPT_ENTRY(CONF_DERECHO_RESTART_LEADERS),
-        MAKE_LONG_OPT_ENTRY(CONF_DERECHO_RESTART_LEADER_PORTS),
-        MAKE_LONG_OPT_ENTRY(CONF_DERECHO_LOCAL_ID),
-        MAKE_LONG_OPT_ENTRY(CONF_DERECHO_LOCAL_IP),
-        MAKE_LONG_OPT_ENTRY(CONF_DERECHO_GMS_PORT),
-        MAKE_LONG_OPT_ENTRY(CONF_DERECHO_STATE_TRANSFER_PORT),
-        MAKE_LONG_OPT_ENTRY(CONF_DERECHO_SST_PORT),
-        MAKE_LONG_OPT_ENTRY(CONF_DERECHO_RDMC_PORT),
-        MAKE_LONG_OPT_ENTRY(CONF_DERECHO_EXTERNAL_PORT),
-        MAKE_LONG_OPT_ENTRY(CONF_DERECHO_P2P_LOOP_BUSY_WAIT_BEFORE_SLEEP_MS),
-        MAKE_LONG_OPT_ENTRY(CONF_DERECHO_HEARTBEAT_MS),
-        MAKE_LONG_OPT_ENTRY(CONF_DERECHO_SST_POLL_CQ_TIMEOUT_MS),
-        MAKE_LONG_OPT_ENTRY(CONF_DERECHO_RESTART_TIMEOUT_MS),
-        MAKE_LONG_OPT_ENTRY(CONF_DERECHO_ENABLE_BACKUP_RESTART_LEADERS),
-        MAKE_LONG_OPT_ENTRY(CONF_DERECHO_DISABLE_PARTITIONING_SAFETY),
-        MAKE_LONG_OPT_ENTRY(CONF_DERECHO_MAX_P2P_REQUEST_PAYLOAD_SIZE),
-        MAKE_LONG_OPT_ENTRY(CONF_DERECHO_MAX_P2P_REPLY_PAYLOAD_SIZE),
-        MAKE_LONG_OPT_ENTRY(CONF_DERECHO_P2P_WINDOW_SIZE),
-        MAKE_LONG_OPT_ENTRY(CONF_DERECHO_MAX_NODE_ID),
-        MAKE_LONG_OPT_ENTRY(CONF_LAYOUT_JSON_LAYOUT),
-        MAKE_LONG_OPT_ENTRY(CONF_LAYOUT_JSON_LAYOUT_FILE),
+        MAKE_LONG_OPT_ENTRY(DERECHO_LEADER_IP),
+        MAKE_LONG_OPT_ENTRY(DERECHO_LEADER_GMS_PORT),
+        MAKE_LONG_OPT_ENTRY(DERECHO_LEADER_EXTERNAL_PORT),
+        MAKE_LONG_OPT_ENTRY(DERECHO_RESTART_LEADERS),
+        MAKE_LONG_OPT_ENTRY(DERECHO_RESTART_LEADER_PORTS),
+        MAKE_LONG_OPT_ENTRY(DERECHO_LOCAL_ID),
+        MAKE_LONG_OPT_ENTRY(DERECHO_LOCAL_IP),
+        MAKE_LONG_OPT_ENTRY(DERECHO_GMS_PORT),
+        MAKE_LONG_OPT_ENTRY(DERECHO_STATE_TRANSFER_PORT),
+        MAKE_LONG_OPT_ENTRY(DERECHO_SST_PORT),
+        MAKE_LONG_OPT_ENTRY(DERECHO_RDMC_PORT),
+        MAKE_LONG_OPT_ENTRY(DERECHO_EXTERNAL_PORT),
+        MAKE_LONG_OPT_ENTRY(DERECHO_P2P_LOOP_BUSY_WAIT_BEFORE_SLEEP_MS),
+        MAKE_LONG_OPT_ENTRY(DERECHO_HEARTBEAT_MS),
+        MAKE_LONG_OPT_ENTRY(DERECHO_SST_POLL_CQ_TIMEOUT_MS),
+        MAKE_LONG_OPT_ENTRY(DERECHO_RESTART_TIMEOUT_MS),
+        MAKE_LONG_OPT_ENTRY(DERECHO_ENABLE_BACKUP_RESTART_LEADERS),
+        MAKE_LONG_OPT_ENTRY(DERECHO_DISABLE_PARTITIONING_SAFETY),
+        MAKE_LONG_OPT_ENTRY(DERECHO_MAX_P2P_REQUEST_PAYLOAD_SIZE),
+        MAKE_LONG_OPT_ENTRY(DERECHO_MAX_P2P_REPLY_PAYLOAD_SIZE),
+        MAKE_LONG_OPT_ENTRY(DERECHO_P2P_WINDOW_SIZE),
+        MAKE_LONG_OPT_ENTRY(DERECHO_MAX_NODE_ID),
+        MAKE_LONG_OPT_ENTRY(LAYOUT_JSON_LAYOUT),
+        MAKE_LONG_OPT_ENTRY(LAYOUT_JSON_LAYOUT_FILE),
         // [SUBGROUP/<subgroup name>]
-        MAKE_LONG_OPT_ENTRY(CONF_SUBGROUP_DEFAULT_RDMC_SEND_ALGORITHM),
-        MAKE_LONG_OPT_ENTRY(CONF_SUBGROUP_DEFAULT_MAX_PAYLOAD_SIZE),
-        MAKE_LONG_OPT_ENTRY(CONF_SUBGROUP_DEFAULT_MAX_REPLY_PAYLOAD_SIZE),
-        MAKE_LONG_OPT_ENTRY(CONF_SUBGROUP_DEFAULT_MAX_SMC_PAYLOAD_SIZE),
-        MAKE_LONG_OPT_ENTRY(CONF_SUBGROUP_DEFAULT_BLOCK_SIZE),
-        MAKE_LONG_OPT_ENTRY(CONF_SUBGROUP_DEFAULT_WINDOW_SIZE),
+        MAKE_LONG_OPT_ENTRY(SUBGROUP_DEFAULT_RDMC_SEND_ALGORITHM),
+        MAKE_LONG_OPT_ENTRY(SUBGROUP_DEFAULT_MAX_PAYLOAD_SIZE),
+        MAKE_LONG_OPT_ENTRY(SUBGROUP_DEFAULT_MAX_REPLY_PAYLOAD_SIZE),
+        MAKE_LONG_OPT_ENTRY(SUBGROUP_DEFAULT_MAX_SMC_PAYLOAD_SIZE),
+        MAKE_LONG_OPT_ENTRY(SUBGROUP_DEFAULT_BLOCK_SIZE),
+        MAKE_LONG_OPT_ENTRY(SUBGROUP_DEFAULT_WINDOW_SIZE),
         // [RDMA]
-        MAKE_LONG_OPT_ENTRY(CONF_RDMA_PROVIDER),
-        MAKE_LONG_OPT_ENTRY(CONF_RDMA_DOMAIN),
-        MAKE_LONG_OPT_ENTRY(CONF_RDMA_TX_DEPTH),
-        MAKE_LONG_OPT_ENTRY(CONF_RDMA_RX_DEPTH),
+        MAKE_LONG_OPT_ENTRY(RDMA_PROVIDER),
+        MAKE_LONG_OPT_ENTRY(RDMA_DOMAIN),
+        MAKE_LONG_OPT_ENTRY(RDMA_TX_DEPTH),
+        MAKE_LONG_OPT_ENTRY(RDMA_RX_DEPTH),
         // [PERS]
-        MAKE_LONG_OPT_ENTRY(CONF_PERS_FILE_PATH),
-        MAKE_LONG_OPT_ENTRY(CONF_PERS_RAMDISK_PATH),
-        MAKE_LONG_OPT_ENTRY(CONF_PERS_RESET),
-        MAKE_LONG_OPT_ENTRY(CONF_PERS_MAX_LOG_ENTRY),
-        MAKE_LONG_OPT_ENTRY(CONF_PERS_MAX_DATA_SIZE),
-        MAKE_LONG_OPT_ENTRY(CONF_PERS_PRIVATE_KEY_FILE),
+        MAKE_LONG_OPT_ENTRY(PERS_FILE_PATH),
+        MAKE_LONG_OPT_ENTRY(PERS_RAMDISK_PATH),
+        MAKE_LONG_OPT_ENTRY(PERS_RESET),
+        MAKE_LONG_OPT_ENTRY(PERS_MAX_LOG_ENTRY),
+        MAKE_LONG_OPT_ENTRY(PERS_MAX_DATA_SIZE),
+        MAKE_LONG_OPT_ENTRY(PERS_PRIVATE_KEY_FILE),
         // [LOGGER]
-        MAKE_LONG_OPT_ENTRY(CONF_LOGGER_LOG_FILE_DEPTH),
-        MAKE_LONG_OPT_ENTRY(CONF_LOGGER_LOG_TO_TERMINAL),
-        MAKE_LONG_OPT_ENTRY(CONF_LOGGER_DEFAULT_LOG_LEVEL),
-        MAKE_LONG_OPT_ENTRY(CONF_LOGGER_SST_LOG_LEVEL),
-        MAKE_LONG_OPT_ENTRY(CONF_LOGGER_RPC_LOG_LEVEL),
-        MAKE_LONG_OPT_ENTRY(CONF_LOGGER_VIEWMANAGER_LOG_LEVEL),
-        MAKE_LONG_OPT_ENTRY(CONF_LOGGER_PERSISTENCE_LOG_LEVEL),
+        MAKE_LONG_OPT_ENTRY(LOGGER_LOG_FILE_DEPTH),
+        MAKE_LONG_OPT_ENTRY(LOGGER_LOG_TO_TERMINAL),
+        MAKE_LONG_OPT_ENTRY(LOGGER_DEFAULT_LOG_LEVEL),
+        MAKE_LONG_OPT_ENTRY(LOGGER_SST_LOG_LEVEL),
+        MAKE_LONG_OPT_ENTRY(LOGGER_RPC_LOG_LEVEL),
+        MAKE_LONG_OPT_ENTRY(LOGGER_VIEWMANAGER_LOG_LEVEL),
+        MAKE_LONG_OPT_ENTRY(LOGGER_PERSISTENCE_LOG_LEVEL),
         {0, 0, 0, 0}};
 
 void Conf::initialize(int argc, char* argv[], const char* conf_file) {
@@ -113,21 +111,21 @@ void Conf::initialize(int argc, char* argv[], const char* conf_file) {
         delete cfg;
 
         // 3 - set optional log-level keys to equal the default log level if they are not present
-        const std::string& default_log_level = Conf::singleton->getString(CONF_LOGGER_DEFAULT_LOG_LEVEL);
-        Conf::singleton->config.try_emplace(CONF_LOGGER_SST_LOG_LEVEL, default_log_level);
-        Conf::singleton->config.try_emplace(CONF_LOGGER_RPC_LOG_LEVEL, default_log_level);
-        Conf::singleton->config.try_emplace(CONF_LOGGER_VIEWMANAGER_LOG_LEVEL, default_log_level);
-        Conf::singleton->config.try_emplace(CONF_LOGGER_PERSISTENCE_LOG_LEVEL, default_log_level);
+        const std::string& default_log_level = Conf::singleton->getString(LOGGER_DEFAULT_LOG_LEVEL);
+        Conf::singleton->config.try_emplace(LOGGER_SST_LOG_LEVEL, default_log_level);
+        Conf::singleton->config.try_emplace(LOGGER_RPC_LOG_LEVEL, default_log_level);
+        Conf::singleton->config.try_emplace(LOGGER_VIEWMANAGER_LOG_LEVEL, default_log_level);
+        Conf::singleton->config.try_emplace(LOGGER_PERSISTENCE_LOG_LEVEL, default_log_level);
 
         // 4 - set the flag to initialized
         Conf::singleton_initialized_flag.store(CONF_INITIALIZED, std::memory_order_acq_rel);
 
         // 5 - check the configuration for sanity
-        if(hasCustomizedConfKey(CONF_LAYOUT_JSON_LAYOUT) && hasCustomizedConfKey(CONF_LAYOUT_JSON_LAYOUT_FILE)) {
-            throw std::logic_error("Configuration error: Both " CONF_LAYOUT_JSON_LAYOUT " and " CONF_LAYOUT_JSON_LAYOUT_FILE " were specified. These options are mutually exclusive");
+        if(hasCustomizedConfKey(LAYOUT_JSON_LAYOUT) && hasCustomizedConfKey(LAYOUT_JSON_LAYOUT_FILE)) {
+            throw std::logic_error("Configuration error: Both json_layout and json_layout_file were specified. These options are mutually exclusive");
         }
-        if(hasCustomizedConfKey(CONF_LAYOUT_JSON_LAYOUT_FILE)) {
-            std::ifstream json_file_stream(getConfString(CONF_LAYOUT_JSON_LAYOUT_FILE));
+        if(hasCustomizedConfKey(LAYOUT_JSON_LAYOUT_FILE)) {
+            std::ifstream json_file_stream(getConfString(LAYOUT_JSON_LAYOUT_FILE));
             if(!json_file_stream) {
                 throw std::logic_error("Configuration error: The JSON layout file could not be opened for reading");
             }
@@ -139,23 +137,23 @@ void Conf::initialize(int argc, char* argv[], const char* conf_file) {
                 std::throw_with_nested(std::logic_error("Configuration error: The JSON layout file does not contain valid JSON"));
             }
         }
-        if(hasCustomizedConfKey(CONF_LAYOUT_JSON_LAYOUT)) {
+        if(hasCustomizedConfKey(LAYOUT_JSON_LAYOUT)) {
             nlohmann::json json_obj;
             try {
-                json_obj = nlohmann::json::parse(getConfString(CONF_LAYOUT_JSON_LAYOUT));
+                json_obj = nlohmann::json::parse(getConfString(LAYOUT_JSON_LAYOUT));
             } catch(nlohmann::json::exception& ex) {
                 std::throw_with_nested(std::logic_error("Configuration error: The JSON layout string is not valid JSON"));
             }
         }
 
-        if(getConfUInt32(CONF_DERECHO_LOCAL_ID) >= getConfUInt32(CONF_DERECHO_MAX_NODE_ID)) {
+        if(getConfUInt32(DERECHO_LOCAL_ID) >= getConfUInt32(DERECHO_MAX_NODE_ID)) {
             throw std::logic_error("Configuration error: Local node ID must be less than max node ID");
         }
-        if(getConfUInt32(CONF_SUBGROUP_DEFAULT_MAX_REPLY_PAYLOAD_SIZE) < DERECHO_MIN_RPC_RESPONSE_SIZE) {
+        if(getConfUInt32(SUBGROUP_DEFAULT_MAX_REPLY_PAYLOAD_SIZE) < DERECHO_MIN_RPC_RESPONSE_SIZE) {
             throw std::logic_error(std::string("Configuration error: Default subgroup reply size must be at least ")
                                    + std::to_string(DERECHO_MIN_RPC_RESPONSE_SIZE));
         }
-        if(getConfUInt32(CONF_DERECHO_MAX_P2P_REPLY_PAYLOAD_SIZE) < DERECHO_MIN_RPC_RESPONSE_SIZE) {
+        if(getConfUInt32(DERECHO_MAX_P2P_REPLY_PAYLOAD_SIZE) < DERECHO_MIN_RPC_RESPONSE_SIZE) {
             throw std::logic_error(std::string("Configuration error: P2P reply payload size must be at least ")
                                    + std::to_string(DERECHO_MIN_RPC_RESPONSE_SIZE));
         }

--- a/src/core/git_version.cpp
+++ b/src/core/git_version.cpp
@@ -13,8 +13,8 @@ namespace derecho {
 const int MAJOR_VERSION = 2;
 const int MINOR_VERSION = 3;
 const int PATCH_VERSION = 0;
-const int COMMITS_AHEAD_OF_VERSION = 89;
+const int COMMITS_AHEAD_OF_VERSION = 90;
 const char* VERSION_STRING = "2.3.0";
-const char* VERSION_STRING_PLUS_COMMITS = "2.3.0+89";
+const char* VERSION_STRING_PLUS_COMMITS = "2.3.0+90";
 
 }

--- a/src/core/git_version.cpp
+++ b/src/core/git_version.cpp
@@ -13,8 +13,8 @@ namespace derecho {
 const int MAJOR_VERSION = 2;
 const int MINOR_VERSION = 3;
 const int PATCH_VERSION = 0;
-const int COMMITS_AHEAD_OF_VERSION = 90;
+const int COMMITS_AHEAD_OF_VERSION = 91;
 const char* VERSION_STRING = "2.3.0";
-const char* VERSION_STRING_PLUS_COMMITS = "2.3.0+90";
+const char* VERSION_STRING_PLUS_COMMITS = "2.3.0+91";
 
 }

--- a/src/core/p2p_connection_manager.cpp
+++ b/src/core/p2p_connection_manager.cpp
@@ -18,8 +18,8 @@ namespace sst {
 P2PConnectionManager::P2PConnectionManager(const P2PParams params)
         : my_node_id(params.my_node_id),
           rpc_logger(spdlog::get(LoggerFactory::RPC_LOGGER_NAME)),
-          p2p_connections(derecho::getConfUInt32(CONF_DERECHO_MAX_NODE_ID)),
-          active_p2p_connections(new char[derecho::getConfUInt32(CONF_DERECHO_MAX_NODE_ID)]),
+          p2p_connections(derecho::getConfUInt32(derecho::Conf::DERECHO_MAX_NODE_ID)),
+          active_p2p_connections(new char[derecho::getConfUInt32(derecho::Conf::DERECHO_MAX_NODE_ID)]),
           failure_upcall(params.failure_upcall) {
     // HARD-CODED. Adding another request type will break this
 
@@ -30,7 +30,7 @@ P2PConnectionManager::P2PConnectionManager(const P2PParams params)
     request_params.max_msg_sizes[P2P_REQUEST] = params.max_p2p_request_size;
     request_params.max_msg_sizes[RPC_REPLY] = params.max_rpc_reply_size;
 
-    for(uint32_t i = 0; i < derecho::getConfUInt32(CONF_DERECHO_MAX_NODE_ID); ++i) {
+    for(uint32_t i = 0; i < derecho::getConfUInt32(derecho::Conf::DERECHO_MAX_NODE_ID); ++i) {
         active_p2p_connections[i] = false;
     }
 
@@ -152,8 +152,8 @@ void P2PConnectionManager::send(node_id_t node_id, MESSAGE_TYPE type, uint64_t s
 void P2PConnectionManager::check_failures_loop() {
     pthread_setname_np(pthread_self(), "p2p_timeout");
 
-    // using CONF_DERECHO_HEARTBEAT_MS from derecho.cfg
-    uint32_t heartbeat_ms = derecho::getConfUInt32(CONF_DERECHO_HEARTBEAT_MS);
+    // using Conf::DERECHO_HEARTBEAT_MS from derecho.cfg
+    uint32_t heartbeat_ms = derecho::getConfUInt32(derecho::Conf::DERECHO_HEARTBEAT_MS);
     const auto tid = std::this_thread::get_id();
     // get id first
     uint32_t ce_idx = util::polling_data.get_index(tid);
@@ -201,7 +201,7 @@ void P2PConnectionManager::check_failures_loop() {
         std::vector<node_id_t> failed_node_indexes;
 
         /** Completion Queue poll timeout in millisec */
-        const unsigned int MAX_POLL_CQ_TIMEOUT = derecho::getConfUInt32(CONF_DERECHO_SST_POLL_CQ_TIMEOUT_MS);
+        const unsigned int MAX_POLL_CQ_TIMEOUT = derecho::getConfUInt32(derecho::Conf::DERECHO_SST_POLL_CQ_TIMEOUT_MS);
         unsigned long start_time_msec;
         unsigned long cur_time_msec;
         struct timeval cur_time;

--- a/src/core/persistence_manager.cpp
+++ b/src/core/persistence_manager.cpp
@@ -29,7 +29,7 @@ PersistenceManager::PersistenceManager(
         throw derecho_exception("Cannot initialize persistent_request_sem:errno=" + std::to_string(errno));
     }
     if(any_signed_objects) {
-        openssl::EnvelopeKey signing_key = openssl::EnvelopeKey::from_pem_private(getConfString(CONF_PERS_PRIVATE_KEY_FILE));
+        openssl::EnvelopeKey signing_key = openssl::EnvelopeKey::from_pem_private(getConfString(Conf::PERS_PRIVATE_KEY_FILE));
         signature_size = signing_key.get_max_size();
         //The Verifier only needs the public key, but we loaded both public and private components from the private key file
         signature_verifier = std::make_unique<openssl::Verifier>(signing_key, openssl::DigestAlgorithm::SHA256);

--- a/src/core/restart_state.cpp
+++ b/src/core/restart_state.cpp
@@ -111,7 +111,7 @@ RestartLeaderState::RestartLeaderState(std::unique_ptr<View> _curr_view, Restart
 
 void RestartLeaderState::await_quorum(tcp::connection_listener& server_socket) {
     bool ready_to_restart = false;
-    int time_remaining_ms = getConfUInt32(CONF_DERECHO_RESTART_TIMEOUT_MS);
+    int time_remaining_ms = getConfUInt32(Conf::DERECHO_RESTART_TIMEOUT_MS);
     while(time_remaining_ms > 0) {
         using namespace std::chrono;
         auto start_time = high_resolution_clock::now();
@@ -181,7 +181,7 @@ void RestartLeaderState::await_quorum(tcp::connection_listener& server_socket) {
             }
         } else if(!ready_to_restart) {
             //Accept timed out, but we haven't heard from enough nodes yet, so reset the timer
-            time_remaining_ms = getConfUInt32(CONF_DERECHO_RESTART_TIMEOUT_MS);
+            time_remaining_ms = getConfUInt32(Conf::DERECHO_RESTART_TIMEOUT_MS);
         }
     }
 }
@@ -453,12 +453,12 @@ std::unique_ptr<View> RestartLeaderState::update_curr_and_next_restart_view() {
     //Ensure the restart leader itself will be in the next view
     if(curr_view->rank_of(my_id) == -1) {
         nodes_to_add_in_next_view.emplace_back(my_id);
-        ips_and_ports_to_add_in_next_view.emplace_back(getConfString(CONF_DERECHO_LOCAL_IP),
-                                                       getConfUInt16(CONF_DERECHO_GMS_PORT),
-                                                       getConfUInt16(CONF_DERECHO_STATE_TRANSFER_PORT),
-                                                       getConfUInt16(CONF_DERECHO_SST_PORT),
-                                                       getConfUInt16(CONF_DERECHO_RDMC_PORT),
-                                                       getConfUInt16(CONF_DERECHO_EXTERNAL_PORT));
+        ips_and_ports_to_add_in_next_view.emplace_back(getConfString(Conf::DERECHO_LOCAL_IP),
+                                                       getConfUInt16(Conf::DERECHO_GMS_PORT),
+                                                       getConfUInt16(Conf::DERECHO_STATE_TRANSFER_PORT),
+                                                       getConfUInt16(Conf::DERECHO_SST_PORT),
+                                                       getConfUInt16(Conf::DERECHO_RDMC_PORT),
+                                                       getConfUInt16(Conf::DERECHO_EXTERNAL_PORT));
     }
     //Mark any nodes from the last view that haven't yet responded as failed
     for(std::size_t rank = 0; rank < curr_view->members.size(); ++rank) {
@@ -517,7 +517,7 @@ std::unique_ptr<View> RestartLeaderState::make_next_view(const std::unique_ptr<V
     //Initialize my_rank in next_view
     //Note that the restart leader might not be a member of curr_view, so we can't use curr_view->my_rank
     int32_t my_new_rank = -1;
-    const uint32_t my_id = getConfUInt32(CONF_DERECHO_LOCAL_ID);
+    const uint32_t my_id = getConfUInt32(Conf::DERECHO_LOCAL_ID);
     for(int i = 0; i < next_num_members; ++i) {
         if(members[i] == my_id) {
             my_new_rank = i;

--- a/src/core/rpc_manager.cpp
+++ b/src/core/rpc_manager.cpp
@@ -25,11 +25,11 @@ thread_local node_id_t RPCManager::rpc_caller_id;
 
 RPCManager::RPCManager(ViewManager& group_view_manager,
                        const std::vector<DeserializationContext*>& deserialization_context)
-        : nid(getConfUInt32(CONF_DERECHO_LOCAL_ID)),
-          rpc_logger(LoggerFactory::createIfAbsent(LoggerFactory::RPC_LOGGER_NAME, getConfString(CONF_LOGGER_RPC_LOG_LEVEL))),
+        : nid(getConfUInt32(Conf::DERECHO_LOCAL_ID)),
+          rpc_logger(LoggerFactory::createIfAbsent(LoggerFactory::RPC_LOGGER_NAME, getConfString(Conf::LOGGER_RPC_LOG_LEVEL))),
           receivers(new std::decay_t<decltype(*receivers)>()),
           view_manager(group_view_manager),
-          busy_wait_before_sleep_ms(getConfUInt64(CONF_DERECHO_P2P_LOOP_BUSY_WAIT_BEFORE_SLEEP_MS)) {
+          busy_wait_before_sleep_ms(getConfUInt64(Conf::DERECHO_P2P_LOOP_BUSY_WAIT_BEFORE_SLEEP_MS)) {
     RpcLoggerPtr::initialize();
     for(const auto& deserialization_context_ptr : deserialization_context) {
         rdv.push_back(deserialization_context_ptr);
@@ -60,10 +60,10 @@ void RPCManager::report_failure(const node_id_t who) {
 void RPCManager::create_connections() {
     connections = std::make_unique<sst::P2PConnectionManager>(sst::P2PParams{
             nid,
-            getConfUInt32(CONF_DERECHO_P2P_WINDOW_SIZE),
+            getConfUInt32(Conf::DERECHO_P2P_WINDOW_SIZE),
             view_manager.view_max_rpc_window_size,
-            getConfUInt64(CONF_DERECHO_MAX_P2P_REPLY_PAYLOAD_SIZE) + sizeof(header),
-            getConfUInt64(CONF_DERECHO_MAX_P2P_REQUEST_PAYLOAD_SIZE) + sizeof(header),
+            getConfUInt64(Conf::DERECHO_MAX_P2P_REPLY_PAYLOAD_SIZE) + sizeof(header),
+            getConfUInt64(Conf::DERECHO_MAX_P2P_REQUEST_PAYLOAD_SIZE) + sizeof(header),
             view_manager.view_max_rpc_reply_payload_size + sizeof(header),
             false,
             [this](const uint32_t node_id) { report_failure(node_id); }});

--- a/src/core/subgroup_functions.cpp
+++ b/src/core/subgroup_functions.cpp
@@ -675,16 +675,16 @@ DefaultSubgroupAllocator::DefaultSubgroupAllocator(std::vector<std::type_index> 
 DefaultSubgroupAllocator::DefaultSubgroupAllocator(std::vector<std::type_index> subgroup_types) {
     //It's not possible to delegate to a different constructor based on a boolean,
     //so I have to copy and paste from the other two constructors
-    if(hasCustomizedConfKey(CONF_LAYOUT_JSON_LAYOUT)) {
-        json layout_array = json::parse(getConfString(CONF_LAYOUT_JSON_LAYOUT));
+    if(hasCustomizedConfKey(Conf::LAYOUT_JSON_LAYOUT)) {
+        json layout_array = json::parse(getConfString(Conf::LAYOUT_JSON_LAYOUT));
         for(std::size_t subgroup_type_index = 0; subgroup_type_index < subgroup_types.size(); ++subgroup_type_index) {
             policies.emplace(subgroup_types[subgroup_type_index],
                              parse_json_subgroup_policy(layout_array[subgroup_type_index], all_reserved_node_ids));
         }
-    } else if(hasCustomizedConfKey(CONF_LAYOUT_JSON_LAYOUT_FILE)) {
+    } else if(hasCustomizedConfKey(Conf::LAYOUT_JSON_LAYOUT_FILE)) {
         json layout_array;
 
-        std::string json_layout_file_path = getAbsoluteFilePath(getConfString(CONF_LAYOUT_JSON_LAYOUT_FILE));
+        std::string json_layout_file_path = getAbsoluteFilePath(getConfString(Conf::LAYOUT_JSON_LAYOUT_FILE));
 
         std::ifstream json_file_stream(json_layout_file_path);
         if(!json_file_stream) {

--- a/src/core/view_manager.cpp
+++ b/src/core/view_manager.cpp
@@ -33,14 +33,14 @@ ViewManager::ViewManager(
         std::map<subgroup_id_t, ReplicatedObject*>& object_pointer_map,
         PersistenceManager& persistence_manager,
         std::vector<view_upcall_t> _view_upcalls)
-        : vm_logger(LoggerFactory::createIfAbsent(LoggerFactory::VIEWMANAGER_LOGGER_NAME, getConfString(CONF_LOGGER_VIEWMANAGER_LOG_LEVEL))),
-          server_socket(getConfUInt16(CONF_DERECHO_GMS_PORT)),
+        : vm_logger(LoggerFactory::createIfAbsent(LoggerFactory::VIEWMANAGER_LOGGER_NAME, getConfString(Conf::LOGGER_VIEWMANAGER_LOG_LEVEL))),
+          server_socket(getConfUInt16(Conf::DERECHO_GMS_PORT)),
           thread_shutdown(false),
-          disable_partitioning_safety(getConfBoolean(CONF_DERECHO_DISABLE_PARTITIONING_SAFETY)),
+          disable_partitioning_safety(getConfBoolean(Conf::DERECHO_DISABLE_PARTITIONING_SAFETY)),
           view_upcalls(_view_upcalls),
           subgroup_info(subgroup_info),
           subgroup_type_order(subgroup_type_order),
-          tcp_sockets(getConfUInt32(CONF_DERECHO_LOCAL_ID), getConfUInt16(CONF_DERECHO_STATE_TRANSFER_PORT)),
+          tcp_sockets(getConfUInt32(Conf::DERECHO_LOCAL_ID), getConfUInt16(Conf::DERECHO_STATE_TRANSFER_PORT)),
           subgroup_objects(object_pointer_map),
           any_persistent_objects(any_persistent_objects),
           persistence_manager(persistence_manager) {
@@ -52,7 +52,7 @@ ViewManager::ViewManager(
 ViewManager::~ViewManager() {
     thread_shutdown = true;
     // force accept to return.
-    tcp::socket s{"localhost", getConfUInt16(CONF_DERECHO_GMS_PORT)};
+    tcp::socket s{"localhost", getConfUInt16(Conf::DERECHO_GMS_PORT)};
     if(client_listener_thread.joinable()) {
         client_listener_thread.join();
     }
@@ -74,10 +74,10 @@ bool ViewManager::first_init() {
     if(curr_view) {
         dbg_debug(vm_logger, "Found view {} on disk", curr_view->vid);
         restart_state = std::make_unique<RestartState>();
-        restart_state->restart_leader_ips = split_string(getConfString(CONF_DERECHO_RESTART_LEADERS));
+        restart_state->restart_leader_ips = split_string(getConfString(Conf::DERECHO_RESTART_LEADERS));
         restart_state->restart_leader_ports = [&]() {
             //"Apply std::stoi over the result of split_string(getConfString(...))"
-            auto port_list = split_string(getConfString(CONF_DERECHO_RESTART_LEADER_PORTS));
+            auto port_list = split_string(getConfString(Conf::DERECHO_RESTART_LEADER_PORTS));
             std::vector<uint16_t> ports;
             for(const auto& port_str : port_list) {
                 ports.emplace_back((uint16_t)std::stoi(port_str));
@@ -93,21 +93,21 @@ bool ViewManager::first_init() {
 }
 
 void ViewManager::startup_to_first_view() {
-    const ip_addr_t my_ip = getConfString(CONF_DERECHO_LOCAL_IP);
-    const uint32_t my_id = getConfUInt32(CONF_DERECHO_LOCAL_ID);
-    const uint16_t my_gms_port = getConfUInt16(CONF_DERECHO_GMS_PORT);
+    const ip_addr_t my_ip = getConfString(Conf::DERECHO_LOCAL_IP);
+    const uint32_t my_id = getConfUInt32(Conf::DERECHO_LOCAL_ID);
+    const uint16_t my_gms_port = getConfUInt16(Conf::DERECHO_GMS_PORT);
     in_total_restart = false;
     //Determine if I am the initial leader for a new group
-    if(my_ip == getConfString(CONF_DERECHO_LEADER_IP) && my_gms_port == getConfUInt16(CONF_DERECHO_LEADER_GMS_PORT)) {
+    if(my_ip == getConfString(Conf::DERECHO_LEADER_IP) && my_gms_port == getConfUInt16(Conf::DERECHO_LEADER_GMS_PORT)) {
         curr_view = std::make_unique<View>(
                 0, std::vector<node_id_t>{my_id},
                 std::vector<IpAndPorts>{
-                        {getConfString(CONF_DERECHO_LOCAL_IP),
-                         getConfUInt16(CONF_DERECHO_GMS_PORT),
-                         getConfUInt16(CONF_DERECHO_STATE_TRANSFER_PORT),
-                         getConfUInt16(CONF_DERECHO_SST_PORT),
-                         getConfUInt16(CONF_DERECHO_RDMC_PORT),
-                         getConfUInt16(CONF_DERECHO_EXTERNAL_PORT)}},
+                        {getConfString(Conf::DERECHO_LOCAL_IP),
+                         getConfUInt16(Conf::DERECHO_GMS_PORT),
+                         getConfUInt16(Conf::DERECHO_STATE_TRANSFER_PORT),
+                         getConfUInt16(Conf::DERECHO_SST_PORT),
+                         getConfUInt16(Conf::DERECHO_RDMC_PORT),
+                         getConfUInt16(Conf::DERECHO_EXTERNAL_PORT)}},
                 std::vector<char>{0},
                 std::vector<node_id_t>{}, std::vector<node_id_t>{},
                 0, 0, subgroup_type_order);
@@ -117,8 +117,8 @@ void ViewManager::startup_to_first_view() {
     } else {
         active_leader = false;
         dbg_info(vm_logger, "Non-leader node {} initiating a join request at the leader", my_id);
-        leader_connection = std::make_unique<tcp::socket>(getConfString(CONF_DERECHO_LEADER_IP),
-                                                          getConfUInt16(CONF_DERECHO_LEADER_GMS_PORT));
+        leader_connection = std::make_unique<tcp::socket>(getConfString(Conf::DERECHO_LEADER_IP),
+                                                          getConfUInt16(Conf::DERECHO_LEADER_GMS_PORT));
         bool success = receive_initial_view();
         if(!success) {
             throw derecho_exception("Leader crashed before it could send the initial View! Try joining again at the new leader.");
@@ -128,10 +128,10 @@ void ViewManager::startup_to_first_view() {
 }
 
 bool ViewManager::restart_to_initial_view() {
-    const ip_addr_t my_ip = getConfString(CONF_DERECHO_LOCAL_IP);
-    const uint32_t my_id = getConfUInt32(CONF_DERECHO_LOCAL_ID);
-    const uint16_t my_gms_port = getConfUInt16(CONF_DERECHO_GMS_PORT);
-    const bool enable_backup_restart_leaders = getConfBoolean(CONF_DERECHO_ENABLE_BACKUP_RESTART_LEADERS);
+    const ip_addr_t my_ip = getConfString(Conf::DERECHO_LOCAL_IP);
+    const uint32_t my_id = getConfUInt32(Conf::DERECHO_LOCAL_ID);
+    const uint16_t my_gms_port = getConfUInt16(Conf::DERECHO_GMS_PORT);
+    const bool enable_backup_restart_leaders = getConfBoolean(Conf::DERECHO_ENABLE_BACKUP_RESTART_LEADERS);
 
     bool got_initial_view = false;
     while(!got_initial_view) {
@@ -157,7 +157,7 @@ bool ViewManager::restart_to_initial_view() {
             using namespace std::chrono;
             leader_connection = std::make_unique<tcp::socket>();
             //Heuristic: Wait for half the leader's restart timeout before concluding the leader isn't responding
-            int time_remaining_micro = getConfUInt32(CONF_DERECHO_RESTART_TIMEOUT_MS) * 1000 / 2;
+            int time_remaining_micro = getConfUInt32(Conf::DERECHO_RESTART_TIMEOUT_MS) * 1000 / 2;
             int connect_status = -1;
             //Annoyingly, try_connect will return immediately if the connection is refused,
             //which is the usual result while waiting for the leader to start up.
@@ -197,7 +197,7 @@ bool ViewManager::restart_to_initial_view() {
 
 bool ViewManager::receive_initial_view() {
     assert(leader_connection);
-    const node_id_t my_id = getConfUInt32(CONF_DERECHO_LOCAL_ID);
+    const node_id_t my_id = getConfUInt32(Conf::DERECHO_LOCAL_ID);
     JoinResponse leader_response;
     bool leader_redirect;
     do {
@@ -246,9 +246,9 @@ bool ViewManager::receive_initial_view() {
                                                std::vector<std::type_index>{});
             // Initialize restart_state, which wasn't created in first_init() because we had no logged View
             restart_state = std::make_unique<RestartState>();
-            restart_state->restart_leader_ips = split_string(getConfString(CONF_DERECHO_RESTART_LEADERS));
+            restart_state->restart_leader_ips = split_string(getConfString(Conf::DERECHO_RESTART_LEADERS));
             restart_state->restart_leader_ports = [&]() {
-                auto port_list = split_string(getConfString(CONF_DERECHO_RESTART_LEADER_PORTS));
+                auto port_list = split_string(getConfString(Conf::DERECHO_RESTART_LEADER_PORTS));
                 std::vector<uint16_t> ports;
                 for(const auto& port_str : port_list) {
                     ports.emplace_back((uint16_t)std::stoi(port_str));
@@ -288,11 +288,11 @@ bool ViewManager::receive_initial_view() {
         restart_state.reset();
     }
     try {
-        leader_connection->write(getConfUInt16(CONF_DERECHO_GMS_PORT));
-        leader_connection->write(getConfUInt16(CONF_DERECHO_STATE_TRANSFER_PORT));
-        leader_connection->write(getConfUInt16(CONF_DERECHO_SST_PORT));
-        leader_connection->write(getConfUInt16(CONF_DERECHO_RDMC_PORT));
-        leader_connection->write(getConfUInt16(CONF_DERECHO_EXTERNAL_PORT));
+        leader_connection->write(getConfUInt16(Conf::DERECHO_GMS_PORT));
+        leader_connection->write(getConfUInt16(Conf::DERECHO_STATE_TRANSFER_PORT));
+        leader_connection->write(getConfUInt16(Conf::DERECHO_SST_PORT));
+        leader_connection->write(getConfUInt16(Conf::DERECHO_RDMC_PORT));
+        leader_connection->write(getConfUInt16(Conf::DERECHO_EXTERNAL_PORT));
     } catch(tcp::socket_error& e) {
         return false;
     }
@@ -340,7 +340,7 @@ bool ViewManager::receive_view_and_leaders() {
 
     //Set up non-serialized fields of curr_view
     curr_view->subgroup_type_order = subgroup_type_order;
-    curr_view->my_rank = curr_view->rank_of(getConfUInt32(CONF_DERECHO_LOCAL_ID));
+    curr_view->my_rank = curr_view->rank_of(getConfUInt32(Conf::DERECHO_LOCAL_ID));
     return true;
 }
 
@@ -365,7 +365,7 @@ void ViewManager::check_view_committed(bool& view_confirmed, bool& leader_failed
         //This checks if either the first or the second message was Abort
         if(commit_message == CommitMessage::ABORT) {
             dbg_debug(vm_logger, "Leader sent ABORT");
-            const uint32_t my_id = getConfUInt32(CONF_DERECHO_LOCAL_ID);
+            const uint32_t my_id = getConfUInt32(Conf::DERECHO_LOCAL_ID);
             //Wait for a new initial view and ragged trim to be sent,
             //so that when this method returns we can try state transfer again
             leader_failed = !receive_view_and_leaders();
@@ -376,7 +376,7 @@ void ViewManager::check_view_committed(bool& view_confirmed, bool& leader_failed
         }
     } catch(tcp::socket_error&) {
         leader_failed = true;
-        if(restart_state && getConfBoolean(CONF_DERECHO_ENABLE_BACKUP_RESTART_LEADERS)) {
+        if(restart_state && getConfBoolean(Conf::DERECHO_ENABLE_BACKUP_RESTART_LEADERS)) {
             restart_state->num_leader_failures++;
             //Throw out the curr_view the leader sent and revert to the logged one on disk
             curr_view = persistent::loadObject<View>();
@@ -397,7 +397,7 @@ void ViewManager::truncate_logs() {
     }
     dbg_debug(vm_logger, "Truncating persistent logs to conform to leader's ragged trim");
 
-    const node_id_t my_id = getConfUInt32(CONF_DERECHO_LOCAL_ID);
+    const node_id_t my_id = getConfUInt32(Conf::DERECHO_LOCAL_ID);
 
     for(const auto& id_to_shard_map : restart_state->logged_ragged_trim) {
         subgroup_id_t subgroup_id = id_to_shard_map.first;
@@ -499,7 +499,7 @@ void ViewManager::send_logs() {
     const View& restart_view = curr_view ? *curr_view : restart_leader_state_machine->get_restart_view();
     /* If we're in total restart mode, prior_view_shard_leaders is equal
      * to restart_state->restart_shard_leaders */
-    node_id_t my_id = getConfUInt32(CONF_DERECHO_LOCAL_ID);
+    node_id_t my_id = getConfUInt32(Conf::DERECHO_LOCAL_ID);
     for(subgroup_id_t subgroup_id = 0; subgroup_id < prior_view_shard_leaders.size(); ++subgroup_id) {
         for(uint32_t shard = 0; shard < prior_view_shard_leaders[subgroup_id].size(); ++shard) {
             if(my_id == prior_view_shard_leaders[subgroup_id][shard]) {
@@ -554,8 +554,8 @@ bool ViewManager::is_starting_leader() const {
     if(in_total_restart) {
         return active_leader;
     } else {
-        return getConfString(CONF_DERECHO_LOCAL_IP) == getConfString(CONF_DERECHO_LEADER_IP)
-               && getConfUInt16(CONF_DERECHO_GMS_PORT) == getConfUInt16(CONF_DERECHO_LEADER_GMS_PORT);
+        return getConfString(Conf::DERECHO_LOCAL_IP) == getConfString(Conf::DERECHO_LEADER_IP)
+               && getConfUInt16(Conf::DERECHO_GMS_PORT) == getConfUInt16(Conf::DERECHO_LEADER_GMS_PORT);
     }
 }
 
@@ -566,7 +566,7 @@ void ViewManager::start() {
 
 void ViewManager::await_first_view() {
     dbg_info(vm_logger, "Group leader waiting for an initial adequate view");
-    const node_id_t my_id = getConfUInt32(CONF_DERECHO_LOCAL_ID);
+    const node_id_t my_id = getConfUInt32(Conf::DERECHO_LOCAL_ID);
     std::map<node_id_t, tcp::socket> waiting_join_sockets;
     std::set<node_id_t> members_sent_view;
     curr_view->is_adequately_provisioned = false;
@@ -760,8 +760,8 @@ void ViewManager::initialize_rdmc_sst() {
     node_id_t my_id = curr_view->members[curr_view->my_rank];
     const std::map<node_id_t, std::pair<ip_addr_t, uint16_t>> self_ip_and_port_map = {
             {my_id,
-             {getConfString(CONF_DERECHO_LOCAL_IP),
-              getConfUInt16(CONF_DERECHO_EXTERNAL_PORT)}}};
+             {getConfString(Conf::DERECHO_LOCAL_IP),
+              getConfUInt16(Conf::DERECHO_EXTERNAL_PORT)}}};
 
 #ifdef USE_VERBS_API
     sst::verbs_initialize(member_ips_and_sst_ports_map,
@@ -1066,9 +1066,9 @@ void ViewManager::external_join_handler(tcp::socket& client_socket, const node_i
     try {
         if(curr_view->rank_of(joiner_id) != -1) {
             // external can't have same id as any member
-            client_socket.write(JoinResponse{JoinResponseCode::ID_IN_USE, getConfUInt32(CONF_DERECHO_LOCAL_ID)});
+            client_socket.write(JoinResponse{JoinResponseCode::ID_IN_USE, getConfUInt32(Conf::DERECHO_LOCAL_ID)});
         }
-        client_socket.write(JoinResponse{JoinResponseCode::OK, getConfUInt32(CONF_DERECHO_LOCAL_ID)});
+        client_socket.write(JoinResponse{JoinResponseCode::OK, getConfUInt32(Conf::DERECHO_LOCAL_ID)});
         client_socket.read(request);
     } catch(tcp::socket_error& ex) {
         dbg_warn(vm_logger, "TCP connection to external client {} failed before it could send a request. Ignoring request.", joiner_id);
@@ -1644,7 +1644,7 @@ void ViewManager::construct_multicast_group(const UserMessageCallbacks& callback
     curr_view->multicast_group = std::make_unique<MulticastGroup>(
             curr_view->members, curr_view->members[curr_view->my_rank],
             curr_view->gmsSST, callbacks, internal_callbacks, num_subgroups, subgroup_settings,
-            getConfUInt32(CONF_DERECHO_HEARTBEAT_MS),
+            getConfUInt32(Conf::DERECHO_HEARTBEAT_MS),
             persistence_manager, curr_view->failed);
 }
 

--- a/src/persistent/FilePersistLog.cpp
+++ b/src/persistent/FilePersistLog.cpp
@@ -41,8 +41,8 @@ FilePersistLog::FilePersistLog(const string& name, const string& dataPath, bool 
           m_sMetaFile(dataPath + "/" + name + "." + META_FILE_SUFFIX),
           m_sLogFile(dataPath + "/" + name + "." + LOG_FILE_SUFFIX),
           m_sDataFile(dataPath + "/" + name + "." + DATA_FILE_SUFFIX),
-          m_iMaxLogEntry(derecho::getConfUInt64(CONF_PERS_MAX_LOG_ENTRY)),
-          m_iMaxDataSize(derecho::getConfUInt64(CONF_PERS_MAX_DATA_SIZE)),
+          m_iMaxLogEntry(derecho::getConfUInt64(derecho::Conf::PERS_MAX_LOG_ENTRY)),
+          m_iMaxDataSize(derecho::getConfUInt64(derecho::Conf::PERS_MAX_DATA_SIZE)),
           m_logger(PersistLogger::get()),
           m_iLogFileDesc(-1),
           m_iDataFileDesc(-1),
@@ -55,7 +55,7 @@ FilePersistLog::FilePersistLog(const string& name, const string& dataPath, bool 
         throw persistent_lock_error("mutex_init failed", errno);
     }
     dbg_trace(m_logger, "{0} constructor: before load()", name);
-    if(derecho::getConfBoolean(CONF_PERS_RESET)) {
+    if(derecho::getConfBoolean(derecho::Conf::PERS_RESET)) {
         reset();
     }
     load();

--- a/src/persistent/PersistLog.cpp
+++ b/src/persistent/PersistLog.cpp
@@ -9,7 +9,7 @@ namespace persistent {
 PersistLog::PersistLog(const std::string& name, bool enable_signatures) noexcept(true)
         : m_sName(name),
           signature_size(enable_signatures
-                                 ? openssl::EnvelopeKey::from_pem_private(derecho::getConfString(CONF_PERS_PRIVATE_KEY_FILE)).get_max_size()
+                                 ? openssl::EnvelopeKey::from_pem_private(derecho::getConfString(derecho::Conf::PERS_PRIVATE_KEY_FILE)).get_max_size()
                                  : 0) {
 }
 

--- a/src/persistent/logger.cpp
+++ b/src/persistent/logger.cpp
@@ -18,7 +18,7 @@ void PersistLogger::initialize() {
     uint32_t expected = logger_uninitialized;
     if(initialize_state.compare_exchange_strong(expected, logger_initializing, std::memory_order_acq_rel)) {
         logger = LoggerFactory::createLogger(LoggerFactory::PERSISTENT_LOGGER_NAME,
-                                             derecho::getConfString(CONF_LOGGER_PERSISTENCE_LOG_LEVEL));
+                                             derecho::getConfString(derecho::Conf::LOGGER_PERSISTENCE_LOG_LEVEL));
         initialize_state.store(logger_initialized, std::memory_order_acq_rel);
     }
     while(initialize_state.load(std::memory_order_acquire) != logger_initialized) {

--- a/src/persistent/test.cpp
+++ b/src/persistent/test.cpp
@@ -250,7 +250,7 @@ int main(int argc, char** argv) {
         return 0;
     }
     //If the private key file exists, assume signatures should be enabled
-    bool use_signature = checkRegularFile(derecho::getConfString(CONF_PERS_PRIVATE_KEY_FILE));
+    bool use_signature = checkRegularFile(derecho::getConfString(derecho::Conf::PERS_PRIVATE_KEY_FILE));
 
     PersistentRegistry pr(nullptr, typeid(ReplicatedT), 123, 321);
     Persistent<X> px1([]() { return std::make_unique<X>(); }, "PersistentXObject", &pr, use_signature);
@@ -274,7 +274,7 @@ int main(int argc, char** argv) {
 
     if (use_signature) {
         prikey = std::make_unique<openssl::EnvelopeKey>(
-                openssl::EnvelopeKey::from_pem_private(derecho::getConfString(CONF_PERS_PRIVATE_KEY_FILE)));
+                openssl::EnvelopeKey::from_pem_private(derecho::getConfString(derecho::Conf::PERS_PRIVATE_KEY_FILE)));
         signer = std::make_unique<openssl::Signer>(*prikey, openssl::DigestAlgorithm::SHA256);
         verifier = std::make_unique<openssl::Verifier>(*prikey, openssl::DigestAlgorithm::SHA256);
         signer->init();

--- a/src/rdmc/lf_helper.cpp
+++ b/src/rdmc/lf_helper.cpp
@@ -140,18 +140,18 @@ static void default_context() {
 
     /** Set the provider, can be verbs|psm|sockets|usnic */
     g_ctxt.hints->fabric_attr->prov_name = crash_if_nullptr("strdup provider name.",
-                                                            strdup, derecho::getConfString(CONF_RDMA_PROVIDER).c_str());
+                                                            strdup, derecho::getConfString(derecho::Conf::RDMA_PROVIDER).c_str());
     /** Set the domain */
     g_ctxt.hints->domain_attr->name = crash_if_nullptr("strdup domain name.",
-                                                       strdup, derecho::getConfString(CONF_RDMA_DOMAIN).c_str());
+                                                       strdup, derecho::getConfString(derecho::Conf::RDMA_DOMAIN).c_str());
     /** Set the memory region mode mode bits, see fi_mr(3) for details */
     if((strcmp(g_ctxt.hints->fabric_attr->prov_name, "sockets") == 0) ||
        (strcmp(g_ctxt.hints->fabric_attr->prov_name, "tcp") == 0)) {
         g_ctxt.hints->domain_attr->mr_mode = FI_MR_BASIC;
     } else {  // default
         /** Set the sizes of the tx and rx queues */
-        g_ctxt.hints->tx_attr->size = derecho::Conf::get()->getInt32(CONF_RDMA_TX_DEPTH);
-        g_ctxt.hints->rx_attr->size = derecho::Conf::get()->getInt32(CONF_RDMA_RX_DEPTH);
+        g_ctxt.hints->tx_attr->size = derecho::Conf::get()->getInt32(derecho::Conf::RDMA_TX_DEPTH);
+        g_ctxt.hints->rx_attr->size = derecho::Conf::get()->getInt32(derecho::Conf::RDMA_RX_DEPTH);
         if(g_ctxt.hints->tx_attr->size == 0 || g_ctxt.hints->rx_attr->size == 0) {
             dbg_default_error("Configuration error! RDMA TX and RX depth must be nonzero.");
             std::cerr << "Configuration error! RDMA TX and RX depth must be nonzero." << std::endl;

--- a/src/rdmc/verbs_helper.cpp
+++ b/src/rdmc/verbs_helper.cpp
@@ -289,7 +289,7 @@ bool verbs_initialize(const map<uint32_t, std::pair<ip_addr_t, uint16_t>>& ip_ad
         goto resources_create_exit;
     }
 
-    local_config.dev_name = strdup(derecho::getConfString(CONF_RDMA_DOMAIN).c_str());
+    local_config.dev_name = strdup(derecho::getConfString(derecho::Conf::RDMA_DOMAIN).c_str());
     fprintf(stdout, "found %d device(s)\n", num_devices);
     /* search for the specific device we want to work with */
     for(i = 0; i < num_devices; i++) {
@@ -526,8 +526,8 @@ queue_pair::queue_pair(size_t remote_index,
     qp_init_attr.sq_sig_all = 1;
     qp_init_attr.send_cq = verbs_resources.cq;
     qp_init_attr.recv_cq = verbs_resources.cq;
-    qp_init_attr.cap.max_send_wr = derecho::getConfUInt32(CONF_RDMA_TX_DEPTH);
-    qp_init_attr.cap.max_recv_wr = derecho::getConfUInt32(CONF_RDMA_RX_DEPTH);
+    qp_init_attr.cap.max_send_wr = derecho::getConfUInt32(derecho::Conf::RDMA_TX_DEPTH);
+    qp_init_attr.cap.max_recv_wr = derecho::getConfUInt32(derecho::Conf::RDMA_RX_DEPTH);
     qp_init_attr.cap.max_send_sge = 1;
     qp_init_attr.cap.max_recv_sge = 1;
 

--- a/src/sst/lf.cpp
+++ b/src/sst/lf.cpp
@@ -147,10 +147,10 @@ static void load_configuration() {
 
     // provider:
     g_ctxt.hints->fabric_attr->prov_name = crash_if_nullptr("strdup provider name.",
-                                                            strdup, derecho::getConfString(CONF_RDMA_PROVIDER).c_str());
+                                                            strdup, derecho::getConfString(derecho::Conf::RDMA_PROVIDER).c_str());
     // domain:
     g_ctxt.hints->domain_attr->name = crash_if_nullptr("strdup domain name.",
-                                                       strdup, derecho::getConfString(CONF_RDMA_DOMAIN).c_str());
+                                                       strdup, derecho::getConfString(derecho::Conf::RDMA_DOMAIN).c_str());
     if((strcmp(g_ctxt.hints->fabric_attr->prov_name, "sockets") == 0) || (strcmp(g_ctxt.hints->fabric_attr->prov_name, "tcp") == 0)) {
         g_ctxt.hints->domain_attr->mr_mode = FI_MR_BASIC;
     } else {  // default
@@ -165,8 +165,8 @@ static void load_configuration() {
     // g_ctxt.rx_depth = DEFAULT_RX_DEPTH;
 
     // tx_depth
-    g_ctxt.hints->tx_attr->size = derecho::Conf::get()->getInt32(CONF_RDMA_TX_DEPTH);
-    g_ctxt.hints->rx_attr->size = derecho::Conf::get()->getInt32(CONF_RDMA_RX_DEPTH);
+    g_ctxt.hints->tx_attr->size = derecho::Conf::get()->getInt32(derecho::Conf::RDMA_TX_DEPTH);
+    g_ctxt.hints->rx_attr->size = derecho::Conf::get()->getInt32(derecho::Conf::RDMA_RX_DEPTH);
 }
 
 std::shared_mutex _resources::oob_mrs_mutex;
@@ -658,7 +658,7 @@ void _resources::oob_remote_op(uint32_t op, const struct iovec* iov, int iovcnt,
     struct timeval  cur_time;
     gettimeofday(&cur_time, NULL);
     start_time_msec = (cur_time.tv_sec*1e3)+(cur_time.tv_usec/1e3);
-    uint64_t        poll_cq_timeout_ms = derecho::getConfUInt64(CONF_DERECHO_SST_POLL_CQ_TIMEOUT_MS);
+    uint64_t        poll_cq_timeout_ms = derecho::getConfUInt64(derecho::Conf::DERECHO_SST_POLL_CQ_TIMEOUT_MS);
 
     while (true) {
         ce = util::polling_data.get_completion_entry(tid);
@@ -1004,7 +1004,7 @@ void lf_initialize(const std::map<node_id_t, std::pair<ip_addr_t, uint16_t>>& in
                    uint32_t node_id) {
     // Create SST logger, which must be done exactly once before any SST functions are called
     auto logger = LoggerFactory::createLogger(LoggerFactory::SST_LOGGER_NAME,
-                                              derecho::getConfString(CONF_LOGGER_SST_LOG_LEVEL));
+                                              derecho::getConfString(derecho::Conf::LOGGER_SST_LOG_LEVEL));
 
     // initialize derecho connection manager
     // May there be a better design?

--- a/src/sst/verbs.cpp
+++ b/src/sst/verbs.cpp
@@ -130,8 +130,8 @@ _resources::_resources(int r_index, uint8_t* write_addr, uint8_t* read_addr, int
     qp_init_attr.send_cq = g_res->cq;
     qp_init_attr.recv_cq = g_res->cq;
     // since we send the value first and the update the counter, we double the depth configurations.
-    qp_init_attr.cap.max_send_wr = derecho::getConfUInt32(CONF_RDMA_TX_DEPTH) << 1;
-    qp_init_attr.cap.max_recv_wr = derecho::getConfUInt32(CONF_RDMA_RX_DEPTH) << 1;
+    qp_init_attr.cap.max_send_wr = derecho::getConfUInt32(derecho::Conf::RDMA_TX_DEPTH) << 1;
+    qp_init_attr.cap.max_recv_wr = derecho::getConfUInt32(derecho::Conf::RDMA_RX_DEPTH) << 1;
     qp_init_attr.cap.max_send_sge = 1;
     qp_init_attr.cap.max_recv_sge = 1;
     // create the queue pair
@@ -148,7 +148,7 @@ _resources::_resources(int r_index, uint8_t* write_addr, uint8_t* read_addr, int
     without_completion_send_cnt = 0;
     // leave 20% queue pair space for ops with completion.
     // send signal every half of the capacity.
-    without_completion_send_signal_interval = (derecho::getConfInt32(CONF_RDMA_TX_DEPTH) * 4 / 5) / 2;
+    without_completion_send_signal_interval = (derecho::getConfInt32(derecho::Conf::RDMA_TX_DEPTH) * 4 / 5) / 2;
     without_completion_send_capacity = without_completion_send_signal_interval * 2;
     // sender context
     without_completion_sender_ctxt.type = verbs_sender_ctxt::INTERNAL_FLOW_CONTROL;
@@ -653,7 +653,7 @@ void resources_create() {
         cout << "NO RDMA device present" << endl;
     }
     // search for the specific device we want to work with
-    char* dev_name = strdup(derecho::getConfString(CONF_RDMA_DOMAIN).c_str());
+    char* dev_name = strdup(derecho::getConfString(derecho::Conf::RDMA_DOMAIN).c_str());
     for(i = 0; i < num_devices; i++) {
         if(!dev_name) {
             dev_name = strdup(ibv_get_device_name(dev_list[i]));

--- a/src/utils/logger.cpp
+++ b/src/utils/logger.cpp
@@ -30,7 +30,7 @@ std::shared_ptr<spdlog::logger> LoggerFactory::_create_logger(
     spdlog::level::level_enum log_level) {
     std::vector<spdlog::sink_ptr> log_sinks;
     log_sinks.push_back(_file_sink);
-    if(derecho::getConfBoolean(CONF_LOGGER_LOG_TO_TERMINAL)) {
+    if(derecho::getConfBoolean(derecho::Conf::LOGGER_LOG_TO_TERMINAL)) {
         log_sinks.push_back(_stdout_sink);
     }
     std::shared_ptr<spdlog::logger> log = std::make_shared<spdlog::async_logger>(
@@ -57,12 +57,12 @@ void LoggerFactory::_initialize() {
         spdlog::init_thread_pool(1L<<20, 1); // 1MB buffer, 1 thread
         _thread_pool_holder = spdlog::thread_pool();
         // 2 - initialize the sink objects that will be shared by all loggers
-        std::string default_logger_name = derecho::getConfString(CONF_LOGGER_DEFAULT_LOG_NAME);
+        std::string default_logger_name = derecho::getConfString(derecho::Conf::LOGGER_DEFAULT_LOG_NAME);
         _file_sink = std::make_shared<spdlog::sinks::rotating_file_sink_mt>(
-            default_logger_name + ".log", 1L<<20, derecho::getConfUInt32(CONF_LOGGER_LOG_FILE_DEPTH));
+            default_logger_name + ".log", 1L<<20, derecho::getConfUInt32(derecho::Conf::LOGGER_LOG_FILE_DEPTH));
         _stdout_sink = std::make_shared<spdlog::sinks::stdout_color_sink_mt>();
         // 3 - initialize the default Logger
-        std::string default_log_level = derecho::getConfString(CONF_LOGGER_DEFAULT_LOG_LEVEL);
+        std::string default_log_level = derecho::getConfString(derecho::Conf::LOGGER_DEFAULT_LOG_LEVEL);
         _default_logger = _create_logger(default_logger_name,
             spdlog::level::from_str(default_log_level));
         // 3 - change state to initialized


### PR DESCRIPTION
Using macros for constants is a holdover from C, and there are usually better ways to define constants in C++. Although string constants in particular are a little more tricky to define because string literals are not `std::string`s, the best way to define a string constant in C++ seems to be to use a `constexpr const char*` initialized to a string literal. According to [this SO question](https://stackoverflow.com/q/459942/1500563) it's safer to use `const char*` rather than `std::string` when you want a constant because `std::string` is a non-POD object that needs dynamic allocation and thus will suffer from the static initialization order fiasco. And according to [this](https://stackoverflow.com/q/29844028/1500563) and [this](https://stackoverflow.com/q/54891550/1500563), the `constexpr` keyword allows you to declare and initialize a `char*` from a string literal all in one line, in a header file, which is much nicer than needing to separately declare the constant in the header file and then initialize it in the CPP file. Since `constexpr` is evaluated at compile-time, there will still only be one copy of each string constant in the compiled Derecho library no matter how many times the header is included.

In this change I replaced the CONF_ macros that define string values in the conf.hpp header with equivalent string constants that are static members of the Conf class. The names of the new constants are the same as the old macros minus the CONF_ prefix, so I simply replaced CONF_ with Conf:: everywhere the macros were used (for example, CONF_DERECHO_LOCAL_ID becomes Conf::DERECHO_LOCAL_ID). 

Note that since the new string constants are now properly contained within the derecho namespace, instead of being in the single global macro namespace, there are some places where I needed to add the `derecho::` prefix before the string constant, e.g. in the unit test files and other "executables." This is a good thing, because it was always a little dangerous that Derecho put so many macro names in the global namespace and expected non-Derecho code to reach in and use them.