### PR TITLE
External clients graceful exit

### DIFF
--- a/include/derecho/core/detail/group_impl.hpp
+++ b/include/derecho/core/detail/group_impl.hpp
@@ -388,6 +388,9 @@ void Group<ReplicatedTypes...>::set_up_components() {
     view_manager.register_add_external_connection_upcall([this](uint32_t node_id) {
         rpc_manager.add_external_connection(node_id);
     });
+    view_manager.register_remove_external_connection_upcall([this](uint32_t node_id) {
+        rpc_manager.remove_external_connection(node_id);
+    });
     // Give RPCManager a standard "new view callback" on every View change
     view_manager.add_view_upcall([this](const View& new_view) {
         rpc_manager.new_view_callback(new_view);

--- a/include/derecho/core/detail/p2p_connection_manager.hpp
+++ b/include/derecho/core/detail/p2p_connection_manager.hpp
@@ -79,6 +79,11 @@ public:
     void add_connections(const std::vector<node_id_t>& node_ids);
     void remove_connections(const std::vector<node_id_t>& node_ids);
     bool contains_node(const node_id_t node_id);
+
+    /**
+     * @return the list of node ids with whom there is an active p2p connection
+     */
+    std::vector<node_id_t> get_active_nodes();
     /**
      * @return the size of the byte array used for sending a single P2P reply
      * in any of the P2P connections. No messages larger than this can be sent.

--- a/include/derecho/core/detail/rpc_manager.hpp
+++ b/include/derecho/core/detail/rpc_manager.hpp
@@ -281,6 +281,14 @@ public:
      * are set up in the new-view callback, but external clients can join at any time.
      */
     void add_external_connection(node_id_t node_id);
+    
+    /**
+     * Remove a P2P connection to an external client. The connection is cleaned up in 
+     * case a failure is detected (i.e. the external client stopped sending heartbeats. 
+     * However, we avoid the failure procedure in case the external client performs a 
+     * graceful exit, informing that it is exiting.
+     */
+    void remove_external_connection(node_id_t node_id);
 
     /**
      * Starts the thread that listens for incoming P2P RPC requests over the RDMA P2P

--- a/include/derecho/core/detail/view_manager.hpp
+++ b/include/derecho/core/detail/view_manager.hpp
@@ -101,7 +101,8 @@ struct JoinRequest {
  */
 enum class ExternalClientRequest {
     GET_VIEW,      //!< GET_VIEW The external client wants to download the current View
-    ESTABLISH_P2P  //!< ESTABLISH_P2P The external client wants to set up a P2P connection with this node
+    ESTABLISH_P2P, //!< ESTABLISH_P2P The external client wants to set up a P2P connection with this node
+    REMOVE_P2P     //!< REMOVE_P2P The external client is informing that it is exiting
 };
 
 template <typename T>
@@ -275,6 +276,7 @@ private:
     std::atomic<bool> bSilent = false;
 
     std::function<void(uint32_t)> add_external_connection_upcall;
+    std::function<void(uint32_t)> remove_external_connection_upcall;
 
     bool has_pending_new() { return pending_new_sockets.locked().access.size() > 0; }
     bool has_pending_join() { return pending_join_sockets.size() > 0; }
@@ -794,6 +796,10 @@ public:
 
     void register_add_external_connection_upcall(const std::function<void(uint32_t)>& upcall) {
         add_external_connection_upcall = upcall;
+    }
+    
+    void register_remove_external_connection_upcall(const std::function<void(uint32_t)>& upcall) {
+        remove_external_connection_upcall = upcall;
     }
 
     /**

--- a/src/core/p2p_connection_manager.cpp
+++ b/src/core/p2p_connection_manager.cpp
@@ -79,6 +79,17 @@ bool P2PConnectionManager::contains_node(const node_id_t node_id) {
     return p2p_connections[node_id].second != nullptr;
 }
 
+std::vector<node_id_t> P2PConnectionManager::get_active_nodes(){
+    std::vector<node_id_t> node_ids;
+    for(uint32_t i = 0; i < derecho::getConfUInt32(derecho::Conf::DERECHO_MAX_NODE_ID); ++i) {
+        std::lock_guard<std::mutex> connection_lock(p2p_connections[i].first);
+        if(active_p2p_connections[i]){
+            node_ids.push_back(i);
+        }
+    }
+    return node_ids;
+}
+
 void P2PConnectionManager::shutdown_failures_thread() {
     thread_shutdown = true;
     if(timeout_thread.joinable()) {

--- a/src/core/rpc_manager.cpp
+++ b/src/core/rpc_manager.cpp
@@ -415,6 +415,13 @@ void RPCManager::add_external_connection(node_id_t node_id) {
     connections->add_connections({node_id});
 }
 
+void RPCManager::remove_external_connection(node_id_t node_id) {
+    if(external_client_ids.erase(node_id) != 0) {
+        dbg_debug(rpc_logger, "External client with id {} gracefully exiting, doing cleanup", node_id);
+        connections->remove_connections({node_id});
+    }
+}
+
 void RPCManager::register_rpc_results(subgroup_id_t subgroup_id, std::weak_ptr<AbstractPendingResults> pending_results_handle) {
     std::lock_guard<std::mutex> lock(pending_results_mutex);
     pending_results_to_fulfill[subgroup_id].push(pending_results_handle);

--- a/src/core/view_manager.cpp
+++ b/src/core/view_manager.cpp
@@ -1092,6 +1092,9 @@ void ViewManager::external_join_handler(tcp::socket& client_socket, const node_i
         sst::add_external_node(joiner_id, {client_socket.get_remote_ip(),
                                            external_client_external_port});
         add_external_connection_upcall(joiner_id);
+    } else if(request == ExternalClientRequest::REMOVE_P2P) {
+        sst::remove_node(joiner_id);
+        remove_external_connection_upcall(joiner_id);
     }
 }
 


### PR DESCRIPTION
This fixes [Cascade Issue #54](https://github.com/Derecho-Project/cascade/issues/54). In the current Derecho implementation, the external client leaves brutally without notifying the Derecho group member. This causes a command line client (like in Cascade) to freeze when it quickly tries to connect again (e.g. due to the following command invocation).

The solution is a graceful exit procedure for a leaving external client. It not only solves the above issue but also gets rid of the annoying error messages. This PR does the following:

- Adds a new JoinRequest type (REMOVE_P2P)
- The ExternalGroupClient destructor sends a REMOVE_P2P join request to all nodes for which there is an active p2p connection
- The ExternalGroupClient destructor does some cleanup to avoid problems when a new process is initiated and try to use the same resources again
-  ViewManager has a new upcall (remove_external_connection), which connects with the RPCManager (calls the new method rpc_manager.remove_external_connection)
- When a REMOVE_P2P join request is received, RPCManager and ViewManager remove the external node from the P2P connections and SST, which is the same cleanup performed when a failure is detected (which was the old way of cleaning up external clients)

I tested this solution with TCP and RDMA, using the Cascade Python and C clients.