### PR TITLE
A bugfix for std::vector deserializer.

### DIFF
--- a/include/derecho/mutils-serialization/SerializationSupport.hpp
+++ b/include/derecho/mutils-serialization/SerializationSupport.hpp
@@ -1164,7 +1164,7 @@ from_bytes(DeserializationManager* ctx, uint8_t const* buffer) {
         int size = ((int*)buffer)[0];
         auto* buffer2 = buffer + sizeof(int);
         std::size_t accumulated_offset = 0;
-        std::unique_ptr<T> accum{new T()};
+        std::unique_ptr<std::remove_cv_t<T>> accum{new std::remove_cv_t<T>()};
         for(int i = 0; i < size; ++i) {
             std::unique_ptr<member> item = from_bytes<member>(ctx, buffer2 + accumulated_offset);
             accumulated_offset += bytes_size(*item);


### PR DESCRIPTION
The in-place deserializer for std::vector (mutils::from_bytes_no_alloc()) has a bug, where the 'const' quialifier needs to be casted off from type T when creating the context_ptr. Otherwise, it's impossible to add entries to it during deserialization. The deserializer for std::map/unordered_map has this correct.