### PR TITLE
Improvements to configuration and restart logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Derecho is aimed at supporting what are called "cloud micro-services", meaning p
 
 The functionality of Derecho centers on:
 * Forming a "group" of servers ("processes").  Membership is automatically tracked and changes are reported via upcalls to your code.
-* Structuring your server group into subgroups.  You would typically have one subgroup for each distinct functionality used.  For example, suppose you were implementing a storage service similar to Apache's Hadoop file system (HDFS).  HDFS has a name-node service, a meta-data service and a storage service.  In Derecho, each would be implemented by a subgroup.  Subgroups can have distinct or overlapping membership, under your control.  For scalability, a subgroup would typically be sharded into even smaller subgroups.  For example, a storage service might have an "array" of mini-storage servers, each handling a subset of the files.  There would be one shard per subset, and the members of that shard would replicate the identical contents.  Unlike in Paxos-based systems you may have read about elsewhere, Derecho supports a full replication model: every active (non-failed) replica has identical, complete contents.  
+* Structuring your server group into subgroups.  You would typically have one subgroup for each distinct functionality used.  For example, suppose you were implementing a storage service similar to Apache's Hadoop file system (HDFS).  HDFS has a name-node service, a meta-data service and a storage service.  In Derecho, each would be implemented by a subgroup.  Subgroups can have distinct or overlapping membership, under your control.  For scalability, a subgroup would typically be sharded into even smaller subgroups.  For example, a storage service might have an "array" of mini-storage servers, each handling a subset of the files.  There would be one shard per subset, and the members of that shard would replicate the identical contents.  Unlike in Paxos-based systems you may have read about elsewhere, Derecho supports a full replication model: every active (non-failed) replica has identical, complete contents.
 * Automated repair after crashes, recoveries, and automated initialization (from a checkpoint) when a new member joins.
 * Automated persisted storage (append-only logging) if desired.
 
@@ -52,12 +52,12 @@ Derecho does not have any specific O/S dependency.  We've tested most extensivel
 This project is organized as a standard CMake-built C++ library: all headers are within the include/derecho/ directory, all CPP files are within the src/ directory, and each subdirectory within src/ contains its own CMakeLists.txt that is included by the root directory's CMakeLists.txt. Within the src/ and include/derecho/ directories, there is a subdirectory for each separate module of Derecho, such as RDMC, SST, and Persistence. Some sample applications and test cases that are built on the Derecho library are included in the src/applications/ directory, which is not included when building the Derecho library itself.
 
 ## Installation
-Derecho is a library that helps you build replicated, fault-tolerant services in a datacenter with RDMA networking. Here's how to start using it in your projects.  
+Derecho is a library that helps you build replicated, fault-tolerant services in a datacenter with RDMA networking. Here's how to start using it in your projects.
 * You will start by verifying that you have a compatible operating system (we do our development on Ubuntu but CentOS should be fine) and network (we recommend RDMA or TCP).
 * Next, decide if you prefer to use a pre-compiled container, which is easier, or would like to build from source.
 * If building from source, you will clone the code base in the place you plan to create the release binaries, then follow the instructions for creating a folder in which the binaries will reside.  Then from "prerequisites" run the .sh shell scripts one by one, for example "sudo ./install-foo.sh".  These should complete without error messages -- if you get warnings or errors, stop and post a question about it on the discussions page.
 * Next, if building from source, follow the remainder of the "installing Derecho" instructions.
-* Last, clone and build the Cascade code base.  
+* Last, clone and build the Cascade code base.
 * You should now be able to set up a configuration file and run our demos.
 
 ### Network requirements (important!)
@@ -140,7 +140,7 @@ To use Derecho in your code, you simply need to
 The configuration file consists of three sections: **DERECHO**, **RDMA**, and **PERS**. The **DERECHO** section includes core configuration options for a Derecho instance, which every application will need to customize. The **RDMA** section includes options for RDMA hardware specifications. The **PERS** section allows you to customize the persistent layer's behavior.
 
 #### Configuring Core Derecho
-Applications need to tell the Derecho library which node is the initial leader with the options **leader_ip** and **leader_gms_port**. Each node then specifies its own ID (**local_id**) and the IP address and ports it will use for Derecho component services (**local_ip**, **gms_port**, **state_transfer_port**, **sst_port**, and **rdmc_port**). Also, if using external clients, applications need to specify the ports serving external clients (**leader_external_port** and **external_port**);
+Applications need to tell the Derecho library which node is the initial leader with the options **leader_ip** and **leader_gms_port**. Each node then specifies its own ID (**local_id**) and the IP address and ports it will use for Derecho component services (**local_ip**, **gms_port**, **state_transfer_port**, **sst_port**, and **rdmc_port**). Also, if using external clients, applications need to specify the ports serving external clients (**external_port**);
 
 The other important parameters are the message sizes. Since Derecho pre-allocates buffers for RDMA communication, each application should decide on an optimal buffer size based on the amount of data it expects to send at once. If the buffer size is much larger than the messages an application actually sends, Derecho will pin a lot of memory and leave it underutilized. If the buffer size is smaller than the application's actual message size, it will have to split messages into segments before sending them, causing unnecessary overhead.
 

--- a/include/derecho/conf/conf.hpp
+++ b/include/derecho/conf/conf.hpp
@@ -21,8 +21,8 @@ constexpr std::size_t DERECHO_MIN_RPC_RESPONSE_SIZE = 128;
 class Conf {
 public:
     //String constants for config options
-    static constexpr const char* DERECHO_LEADER_IP = "DERECHO/leader_ip";
-    static constexpr const char* DERECHO_LEADER_GMS_PORT = "DERECHO/leader_gms_port";
+    static constexpr const char* DERECHO_CONTACT_IP = "DERECHO/contact_ip";
+    static constexpr const char* DERECHO_CONTACT_PORT = "DERECHO/contact_port";
     static constexpr const char* DERECHO_LEADER_EXTERNAL_PORT = "DERECHO/leader_external_port";
     static constexpr const char* DERECHO_RESTART_LEADERS = "DERECHO/restart_leaders";
     static constexpr const char* DERECHO_RESTART_LEADER_PORTS = "DERECHO/restart_leader_ports";
@@ -79,8 +79,8 @@ private:
     // config name --> default value
     std::map<const std::string, std::string> config = {
             // [DERECHO]
-            {DERECHO_LEADER_IP, "127.0.0.1"},
-            {DERECHO_LEADER_GMS_PORT, "23580"},
+            {DERECHO_CONTACT_IP, "127.0.0.1"},
+            {DERECHO_CONTACT_PORT, "23580"},
             {DERECHO_LEADER_EXTERNAL_PORT, "32645"},
             {DERECHO_RESTART_LEADERS, "127.0.0.1"},
             {DERECHO_RESTART_LEADER_PORTS, "23580"},

--- a/include/derecho/core/detail/external_group_impl.hpp
+++ b/include/derecho/core/detail/external_group_impl.hpp
@@ -254,7 +254,7 @@ ExternalGroupClient<ReplicatedTypes...>::~ExternalGroupClient() {
 
             // wait confirmation from server
             bool remove_confirmed;
-            sock.read(remove_confirmed); 
+            sock.read(remove_confirmed);
         } catch(tcp::socket_error&) {
             dbg_default_error("Failed to gracefully exit: socket error while sending join request.");
             dbg_default_flush();
@@ -274,7 +274,7 @@ template <typename... ReplicatedTypes>
 bool ExternalGroupClient<ReplicatedTypes...>::get_view(const node_id_t nid) {
     try {
         tcp::socket sock = (nid == INVALID_NODE_ID)
-                                   ? tcp::socket(getConfString(Conf::DERECHO_LEADER_IP), getConfUInt16(Conf::DERECHO_LEADER_GMS_PORT))
+                                   ? tcp::socket(getConfString(Conf::DERECHO_CONTACT_IP), getConfUInt16(Conf::DERECHO_CONTACT_PORT))
                                    : tcp::socket(curr_view->member_ips_and_ports[curr_view->rank_of(nid)].ip_address,
                                                  curr_view->member_ips_and_ports[curr_view->rank_of(nid)].gms_port, false);
 
@@ -282,14 +282,14 @@ bool ExternalGroupClient<ReplicatedTypes...>::get_view(const node_id_t nid) {
         uint64_t leader_version_hashcode;
         sock.exchange(my_version_hashcode, leader_version_hashcode);
         if(leader_version_hashcode != my_version_hashcode) {
-            dbg_default_error("Leader refused connection because Derecho or compiler version did not match! Local version hashcode = {}, leader version hashcode = {}", my_version_hashcode, leader_version_hashcode);
+            dbg_default_error("Derecho member refused connection because Derecho or compiler version did not match! Local version hashcode = {}, member version hashcode = {}", my_version_hashcode, leader_version_hashcode);
             dbg_default_flush();
             return false;
         }
         sock.write(JoinRequest{my_id, true});
         sock.read(leader_response);
         if(leader_response.code == JoinResponseCode::ID_IN_USE) {
-            dbg_default_error("Leader refused connection because ID {} is already in use!", my_id);
+            dbg_default_error("Derecho member refused connection because ID {} is already in use!", my_id);
             dbg_default_flush();
             return false;
         }

--- a/include/derecho/core/external_group.hpp
+++ b/include/derecho/core/external_group.hpp
@@ -144,7 +144,7 @@ private:
 
     /**
      * requests a new view from group member nid
-     * if nid is -1, then request a view from Conf::DERECHO_LEADER_IP
+     * if nid is -1, then request a view from Conf::DERECHO_CONTACT_IP
      * defined in derecho.cfg
      */
     bool get_view(const node_id_t nid);

--- a/src/applications/archive/initialize.cpp
+++ b/src/applications/archive/initialize.cpp
@@ -24,8 +24,8 @@ std::string read_string(socket& s) {
 std::map<uint32_t, std::pair<ip_addr_t, uint16_t>> initialize(const uint32_t num_nodes) {
     // Get conf file parameters
     // Global information
-    const std::string leader_ip = getConfString(Conf::DERECHO_LEADER_IP);
-    const uint16_t leader_gms_port = getConfUInt16(Conf::DERECHO_LEADER_GMS_PORT);
+    const std::string leader_ip = getConfString(Conf::DERECHO_CONTACT_IP);
+    const uint16_t leader_gms_port = getConfUInt16(Conf::DERECHO_CONTACT_PORT);
     // Local information
     const uint32_t local_id = getConfUInt32(Conf::DERECHO_LOCAL_ID);
     const std::string local_ip = getConfString(Conf::DERECHO_LOCAL_IP);

--- a/src/conf/conf.cpp
+++ b/src/conf/conf.cpp
@@ -29,8 +29,8 @@ std::atomic<uint32_t> Conf::singleton_initialized_flag = 0;
     { x, required_argument, 0, 0 }
 struct option Conf::long_options[] = {
         // [DERECHO]
-        MAKE_LONG_OPT_ENTRY(DERECHO_LEADER_IP),
-        MAKE_LONG_OPT_ENTRY(DERECHO_LEADER_GMS_PORT),
+        MAKE_LONG_OPT_ENTRY(DERECHO_CONTACT_IP),
+        MAKE_LONG_OPT_ENTRY(DERECHO_CONTACT_PORT),
         MAKE_LONG_OPT_ENTRY(DERECHO_LEADER_EXTERNAL_PORT),
         MAKE_LONG_OPT_ENTRY(DERECHO_RESTART_LEADERS),
         MAKE_LONG_OPT_ENTRY(DERECHO_RESTART_LEADER_PORTS),

--- a/src/conf/derecho-sample.cfg
+++ b/src/conf/derecho-sample.cfg
@@ -3,8 +3,6 @@
 leader_ip = 127.0.0.1
 # leader gms port - the leader's gms port
 leader_gms_port = 23580
-# leader external port - the leader's external port
-leader_external_port = 32645
 # list of leaders to contact during a restart in priority order
 restart_leaders = 127.0.0.1,127.0.0.1
 # list of GMS ports of the restart leaders, in the same order

--- a/src/core/git_version.cpp
+++ b/src/core/git_version.cpp
@@ -13,8 +13,8 @@ namespace derecho {
 const int MAJOR_VERSION = 2;
 const int MINOR_VERSION = 3;
 const int PATCH_VERSION = 0;
-const int COMMITS_AHEAD_OF_VERSION = 188;
+const int COMMITS_AHEAD_OF_VERSION = 190;
 const char* VERSION_STRING = "2.3.0";
-const char* VERSION_STRING_PLUS_COMMITS = "2.3.0+188";
+const char* VERSION_STRING_PLUS_COMMITS = "2.3.0+190";
 
 }

--- a/src/core/git_version.cpp
+++ b/src/core/git_version.cpp
@@ -13,8 +13,8 @@ namespace derecho {
 const int MAJOR_VERSION = 2;
 const int MINOR_VERSION = 3;
 const int PATCH_VERSION = 0;
-const int COMMITS_AHEAD_OF_VERSION = 167;
+const int COMMITS_AHEAD_OF_VERSION = 187;
 const char* VERSION_STRING = "2.3.0";
-const char* VERSION_STRING_PLUS_COMMITS = "2.3.0+167";
+const char* VERSION_STRING_PLUS_COMMITS = "2.3.0+187";
 
 }

--- a/src/core/git_version.cpp
+++ b/src/core/git_version.cpp
@@ -13,8 +13,8 @@ namespace derecho {
 const int MAJOR_VERSION = 2;
 const int MINOR_VERSION = 3;
 const int PATCH_VERSION = 0;
-const int COMMITS_AHEAD_OF_VERSION = 187;
+const int COMMITS_AHEAD_OF_VERSION = 188;
 const char* VERSION_STRING = "2.3.0";
-const char* VERSION_STRING_PLUS_COMMITS = "2.3.0+187";
+const char* VERSION_STRING_PLUS_COMMITS = "2.3.0+188";
 
 }

--- a/src/core/view_manager.cpp
+++ b/src/core/view_manager.cpp
@@ -141,7 +141,8 @@ bool ViewManager::restart_to_initial_view() {
 
     // First, attempt to contact a current member to see if the system really is in total restart
     // Try the configured contact node, unless that is equal to this node
-    if(my_ip != getConfString(Conf::DERECHO_CONTACT_IP) && my_gms_port != getConfUInt16(Conf::DERECHO_CONTACT_PORT)) {
+    if(!(my_ip == getConfString(Conf::DERECHO_CONTACT_IP) && my_gms_port == getConfUInt16(Conf::DERECHO_CONTACT_PORT))) {
+        dbg_debug(vm_logger, "Attempting to connect to contact node {}:{} before starting in recovery mode", getConfString(Conf::DERECHO_CONTACT_IP), getConfUInt16(Conf::DERECHO_CONTACT_PORT));
         // This timeout might need to be its own config value, but for now, use 1/2 the restart leader's timeout
         bool connection_success = try_connect_to_leader(getConfString(Conf::DERECHO_CONTACT_IP),
                                                         getConfUInt16(Conf::DERECHO_CONTACT_PORT),
@@ -213,7 +214,7 @@ bool ViewManager::restart_to_initial_view() {
                     dbg_debug(vm_logger, "Restart leader failed, moving to leader #{}", restart_state->num_leader_failures);
                 }
             } else if(enable_backup_restart_leaders) {
-                dbg_warn(vm_logger, "Couldn't connect to restart leader at {}", restart_state->restart_leader_ips[restart_state->num_leader_failures]);
+                dbg_warn(vm_logger, "Couldn't connect to restart leader at {}:{}", restart_state->restart_leader_ips[restart_state->num_leader_failures], restart_state->restart_leader_ports[restart_state->num_leader_failures]);
                 restart_state->num_leader_failures++;
                 //If backup_restart_leaders is disabled, keep num_leader_failures at 0 and just keep retrying
             }

--- a/src/core/view_manager.cpp
+++ b/src/core/view_manager.cpp
@@ -117,10 +117,18 @@ void ViewManager::startup_to_first_view() {
         dbg_info(vm_logger, "Node {} starting up, sending a join request to {}", my_id, getConfString(Conf::DERECHO_CONTACT_IP));
         leader_connection = std::make_unique<tcp::socket>(getConfString(Conf::DERECHO_CONTACT_IP),
                                                           getConfUInt16(Conf::DERECHO_CONTACT_PORT));
-        bool success = receive_initial_view();
+        // Complete the initial handshake with the contact node, which may involve getting redirected to the leader
+        bool success = send_join_request();
         if(!success) {
-            throw derecho_exception("Leader crashed before it could send the initial View! Try joining again at the new leader.");
+            throw derecho_exception("Connection failure when trying to send a join request to the group! Try joining again at a different node.");
         }
+        // Wait for the leader to send a View, which won't happen until the new View (that includes this node) has been committed
+        success = receive_view_and_leaders();
+        if(!success) {
+            throw derecho_exception("Leader failed while sending the initial View! Try joining again at a different node.");
+        }
+        dbg_debug(vm_logger, "Received initial view {} from leader: {}", curr_view->vid, curr_view->debug_string());
+
         setup_initial_tcp_connections(*curr_view, my_id);
     }
 }
@@ -130,6 +138,38 @@ bool ViewManager::restart_to_initial_view() {
     const uint32_t my_id = getConfUInt32(Conf::DERECHO_LOCAL_ID);
     const uint16_t my_gms_port = getConfUInt16(Conf::DERECHO_GMS_PORT);
     const bool enable_backup_restart_leaders = getConfBoolean(Conf::DERECHO_ENABLE_BACKUP_RESTART_LEADERS);
+
+    // First, attempt to contact a current member to see if the system really is in total restart
+    // Try the configured contact node, unless that is equal to this node
+    if(my_ip != getConfString(Conf::DERECHO_CONTACT_IP) && my_gms_port != getConfUInt16(Conf::DERECHO_CONTACT_PORT)) {
+        // This timeout might need to be its own config value, but for now, use 1/2 the restart leader's timeout
+        bool connection_success = try_connect_to_leader(getConfString(Conf::DERECHO_CONTACT_IP),
+                                                        getConfUInt16(Conf::DERECHO_CONTACT_PORT),
+                                                        getConfUInt32(Conf::DERECHO_RESTART_TIMEOUT_MS) / 2);
+        if(connection_success) {
+            // The "contact" member responded, so this node is not the leader, and the group is probably already running
+            // There is still a chance the group really is doing a restart, especially if the contact node is also the first restart leader
+            active_leader = false;
+            bool handshake_success = send_join_request();
+            if(handshake_success) {
+                bool got_initial_view = receive_view_and_leaders();
+                if(got_initial_view) {
+                    // If the contact member successfully sent a View, return early; this method is done
+                    setup_initial_tcp_connections(*curr_view, my_id);
+                    return in_total_restart;
+                } else if(!in_total_restart) {
+                    // If the contact member told us that the group is not doing a restart but then crashed,
+                    // behave like a non-restarting node that experienced a failure while joining
+                    throw derecho_exception("Leader failed while sending the initial View! Try joining again at a different node.");
+                } else {
+                    dbg_debug(vm_logger, "Network error while receiving View from {}:{}. Proceeding to attempt restart with restart leaders.", getConfString(Conf::DERECHO_CONTACT_IP), getConfUInt16(Conf::DERECHO_CONTACT_PORT));
+                }
+            } else {
+                dbg_debug(vm_logger, "Network error while attempting to join at {}:{}. Proceeding to attempt restart with restart leaders.", getConfString(Conf::DERECHO_CONTACT_IP), getConfUInt16(Conf::DERECHO_CONTACT_PORT));
+            }
+        }
+        // If try_connect timed out, proceed with the regular total restart logic
+    }
 
     bool got_initial_view = false;
     while(!got_initial_view) {
@@ -151,32 +191,24 @@ bool ViewManager::restart_to_initial_view() {
             got_initial_view = true;
         } else {
             //If I am not a restart leader, we may or may not be in total restart;
-            //in_total_restart will be set when the leader responds in receive_initial_view
-            using namespace std::chrono;
-            leader_connection = std::make_unique<tcp::socket>();
-            //Heuristic: Wait for half the leader's restart timeout before concluding the leader isn't responding
-            int time_remaining_micro = getConfUInt32(Conf::DERECHO_RESTART_TIMEOUT_MS) * 1000 / 2;
-            int connect_status = -1;
-            //Annoyingly, try_connect will return immediately if the connection is refused,
-            //which is the usual result while waiting for the leader to start up.
-            while(time_remaining_micro > 0 && connect_status != 0) {
-                auto start_time = high_resolution_clock::now();
-                connect_status = leader_connection->try_connect(restart_state->restart_leader_ips[restart_state->num_leader_failures],
-                                                                restart_state->restart_leader_ports[restart_state->num_leader_failures],
-                                                                time_remaining_micro / 1000);
-                auto end_time = high_resolution_clock::now();
-                microseconds time_waited = duration_cast<microseconds>(end_time - start_time);
-                time_remaining_micro -= time_waited.count();
-            }
-            if(connect_status == 0) {
+            //in_total_restart will be set when the leader responds in send_join_request
+            //Timeout heuristic: Wait for half the leader's restart timeout before concluding the leader isn't responding
+            bool connection_success = try_connect_to_leader(restart_state->restart_leader_ips[restart_state->num_leader_failures],
+                                                            restart_state->restart_leader_ports[restart_state->num_leader_failures],
+                                                            getConfUInt32(Conf::DERECHO_RESTART_TIMEOUT_MS) / 2);
+            if(connection_success) {
                 active_leader = false;
-                got_initial_view = receive_initial_view();
+                // If the initial handshake fails, leave got_initial_view false; otherwise proceed to attempt to receive the view
+                if(send_join_request()) {
+                    got_initial_view = receive_view_and_leaders();
+                }
                 if(got_initial_view) {
                     setup_initial_tcp_connections(*curr_view, my_id);
                 } else {
                     if(!enable_backup_restart_leaders) {
                         throw derecho_exception("Restart leader crashed before sending the View, and backup restart leaders are disabled.");
                     }
+                    assert(in_total_restart);
                     restart_state->num_leader_failures++;
                     dbg_debug(vm_logger, "Restart leader failed, moving to leader #{}", restart_state->num_leader_failures);
                 }
@@ -193,7 +225,23 @@ bool ViewManager::restart_to_initial_view() {
     return in_total_restart;
 }
 
-bool ViewManager::receive_initial_view() {
+bool ViewManager::try_connect_to_leader(const ip_addr_t& ip_address, uint16_t port, int timeout_ms) {
+    using namespace std::chrono;
+    // When using try_connect the socket must be default-constructed first
+    leader_connection = std::make_unique<tcp::socket>();
+    int connect_status = -1;
+    int time_remaining_micro = timeout_ms * 1000;
+    while(time_remaining_micro > 0 && connect_status != 0) {
+        auto start_time = high_resolution_clock::now();
+        connect_status = leader_connection->try_connect(ip_address, port, time_remaining_micro / 1000);
+        auto end_time = high_resolution_clock::now();
+        microseconds time_waited = duration_cast<microseconds>(end_time - start_time);
+        time_remaining_micro -= time_waited.count();
+    }
+    return connect_status == 0;
+}
+
+bool ViewManager::send_join_request() {
     assert(leader_connection);
     const node_id_t my_id = getConfUInt32(Conf::DERECHO_LOCAL_ID);
     JoinResponse leader_response;
@@ -232,7 +280,18 @@ bool ViewManager::receive_initial_view() {
             leader_redirect = true;
         }
     } while(leader_redirect);
-
+    // Once connected to the correct leader, send this node's port information
+    try {
+        leader_connection->write(getConfUInt16(Conf::DERECHO_GMS_PORT));
+        leader_connection->write(getConfUInt16(Conf::DERECHO_STATE_TRANSFER_PORT));
+        leader_connection->write(getConfUInt16(Conf::DERECHO_SST_PORT));
+        leader_connection->write(getConfUInt16(Conf::DERECHO_RDMC_PORT));
+        leader_connection->write(getConfUInt16(Conf::DERECHO_EXTERNAL_PORT));
+    } catch(tcp::socket_error& e) {
+        return false;
+    }
+    // If the leader's response was TOTAL_RESTART rather than OK, this node needs to also send its logged View
+    // and ragged trims as part of the rejoin request, and we should change the state variable in_total_restart
     in_total_restart = (leader_response.code == JoinResponseCode::TOTAL_RESTART);
     if(in_total_restart) {
         dbg_info(vm_logger, "Connected to leader in recovery mode.");
@@ -282,24 +341,10 @@ bool ViewManager::receive_initial_view() {
             return false;
         }
     } else {
-        //This might have been constructed even though we don't need it
+        // If the leader responded OK, ensure restart_state is deleted even if this node was expecting a total restart
         restart_state.reset();
     }
-    try {
-        leader_connection->write(getConfUInt16(Conf::DERECHO_GMS_PORT));
-        leader_connection->write(getConfUInt16(Conf::DERECHO_STATE_TRANSFER_PORT));
-        leader_connection->write(getConfUInt16(Conf::DERECHO_SST_PORT));
-        leader_connection->write(getConfUInt16(Conf::DERECHO_RDMC_PORT));
-        leader_connection->write(getConfUInt16(Conf::DERECHO_EXTERNAL_PORT));
-    } catch(tcp::socket_error& e) {
-        return false;
-    }
-    if(receive_view_and_leaders()) {
-        dbg_debug(vm_logger, "Received initial view {} from leader: {}", curr_view->vid, curr_view->debug_string());
-        return true;
-    } else {
-        return false;
-    }
+    return true;
 }
 
 bool ViewManager::receive_view_and_leaders() {
@@ -582,7 +627,7 @@ void ViewManager::await_first_view() {
                 uint64_t joiner_version_code;
                 client_socket.exchange(my_version_hashcode, joiner_version_code);
                 if(joiner_version_code != my_version_hashcode) {
-                    rls_default_warn("Rejected a connection from client at {}. Client was running on an incompatible platform or used an incompatible compiler.", client_socket.get_remote_ip());
+                    rls_default_warn("Rejected a connection from node at {}. Node was running on an incompatible platform or used an incompatible compiler.", client_socket.get_remote_ip());
                     continue;
                 }
                 JoinRequest join_request;
@@ -642,7 +687,7 @@ void ViewManager::await_first_view() {
                 //If any socket operation failed, assume the joining node failed
                 node_id_t failed_joiner_id = waiting_sockets_iter->first;
                 dbg_warn(vm_logger, "Node {} failed after contacting the leader! Removing it from the initial view.", failed_joiner_id);
-                //Remove the failed client and recompute the view
+                //Remove the failed node and recompute the view
                 std::vector<node_id_t> filtered_members(curr_view->members.size() - 1);
                 std::vector<IpAndPorts> filtered_ips_and_ports(curr_view->member_ips_and_ports.size() - 1);
                 std::vector<node_id_t> filtered_joiners(curr_view->joined.size() - 1);
@@ -774,10 +819,10 @@ void ViewManager::initialize_rdmc_sst() {
 
 void ViewManager::create_threads() {
     client_listener_thread = std::thread{[this]() {
-        pthread_setname_np(pthread_self(), "client_thread");
+        pthread_setname_np(pthread_self(), "gms_listener");
         while(!thread_shutdown) {
             tcp::socket client_socket = server_socket.accept();
-            dbg_debug(vm_logger, "Background thread got a client connection from {}", client_socket.get_remote_ip());
+            dbg_debug(vm_logger, "GMS listener got a new connection from {}", client_socket.get_remote_ip());
             pending_new_sockets.locked().access.emplace_back(std::move(client_socket));
         }
     }};
@@ -1004,23 +1049,23 @@ void ViewManager::propose_changes(DerechoSST& gmsSST) {
     }
 }
 
-void ViewManager::redirect_join_attempt(tcp::socket& client_socket) {
+void ViewManager::redirect_join_attempt(tcp::socket& joiner_socket) {
     try {
-        client_socket.write(JoinResponse{JoinResponseCode::LEADER_REDIRECT,
+        joiner_socket.write(JoinResponse{JoinResponseCode::LEADER_REDIRECT,
                                          curr_view->members[curr_view->my_rank]});
-        // Send the client the IP address of the current leader
+        // Send the node the IP address of the current leader
         const int rank_of_leader = curr_view->find_rank_of_leader();
-        client_socket.write(mutils::bytes_size(
+        joiner_socket.write(mutils::bytes_size(
                 curr_view->member_ips_and_ports[rank_of_leader].ip_address));
-        auto bind_socket_write = [&client_socket](const uint8_t* bytes, std::size_t size) {
-            client_socket.write(bytes, size);
+        auto bind_socket_write = [&joiner_socket](const uint8_t* bytes, std::size_t size) {
+            joiner_socket.write(bytes, size);
         };
         mutils::post_object(bind_socket_write,
                             curr_view->member_ips_and_ports[rank_of_leader].ip_address);
-        client_socket.write(curr_view->member_ips_and_ports[rank_of_leader].gms_port);
+        joiner_socket.write(curr_view->member_ips_and_ports[rank_of_leader].gms_port);
     } catch(tcp::socket_error& ex) {
-        // Log the error, but otherwise ignore it, since we no longer care about this client anyway
-        dbg_debug(vm_logger, "TCP connection to client at {} failed while attempting to send it a leader-redirect message. Description: {}", client_socket.get_remote_ip(), ex.what());
+        // Log the error, but otherwise ignore it, since we no longer care about this connection anyway
+        dbg_debug(vm_logger, "TCP connection to node at {} failed while attempting to send it a leader-redirect message. Description: {}", joiner_socket.get_remote_ip(), ex.what());
     }
 }
 
@@ -1033,11 +1078,11 @@ void ViewManager::process_new_sockets() {
     }
     JoinRequest join_request;
     try {
-        // Exchange version codes; close the socket if the client has an incompatible version
+        // Exchange version codes; close the socket if the remote node has an incompatible version
         uint64_t joiner_version_code;
         client_socket.exchange(my_version_hashcode, joiner_version_code);
         if(joiner_version_code != my_version_hashcode) {
-            rls_default_warn("Rejected a connection from client at {}. Client was running on an incompatible platform or used an incompatible compiler.",
+            rls_default_warn("Rejected a connection from node at {}. Node was running on an incompatible platform or used an incompatible compiler.",
                              client_socket.get_remote_ip());
             return;
         }
@@ -1685,9 +1730,9 @@ void ViewManager::transition_multicast_group(
     gmssst::set(next_view->gmsSST->vid[next_view->my_rank], next_view->vid);
 }
 
-bool ViewManager::receive_join(DerechoSST& gmsSST, const node_id_t joiner_id, tcp::socket& client_socket) {
+bool ViewManager::receive_join(DerechoSST& gmsSST, const node_id_t joiner_id, tcp::socket& joiner_socket) {
     struct in_addr joiner_ip_packed;
-    inet_aton(client_socket.get_remote_ip().c_str(), &joiner_ip_packed);
+    inet_aton(joiner_socket.get_remote_ip().c_str(), &joiner_ip_packed);
 
     const node_id_t my_id = curr_view->members[curr_view->my_rank];
     uint16_t joiner_gms_port = 0;
@@ -1697,19 +1742,19 @@ bool ViewManager::receive_join(DerechoSST& gmsSST, const node_id_t joiner_id, tc
     uint16_t joiner_external_port = 0;
     try {
         if(curr_view->rank_of(joiner_id) != -1) {
-            dbg_warn(vm_logger, "Joining node at IP {} announced it has ID {}, which is already in the View!", client_socket.get_remote_ip(), joiner_id);
-            client_socket.write(JoinResponse{JoinResponseCode::ID_IN_USE, my_id});
+            dbg_warn(vm_logger, "Joining node at IP {} announced it has ID {}, which is already in the View!", joiner_socket.get_remote_ip(), joiner_id);
+            joiner_socket.write(JoinResponse{JoinResponseCode::ID_IN_USE, my_id});
             return false;
         }
-        client_socket.write(JoinResponse{JoinResponseCode::OK, my_id});
+        joiner_socket.write(JoinResponse{JoinResponseCode::OK, my_id});
 
-        client_socket.read(joiner_gms_port);
-        client_socket.read(joiner_state_transfer_port);
-        client_socket.read(joiner_sst_port);
-        client_socket.read(joiner_rdmc_port);
-        client_socket.read(joiner_external_port);
+        joiner_socket.read(joiner_gms_port);
+        joiner_socket.read(joiner_state_transfer_port);
+        joiner_socket.read(joiner_sst_port);
+        joiner_socket.read(joiner_rdmc_port);
+        joiner_socket.read(joiner_external_port);
     } catch(tcp::socket_error& ex) {
-        dbg_warn(vm_logger, "TCP connection to node {} at IP {} failed during join-request handshake. Ignoring request.", joiner_id, client_socket.get_remote_ip());
+        dbg_warn(vm_logger, "TCP connection to node {} at IP {} failed during join-request handshake. Ignoring request.", joiner_id, joiner_socket.get_remote_ip());
         dbg_debug(vm_logger, "Socket error description: {}", ex.what());
         return false;
     }
@@ -2012,7 +2057,6 @@ uint64_t ViewManager::get_subgroup_max_payload_size(subgroup_type_id_t subgroup_
     subgroup_id_t subgroup_id = curr_view->subgroup_ids_by_type_id.at(subgroup_type).at(subgroup_index);
     return max_payload_sizes.at(subgroup_id);
 }
-
 
 std::map<node_id_t, std::pair<ip_addr_t, uint16_t>>
 ViewManager::make_member_ips_and_ports_map(const View& view, const PortType port) {


### PR DESCRIPTION
This branch makes two changes aimed at making it easier for nodes to rejoin a group after they crash and restart:

1. Renames the leader_ip and leader_gms_port config options to contact_ip and contact_port, and removes the config option leader_external_port. This reflects existing behavior: Both internal and external clients only need to know the IP and port of any one group member, not the leader, in order to start up and connect.
2. Changes the recover-from-logs procedure so that a restarting node will first attempt to do a "normal" join at the node specified by contact_ip (waiting for half of the configured restart_timeout), before examining the restart_leaders list and deciding if it should act as a restart leader. This allows the node that is configured as the restart leader to individually restart and rejoin the group (which is still running), instead of always attempting to act as a restart leader every time it starts up.  It also matches the existing behavior for restarting nodes that are not configured as the restart leader: When they contact the "restart leader," if that leader responds with JoinResponse::OK instead of JoinResponse::TOTAL_RESTART, they do a normal join instead of a total restart.