### PR TITLE
Timestamp order is guaranteed in a shard, even with loosely synchronized clock.

### DIFF
--- a/include/derecho/core/detail/replicated_impl.hpp
+++ b/include/derecho/core/detail/replicated_impl.hpp
@@ -284,7 +284,11 @@ persistent::version_t Replicated<T>::get_minimum_latest_persisted_version() {
 template <typename T>
 void Replicated<T>::post_next_version(persistent::version_t version, uint64_t ts_us) {
     current_version = version;
-    current_hlc.tick({ts_us,0},false);
+    if (current_hlc > HLC{ts_us,0}) {
+        current_hlc.m_logic ++;
+    } else {
+        current_hlc = {ts_us,0};
+    }
 }
 
 template <typename T>

--- a/include/derecho/core/replicated.hpp
+++ b/include/derecho/core/replicated.hpp
@@ -153,9 +153,9 @@ private:
      */
     _Group* group;
     /** The current version number being processed by an ordered_send */
-    persistent::version_t current_version = persistent::INVALID_VERSION;
-    /** The timestamp associated with the current version number */
-    uint64_t current_timestamp_us = 0;
+    persistent::version_t current_version;
+    /** The HLC associated with the current version number */
+    HLC current_hlc;
 
 public:
     /**
@@ -431,9 +431,9 @@ public:
      * since P2P method calls are handled in a separate thread from ordered_send
      * method calls, and there is no synchronization between these two threads on
      * the value of current_version.
-     * @return an ordered pair (version number, timestamp)
+     * @return an ordered pair (version number, HLC)
      */
-    virtual std::tuple<persistent::version_t, uint64_t> get_current_version();
+    virtual std::tuple<persistent::version_t,HLC> get_current_version();
 
     /**
      * Register a persistent member

--- a/include/derecho/persistent/HLC.hpp
+++ b/include/derecho/persistent/HLC.hpp
@@ -37,7 +37,7 @@ public:
     /**
      * Destructor
      */
-    virtual ~HLC() noexcept(false);
+    virtual ~HLC();
 
     /**
      * Local tick

--- a/src/applications/demos/signed_store_mockup.cpp
+++ b/src/applications/demos/signed_store_mockup.cpp
@@ -167,7 +167,7 @@ void SignatureStore::ordered_add_hash(const SHA256Hash& hash) {
     dbg_default_debug("Received call to ordered_add_hash");
     derecho::Replicated<SignatureStore>& this_subgroup = group->get_subgroup<SignatureStore>(this->subgroup_index);
     //Ask the Replicated interface what version it's about to persist
-    std::tuple<persistent::version_t, uint64_t> curr_version = this_subgroup.get_current_version();
+    std::tuple<persistent::version_t, HLC> curr_version = this_subgroup.get_current_version();
     //Append the new hash to the Persistent log, thus generating a version
     *hashes = hash;
     dbg_default_debug("SHA256 hash added for version {}", std::get<0>(curr_version));

--- a/src/applications/tests/performance_tests/signed_store_test.cpp
+++ b/src/applications/tests/performance_tests/signed_store_test.cpp
@@ -245,7 +245,7 @@ std::vector<unsigned char> SignatureStore::add_hash(const SHA256Hash& hash) cons
 void SignatureStore::ordered_add_hash(const SHA256Hash& hash) {
     derecho::Replicated<SignatureStore>& this_subgroup = group->get_subgroup<SignatureStore>(this->subgroup_index);
     //Ask the Replicated interface what version it's about to persist
-    std::tuple<persistent::version_t, uint64_t> curr_version = this_subgroup.get_current_version();
+    std::tuple<persistent::version_t, HLC> curr_version = this_subgroup.get_current_version();
     //Append the new hash to the Persistent log
     *hashes = hash;
     dbg_default_debug("SHA256 hash added for version {}", std::get<0>(curr_version));
@@ -282,8 +282,8 @@ std::pair<persistent::version_t, uint64_t> ObjectStore::update(const Blob& new_d
 void ObjectStore::ordered_update(const Blob& new_data) {
     derecho::Replicated<ObjectStore>& this_subgroup = group->get_subgroup<ObjectStore>(this->subgroup_index);
     //Ask the Replicated interface what version it's about to generate
-    std::tuple<persistent::version_t, uint64_t> next_version = this_subgroup.get_current_version();
-    dbg_default_debug("Got a version of ({}, {}) in ordered_update", std::get<0>(next_version), std::get<1>(next_version));
+    std::tuple<persistent::version_t, HLC> next_version = this_subgroup.get_current_version();
+    dbg_default_debug("Got a version of ({}, {}) in ordered_update", std::get<0>(next_version), std::get<1>(next_version).m_rtc_us);
     //Update the Persistent object, generating a new version
     *object_log = new_data;
 }

--- a/src/persistent/HLC.cpp
+++ b/src/persistent/HLC.cpp
@@ -27,10 +27,8 @@ HLC::HLC(uint64_t _r, uint64_t _l) : m_rtc_us(_r), m_logic(_l) {
     }
 }
 
-HLC::~HLC() noexcept(false) {
-    if(pthread_spin_destroy(&this->m_oLck) != 0) {
-        throw HLC_EXP_SPIN_DESTROY(errno);
-    }
+HLC::~HLC() {
+    pthread_spin_destroy(&this->m_oLck);
 }
 
 #define HLC_LOCK                                \


### PR DESCRIPTION
Previously, the timestamp for each message in a shard is assigned by the sending member. If the members in a shard have drifting clocks, a message with a higher version might have a lower timestamp than another message with a lower version. We call it out-of-order timestamps. Although we manage the timestamp index independently, it would be nice if timestamp and version orders are consistent. Here we borrow the idea of the HLC clock: on message delivery, the current timestamp to assign is checked against the previous one. If the timestamp goes back, we enforce it to be the previous timestamp + 1 using HLC rules. This operation is consistent among all replicas as the message order is guaranteed among them. 