### PR TITLE
CUDA SUPPORT

### DIFF
--- a/src/applications/demos/oob_rdma.cpp
+++ b/src/applications/demos/oob_rdma.cpp
@@ -337,8 +337,10 @@ void do_test (P2PCaller& p2p_caller, node_id_t nid, uint64_t rkey, void* put_buf
     // 1 - test one-sided OOB
 #ifdef CUDA_FOUND
     if (use_gpu_mem) {
-        char putbuf[oob_data_size] = {'A'};
-        char getbuf[oob_data_size] = {'a'};
+        char putbuf[oob_data_size];
+        char getbuf[oob_data_size];
+        memset(putbuf,'A',oob_data_size);
+        memset(getbuf,'a',oob_data_size);
         ASSERTDRV(cuMemcpyHtoD(
                     reinterpret_cast<CUdeviceptr>(put_buffer_laddr),
                     reinterpret_cast<const void*>(putbuf),

--- a/src/sst/lf.cpp
+++ b/src/sst/lf.cpp
@@ -514,12 +514,11 @@ void _resources::register_oob_memory_ex(void* addr, size_t size, const memory_at
     _attr.auth_key      = nullptr;
     switch (attr.type) {
     case memory_attribute_t::SYSTEM:
-    case memory_attribute_t::CUDA:
         _attr.iface = FI_HMEM_SYSTEM;
         break;
-    // case memory_attribute_t::CUDA:
-    //    _attr.iface = FI_HMEM_CUDA;
-    //    break;
+    case memory_attribute_t::CUDA:
+        _attr.iface = FI_HMEM_CUDA;
+        break;
     case memory_attribute_t::ROCM:
         _attr.iface = FI_HMEM_ROCR;
         break;

--- a/src/sst/lf.cpp
+++ b/src/sst/lf.cpp
@@ -514,11 +514,12 @@ void _resources::register_oob_memory_ex(void* addr, size_t size, const memory_at
     _attr.auth_key      = nullptr;
     switch (attr.type) {
     case memory_attribute_t::SYSTEM:
+    case memory_attribute_t::CUDA:
         _attr.iface = FI_HMEM_SYSTEM;
         break;
-    case memory_attribute_t::CUDA:
-        _attr.iface = FI_HMEM_CUDA;
-        break;
+    // case memory_attribute_t::CUDA:
+    //    _attr.iface = FI_HMEM_CUDA;
+    //    break;
     case memory_attribute_t::ROCM:
         _attr.iface = FI_HMEM_ROCR;
         break;

--- a/src/sst/lf.cpp
+++ b/src/sst/lf.cpp
@@ -123,7 +123,7 @@ static void default_context() {
     memset((void*)&g_ctxt, 0, sizeof(lf_ctxt));
     g_ctxt.hints = crash_if_nullptr("Fail to allocate fi hints", fi_allocinfo);
     //defaults the hints:
-    g_ctxt.hints->caps = FI_MSG | FI_RMA | FI_READ | FI_WRITE | FI_REMOTE_READ | FI_REMOTE_WRITE;
+    g_ctxt.hints->caps = FI_MSG | FI_RMA | FI_READ | FI_WRITE | FI_REMOTE_READ | FI_REMOTE_WRITE | FI_HMEM;
     g_ctxt.hints->ep_attr->type = FI_EP_MSG;  // use connection based endpoint by default.
     g_ctxt.hints->mode = ~0;                  // all modes
 


### PR DESCRIPTION
Derecho OOB transfer now supports CUDA Memory. This has been tested using `src/applications/demos/oob_rdma`. The communication nodes can use GPU memory or host memory independently.