### PR TITLE
Exposing more information through GroupProjection. Removing PAGE_SIZE macro definition.

### DIFF
--- a/derechoConfig.cmake
+++ b/derechoConfig.cmake
@@ -9,8 +9,9 @@ find_dependency(spdlog 1.3.1)
 find_dependency(OpenSSL 1.1.1)
 find_dependency(nlohmann_json 3.9.0)
 
-set_and_check(derecho_INCLUDE_DIRS "@PACKAGE_CMAKE_INSTALL_INCLUDEDIR@")
-set(derecho_LIBRARIES "-L@PACKAGE_CMAKE_INSTALL_LIBDIR@ -lderecho -pthread")
+# We don't support the old style derecho_INCLUDE_DIRS and derecho_LIBRARIES anymore.
+# set_and_check(derecho_INCLUDE_DIRS "@PACKAGE_CMAKE_INSTALL_INCLUDEDIR@")
+# set(derecho_LIBRARIES "-L@PACKAGE_CMAKE_INSTALL_LIBDIR@ -lderecho -pthread")
 include("${CMAKE_CURRENT_LIST_DIR}/derechoTargets.cmake")
 
 check_required_components(derecho)

--- a/include/derecho/core/detail/derecho_sst.hpp
+++ b/include/derecho/core/detail/derecho_sst.hpp
@@ -243,11 +243,9 @@ public:
             num_acked[row] = 0;
             wedged[row] = false;
             // start off local_stability_frontier with the current time
-            struct timespec start_time;
-            clock_gettime(CLOCK_REALTIME, &start_time);
-            auto current_time = start_time.tv_sec * 1e9 + start_time.tv_nsec;
+            auto current_time_ns = get_walltime();
             for(size_t i = 0; i < local_stability_frontier.size(); ++i) {
-                local_stability_frontier[row][i] = current_time;
+                local_stability_frontier[row][i] = current_time_ns;
             }
             rip[row] = false;
         }

--- a/include/derecho/core/detail/external_group_impl.hpp
+++ b/include/derecho/core/detail/external_group_impl.hpp
@@ -541,8 +541,7 @@ void ExternalGroupClient<ReplicatedTypes...>::p2p_receive_loop() {
 
     request_worker_thread = std::thread(&ExternalGroupClient<ReplicatedTypes...>::p2p_request_worker, this);
 
-    struct timespec last_time, cur_time;
-    clock_gettime(CLOCK_REALTIME, &last_time);
+    uint64_t last_time_ms = get_walltime() / INT64_1E6;
 
     // loop event
     while(!thread_shutdown) {
@@ -557,12 +556,10 @@ void ExternalGroupClient<ReplicatedTypes...>::p2p_receive_loop() {
             }
 
             // update last time
-            clock_gettime(CLOCK_REALTIME, &last_time);
+            last_time_ms = get_walltime() / INT64_1E6;
         } else {
-            clock_gettime(CLOCK_REALTIME, &cur_time);
             // check if the system has been inactive for enough time to induce sleep
-            double time_elapsed_in_ms = (cur_time.tv_sec - last_time.tv_sec) * 1e3
-                                        + (cur_time.tv_nsec - last_time.tv_nsec) / 1e6;
+            uint64_t time_elapsed_in_ms = (get_walltime() / INT64_1E6) - last_time_ms;
             if(time_elapsed_in_ms > busy_wait_before_sleep_ms) {
                 using namespace std::chrono_literals;
                 std::this_thread::sleep_for(1ms);

--- a/include/derecho/core/detail/group_impl.hpp
+++ b/include/derecho/core/detail/group_impl.hpp
@@ -600,6 +600,16 @@ node_id_t Group<ReplicatedTypes...>::get_rpc_caller_id() {
 }
 
 template <typename... ReplicatedTypes>
+uint64_t Group<ReplicatedTypes...>::get_max_p2p_request_payload_size() {
+    return getConfUInt64(Conf::DERECHO_MAX_P2P_REQUEST_PAYLOAD_SIZE);
+}
+
+template <typename... ReplicatedTypes>
+uint64_t Group<ReplicatedTypes...>::get_max_p2p_reply_payload_size() {
+    return getConfUInt64(Conf::DERECHO_MAX_P2P_REPLY_PAYLOAD_SIZE);
+}
+
+template <typename... ReplicatedTypes>
 void Group<ReplicatedTypes...>::barrier_sync() {
     view_manager.barrier_sync();
 }

--- a/include/derecho/core/detail/group_impl.hpp
+++ b/include/derecho/core/detail/group_impl.hpp
@@ -25,6 +25,14 @@ auto& _Group::get_subgroup(uint32_t subgroup_num) {
 }
 
 template <typename SubgroupType>
+uint32_t _Group::get_subgroup_max_payload_size(uint32_t subgroup_num) {
+    if (auto gptr = dynamic_cast<GroupProjection<SubgroupType>*>(this)) {
+        return gptr->get_subgroup_max_payload_size(subgroup_num);
+    } else 
+        throw derecho_exception("Error: this top-level group contains no subgroups for the selected type.");
+}
+
+template <typename SubgroupType>
 auto& _Group::get_nonmember_subgroup(uint32_t subgroup_num) {
     if(auto gptr = dynamic_cast<GroupProjection<SubgroupType>*>(this)) {
         return gptr->get_nonmember_subgroup(subgroup_num);
@@ -79,6 +87,13 @@ GroupProjection<ReplicatedType>::get_subgroup(uint32_t subgroup_num) {
     set_replicated_pointer(std::type_index{typeid(ReplicatedType)}, subgroup_num,
                            &pointer_to_replicated);
     return *static_cast<Replicated<ReplicatedType>*>(pointer_to_replicated);
+}
+
+template <typename ReplicatedType>
+uint32_t
+GroupProjection<ReplicatedType>::get_subgroup_max_payload_size(uint32_t subgroup_num) {
+    void* pointer_to_replicated{nullptr};
+    return get_view_manager().get_subgroup_max_payload_size(get_index_of_type(typeid(ReplicatedType)), subgroup_num);
 }
 
 template <typename ReplicatedType>

--- a/include/derecho/core/detail/view_manager.hpp
+++ b/include/derecho/core/detail/view_manager.hpp
@@ -977,6 +977,14 @@ public:
     // UGLY - IMPROVE LATER
     std::map<subgroup_id_t, uint64_t> max_payload_sizes;
     std::map<subgroup_id_t, uint64_t> get_max_payload_sizes();
+    /**
+     * @fn get_Subgroup_max_payload_size(sbugroup_type_id_t,uint32_t) view_manager.hpp \<derecho/core/detail/view_manager.hpp\>
+     * @brief get maximum payload size of a given subgroup.
+     * @param[in]   subgroup_type   The type of the subgroup.
+     * @param[in]   subgroup_index  The index of the subgroup.
+     * @return the maximum payload size of the subgroup.
+     */
+    uint64_t get_subgroup_max_payload_size(subgroup_type_id_t subgroup_type, uint32_t subgroup_index);
     // max of max_payload_sizes
     uint64_t view_max_rpc_reply_payload_size = 0;
     uint32_t view_max_rpc_window_size = 0;

--- a/include/derecho/core/group.hpp
+++ b/include/derecho/core/group.hpp
@@ -116,6 +116,10 @@ public:
 
     virtual node_id_t get_rpc_caller_id() = 0;
 
+    virtual uint64_t get_max_p2p_request_payload_size() = 0;
+
+    virtual uint64_t get_max_p2p_reply_payload_size() = 0;
+
 };
 
 /**
@@ -488,6 +492,12 @@ public:
 
     /** @returns the id of the lastest rpc caller, only valid when called from an RPC handler */
     node_id_t get_rpc_caller_id() override;
+
+    /** @returns the maximal allowed p2p request payload size */
+    uint64_t get_max_p2p_request_payload_size() override;
+
+    /** @returns the maximal allowed p2p reply payload size */
+    uint64_t get_max_p2p_reply_payload_size() override;
 
     /**
      * @returns the shard number that this node is a member of in the specified

--- a/include/derecho/core/group.hpp
+++ b/include/derecho/core/group.hpp
@@ -92,6 +92,9 @@ public:
     auto& get_subgroup(uint32_t subgroup_index = 0);
 
     template <typename SubgroupType>
+    uint32_t get_subgroup_max_payload_size(uint32_t subgroup_index = 0);
+
+    template <typename SubgroupType>
     auto& get_nonmember_subgroup(uint32_t subgroup_num = 0);
 
     template <typename SubgroupType>
@@ -112,6 +115,7 @@ public:
     virtual node_id_t get_my_id() = 0;
 
     virtual node_id_t get_rpc_caller_id() = 0;
+
 };
 
 /**
@@ -132,6 +136,7 @@ protected:
 
 public:
     Replicated<ReplicatedType>& get_subgroup(uint32_t subgroup_index = 0);
+    uint32_t get_subgroup_max_payload_size(uint32_t subgroup_index = 0);
     PeerCaller<ReplicatedType>& get_nonmember_subgroup(uint32_t subgroup_index = 0);
     ExternalClientCallback<ReplicatedType>& get_client_callback(uint32_t subgroup_index = 0);
     std::vector<std::vector<node_id_t>> get_subgroup_members(uint32_t subgroup_index = 0);

--- a/include/derecho/core/replicated.hpp
+++ b/include/derecho/core/replicated.hpp
@@ -328,7 +328,7 @@ public:
 
     inline const HLC getFrontier() {
         // transform from ns to us:
-        HLC hlc(this->compute_global_stability_frontier() / 1e3, 0);
+        HLC hlc(this->compute_global_stability_frontier() / INT64_1E3, 0);
         return hlc;
     }
 

--- a/include/derecho/persistent/Persistent.hpp
+++ b/include/derecho/persistent/Persistent.hpp
@@ -6,8 +6,9 @@
 #include "PersistException.hpp"
 #include "PersistNoLog.hpp"
 #include "PersistentInterface.hpp"
-#include "derecho/mutils-serialization/SerializationSupport.hpp"
-#include "derecho/utils/logger.hpp"
+#include <derecho/mutils-serialization/SerializationSupport.hpp>
+#include <derecho/utils/logger.hpp>
+#include <derecho/utils/time.h>
 #include "detail/FilePersistLog.hpp"
 #include "detail/PersistLog.hpp"
 #include "detail/logger.hpp"
@@ -224,9 +225,7 @@ public:
             return m_temporalQueryFrontierProvider->getFrontier();
 #endif  //NDEBUG
         } else {
-            struct timespec t;
-            clock_gettime(CLOCK_REALTIME, &t);
-            return HLC((uint64_t)(t.tv_sec * 1e6 + t.tv_nsec / 1e3), (uint64_t)0);
+            return HLC(get_walltime()/INT64_1E3, (uint64_t)0);
         }
     }
 

--- a/include/derecho/persistent/detail/FilePersistLog.hpp
+++ b/include/derecho/persistent/detail/FilePersistLog.hpp
@@ -87,8 +87,7 @@ union LogEntry {
 #define NUM_USED_BYTES ((NUM_USED_SLOTS == 0) ? 0 : (LOG_ENTRY_AT(CURR_LOG_IDX)->fields.ofst + LOG_ENTRY_AT(CURR_LOG_IDX)->fields.sdlen - LOG_ENTRY_AT(m_currMetaHeader.fields.head)->fields.ofst))
 #define NUM_FREE_BYTES (MAX_DATA_SIZE - NUM_USED_BYTES)
 
-#define PAGE_SIZE (getpagesize())
-#define ALIGN_TO_PAGE(x) ((void*)(((uint64_t)(x)) - ((uint64_t)(x)) % PAGE_SIZE))
+#define ALIGN_TO_PAGE(x) ((void*)(((uint64_t)(x)) - ((uint64_t)(x)) % getpagesize()))
 
 // declaration for binary search util. see cpp file for comments.
 template <typename TKey, typename KeyGetter>

--- a/include/derecho/utils/time.h
+++ b/include/derecho/utils/time.h
@@ -6,6 +6,10 @@
 #include <sys/resource.h>
 #include <time.h>
 
+#define INT64_1E3  (1000L)
+#define INT64_1E6  (1000000L)
+#define INT64_1E9  (1000000000L)
+
 #ifdef __cplusplus
 extern "C" {
 #endif//__cplusplus
@@ -13,13 +17,13 @@ extern "C" {
 inline uint64_t get_time() {
     struct timespec now;
     clock_gettime(CLOCK_MONOTONIC, &now);
-    return now.tv_sec * 1000000000L + now.tv_nsec;
+    return now.tv_sec * INT64_1E9 + now.tv_nsec;
 }
 
 inline uint64_t get_walltime() {
     struct timespec now;
     clock_gettime(CLOCK_REALTIME, &now);
-    return now.tv_sec * 1000000000L + now.tv_nsec;
+    return now.tv_sec * INT64_1E9 + now.tv_nsec;
 }
 
 // Returns the number of nanoseconds of CPU time that have been used by this
@@ -27,7 +31,7 @@ inline uint64_t get_walltime() {
 inline uint64_t get_process_time() {
     rusage usage;
     getrusage(RUSAGE_SELF, &usage);
-    return (usage.ru_utime.tv_sec + usage.ru_stime.tv_sec) * 1000000000L + (usage.ru_utime.tv_usec + usage.ru_stime.tv_usec) * 1000L;
+    return (usage.ru_utime.tv_sec + usage.ru_stime.tv_sec) * INT64_1E9 + (usage.ru_utime.tv_usec + usage.ru_stime.tv_usec) * INT64_1E3;
 }
 
 #ifdef __cplusplus

--- a/src/core/multicast_group.cpp
+++ b/src/core/multicast_group.cpp
@@ -549,11 +549,9 @@ bool MulticastGroup::version_message(RDMCMessage& msg, const subgroup_id_t& subg
         pending_persistence[subgroup_num][locally_stable_rdmc_messages[subgroup_num].begin()->first] = msg_timestamp;
     }
     // make a version for persistent<t>/volatile<t>
-    uint64_t msg_ts_us = msg_timestamp / 1e3;
+    uint64_t msg_ts_us = msg_timestamp / INT64_1E3;
     if(msg_ts_us == 0) {
-        struct timespec now;
-        clock_gettime(CLOCK_REALTIME, &now);
-        msg_ts_us = (uint64_t)now.tv_sec * 1e6 + now.tv_nsec / 1e3;
+        msg_ts_us = get_walltime() / INT64_1E3;
     }
     persistence_manager.make_version(subgroup_num, version, HLC{msg_ts_us, 0});
     return true;
@@ -571,11 +569,9 @@ bool MulticastGroup::version_message(SSTMessage& msg, const subgroup_id_t& subgr
         pending_persistence[subgroup_num][locally_stable_sst_messages[subgroup_num].begin()->first] = msg_timestamp;
     }
     // make a version for persistent<t>/volatile<t>
-    uint64_t msg_ts_us = msg_timestamp / 1e3;
+    uint64_t msg_ts_us = msg_timestamp / INT64_1E3;
     if(msg_ts_us == 0) {
-        struct timespec now;
-        clock_gettime(CLOCK_REALTIME, &now);
-        msg_ts_us = (uint64_t)now.tv_sec * 1e6 + now.tv_nsec / 1e3;
+        msg_ts_us = get_walltime() / INT64_1E3;
     }
     persistence_manager.make_version(subgroup_num, version, HLC{msg_ts_us, 0});
     return true;

--- a/src/core/view_manager.cpp
+++ b/src/core/view_manager.cpp
@@ -1997,6 +1997,13 @@ std::map<subgroup_id_t, uint64_t> ViewManager::get_max_payload_sizes() {
     return max_payload_sizes;
 }
 
+uint64_t ViewManager::get_subgroup_max_payload_size(subgroup_type_id_t subgroup_type, uint32_t subgroup_index) {
+    shared_lock_t read_lock(view_mutex);
+    subgroup_id_t subgroup_id = curr_view->subgroup_ids_by_type_id.at(subgroup_type).at(subgroup_index);
+    return max_payload_sizes.at(subgroup_id);
+}
+
+
 std::map<node_id_t, std::pair<ip_addr_t, uint16_t>>
 ViewManager::make_member_ips_and_ports_map(const View& view, const PortType port) {
     std::map<node_id_t, std::pair<ip_addr_t, uint16_t>> member_ips_and_ports_map;

--- a/src/persistent/FilePersistLog.cpp
+++ b/src/persistent/FilePersistLog.cpp
@@ -325,10 +325,10 @@ version_t FilePersistLog::persist(version_t ver, bool preLocked) {
             flush_dlen = (LOG_ENTRY_AT(CURR_LOG_IDX)->fields.ofst + LOG_ENTRY_AT(CURR_LOG_IDX)->fields.sdlen - NEXT_LOG_ENTRY_PERS->fields.ofst);
             // flush data
             flush_dstart = ALIGN_TO_PAGE(NEXT_DATA_PERS);
-            flush_dlen += ((int64_t)NEXT_DATA_PERS) % PAGE_SIZE;
+            flush_dlen += ((int64_t)NEXT_DATA_PERS) % getpagesize();
             // flush log
             flush_lstart = ALIGN_TO_PAGE(NEXT_LOG_ENTRY_PERS);
-            flush_llen = ((size_t)NEXT_LOG_ENTRY - (size_t)NEXT_LOG_ENTRY_PERS) + ((int64_t)NEXT_LOG_ENTRY_PERS) % PAGE_SIZE;
+            flush_llen = ((size_t)NEXT_LOG_ENTRY - (size_t)NEXT_LOG_ENTRY_PERS) + ((int64_t)NEXT_LOG_ENTRY_PERS) % getpagesize();
         }
         if(NUM_USED_SLOTS > 0) {
             //get the latest flushed version


### PR DESCRIPTION
Exposing more group configuration information through GroupProjection. Before, the information was retrieved through `derecho::Conf` API, which loads the information from the configuration file. That's not optimal regarding the source of information. Instead, the active group class should take responsibility. 

The other minor change in the pull request is the removal of PAGE_SIZE definition. Previously, I defined it to `getpagesize()` call. That uses the runtime information. Although it does not cause any issues in most cases, it prevents static/compile-time checking. Instead, PAGE_SIZE should derive from the compile-time detector as a constant. However, Derecho only uses it in the file system log layer, so I removed it here.