### PR TITLE
Re-issuing v2.4.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,9 +8,6 @@ set(derecho_VERSION 2.4)
 set(derecho_build_VERSION 2.4.0)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
-if (${USE_VERBS_API})
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DUSE_VERBS_API")
-endif()
 set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -DDERECHO_DEBUG -O0 -Wall -ggdb -gdwarf-3")
 set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -Wall")
 set(CMAKE_CXX_FLAGS_BENCHMARK "${CMAKE_CXX_FLAGS_RELEASE} -Wall -DNOLOG -Ofast -march=native")
@@ -62,6 +59,25 @@ find_package(nlohmann_json 3.9.0 REQUIRED)
 # Target: Doxygen
 find_package(Doxygen)
 
+
+# Source code configurations go to config.h
+# Shift to verbs API. We use libfabric by default.
+if (${USE_VERBS_API})
+set(USE_VERBS_API 1)
+else()
+set(USE_VERBS_API 0)
+endif()
+# Enable High memory registration (for device memory like GPU memory.)
+# Important: this does not work with libfabric provider like tcp and socket because they cannot
+# RDMA to device memory.
+if (${ENABLE_HMEM})
+set(ENABLE_HMEM 1)
+else()
+set(ENABLE_HMEM 0)
+endif()
+CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/config.h.in ${CMAKE_CURRENT_BINARY_DIR}/include/derecho/config.h)
+include_directories(${CMAKE_CURRENT_BINARY_DIR}/include)
+
 add_subdirectory(src/mutils-serialization)
 add_subdirectory(src/conf)
 add_subdirectory(src/utils)
@@ -112,14 +128,14 @@ add_dependencies(derecho
 
 # Setup for make install
 # Declare that we will install the targets built by "derecho"
-install(TARGETS derecho
-        EXPORT derechoTargets
+install(TARGETS derecho EXPORT derechoTargets
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
         INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 # Declare that we will install the "include/" directory as a standard include directory
 install(DIRECTORY
-        include/
-        TYPE INCLUDE)
+        ${CMAKE_CURRENT_SOURCE_DIR}/include/derecho
+        ${CMAKE_CURRENT_BINARY_DIR}/include/derecho
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
 # Use CMakePackageConfigHelpers to create a package version file and config file
 include(CMakePackageConfigHelpers)

--- a/config.h.in
+++ b/config.h.in
@@ -1,0 +1,3 @@
+#pragma once
+#cmakedefine    USE_VERBS_API
+#cmakedefine    ENABLE_HMEM

--- a/include/derecho/conf/conf.hpp
+++ b/include/derecho/conf/conf.hpp
@@ -1,6 +1,8 @@
+#pragma once
 #ifndef CONF_HPP
 #define CONF_HPP
 
+#include <derecho/config.h>
 #include "getpot/GetPot"
 #include <atomic>
 #include <getopt.h>

--- a/include/derecho/core/bytes_object.hpp
+++ b/include/derecho/core/bytes_object.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
-#include "derecho/mutils-serialization/SerializationSupport.hpp"
+#include <derecho/config.h>
+#include <derecho/mutils-serialization/SerializationSupport.hpp>
 
 #include <cstring>
 #include <memory>

--- a/include/derecho/core/derecho.hpp
+++ b/include/derecho/core/derecho.hpp
@@ -5,6 +5,7 @@
  * @brief   This file includes the essential core headers.
  */
 
+#include <derecho/config.h>
 #include "derecho_exception.hpp"
 #include "detail/derecho_internal.hpp"
 #include "derecho_type_definitions.hpp"

--- a/include/derecho/core/derecho_exception.hpp
+++ b/include/derecho/core/derecho_exception.hpp
@@ -5,7 +5,8 @@
 
 #pragma once
 
-#include "derecho/core/git_version.hpp"
+#include <derecho/config.h>
+#include "git_version.hpp"
 
 #include <exception>
 #include <sstream>

--- a/include/derecho/core/derecho_type_definitions.hpp
+++ b/include/derecho/core/derecho_type_definitions.hpp
@@ -2,6 +2,7 @@
 
 #include <string>
 #include <cstdint>
+#include <derecho/config.h>
 
 namespace derecho {
 

--- a/include/derecho/core/detail/connection_manager.hpp
+++ b/include/derecho/core/detail/connection_manager.hpp
@@ -1,7 +1,8 @@
 #pragma once
 
+#include <derecho/config.h>
 #include "../derecho_type_definitions.hpp"
-#include "derecho/tcp/tcp.hpp"
+#include <derecho/tcp/tcp.hpp>
 #include "locked_reference.hpp"
 
 #include <cassert>

--- a/include/derecho/core/detail/derecho_sst.hpp
+++ b/include/derecho/core/detail/derecho_sst.hpp
@@ -1,7 +1,8 @@
 #pragma once
 
+#include <derecho/config.h>
 #include "../derecho_type_definitions.hpp"
-#include "derecho/sst/sst.hpp"
+#include <derecho/sst/sst.hpp>
 #include "derecho_internal.hpp"
 
 #include <atomic>

--- a/include/derecho/core/detail/external_group_impl.hpp
+++ b/include/derecho/core/detail/external_group_impl.hpp
@@ -1,3 +1,4 @@
+#include <derecho/config.h>
 #include "../external_group.hpp"
 #include "version_code.hpp"
 

--- a/include/derecho/core/detail/group_impl.hpp
+++ b/include/derecho/core/detail/group_impl.hpp
@@ -2,11 +2,11 @@
  * @file group_impl.hpp
  * @date Apr 22, 2016
  */
-
+#include <derecho/config.h>
 #include "../group.hpp"
-#include "derecho/mutils-serialization/SerializationSupport.hpp"
-#include "derecho/utils/container_template_functions.hpp"
-#include "derecho/utils/logger.hpp"
+#include <derecho/mutils-serialization/SerializationSupport.hpp>
+#include <derecho/utils/container_template_functions.hpp>
+#include <derecho/utils/logger.hpp>
 #include "derecho_internal.hpp"
 #include "make_kind_map.hpp"
 

--- a/include/derecho/core/detail/make_kind_map.hpp
+++ b/include/derecho/core/detail/make_kind_map.hpp
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <derecho/config.h>
 #include "derecho_internal.hpp"
 #include <mutils-containers/KindMap.hpp>
 

--- a/include/derecho/core/detail/multicast_group.hpp
+++ b/include/derecho/core/detail/multicast_group.hpp
@@ -1,14 +1,15 @@
 #pragma once
 
+#include <derecho/config.h>
 #include "../derecho_modes.hpp"
 #include "../subgroup_info.hpp"
 #include "connection_manager.hpp"
 #include "derecho/conf/conf.hpp"
-#include "derecho/mutils-serialization/SerializationMacros.hpp"
-#include "derecho/mutils-serialization/SerializationSupport.hpp"
-#include "derecho/rdmc/rdmc.hpp"
-#include "derecho/sst/multicast.hpp"
-#include "derecho/sst/sst.hpp"
+#include <derecho/mutils-serialization/SerializationMacros.hpp>
+#include <derecho/mutils-serialization/SerializationSupport.hpp>
+#include <derecho/rdmc/rdmc.hpp>
+#include <derecho/sst/multicast.hpp>
+#include <derecho/sst/sst.hpp>
 #include "derecho_internal.hpp"
 #include "derecho_sst.hpp"
 #include "persistence_manager.hpp"

--- a/include/derecho/core/detail/p2p_connection.hpp
+++ b/include/derecho/core/detail/p2p_connection.hpp
@@ -1,9 +1,10 @@
 #pragma once
 
+#include <derecho/config.h>
 #ifdef USE_VERBS_API
-#include "derecho/sst/detail/verbs.hpp"
+#include <derecho/sst/detail/verbs.hpp>
 #else
-#include "derecho/sst/detail/lf.hpp"
+#include <derecho/sst/detail/lf.hpp>
 #endif
 
 #include <atomic>

--- a/include/derecho/core/detail/p2p_connection_manager.hpp
+++ b/include/derecho/core/detail/p2p_connection_manager.hpp
@@ -1,12 +1,13 @@
 #pragma once
 
+#include <derecho/config.h>
 #include "p2p_connection.hpp"
 #ifdef USE_VERBS_API
-#include "derecho/sst/detail/verbs.hpp"
+#include <derecho/sst/detail/verbs.hpp>
 #else
-#include "derecho/sst/detail/lf.hpp"
+#include <derecho/sst/detail/lf.hpp>
 #endif
-#include "derecho/utils/logger.hpp"
+#include <derecho/utils/logger.hpp>
 
 #include <atomic>
 #include <functional>

--- a/include/derecho/core/detail/persistence_manager.hpp
+++ b/include/derecho/core/detail/persistence_manager.hpp
@@ -5,9 +5,10 @@
  */
 #pragma once
 
-#include "derecho/openssl/signature.hpp"
-#include "derecho/persistent/PersistentInterface.hpp"
-#include "derecho/utils/logger.hpp"
+#include <derecho/config.h>
+#include <derecho/openssl/signature.hpp>
+#include <derecho/persistent/PersistentInterface.hpp>
+#include <derecho/utils/logger.hpp>
 #include "derecho_internal.hpp"
 #include "replicated_interface.hpp"
 

--- a/include/derecho/core/detail/public_key_store.hpp
+++ b/include/derecho/core/detail/public_key_store.hpp
@@ -3,8 +3,9 @@
  */
 #pragma once
 
+#include <derecho/config.h>
 #include "../derecho_exception.hpp"
-#include "derecho/openssl/signature.hpp"
+#include <derecho/openssl/signature.hpp>
 #include "derecho_internal.hpp"
 
 #include <map>

--- a/include/derecho/core/detail/remote_invocable.hpp
+++ b/include/derecho/core/detail/remote_invocable.hpp
@@ -6,9 +6,10 @@
 
 #pragma once
 
-#include "derecho/conf/conf.hpp"
-#include "derecho/mutils-serialization/SerializationSupport.hpp"
-#include "derecho/utils/logger.hpp"
+#include <derecho/config.h>
+#include <derecho/conf/conf.hpp>
+#include <derecho/mutils-serialization/SerializationSupport.hpp>
+#include <derecho/utils/logger.hpp>
 #include "rpc_utils.hpp"
 
 #include <mutils/FunctionalMap.hpp>

--- a/include/derecho/core/detail/replicated_impl.hpp
+++ b/include/derecho/core/detail/replicated_impl.hpp
@@ -1,9 +1,10 @@
 #pragma once
 
+#include <derecho/config.h>
 #include "../replicated.hpp"
 #include "view_manager.hpp"
 
-#include "derecho/mutils-serialization/SerializationSupport.hpp"
+#include <derecho/mutils-serialization/SerializationSupport.hpp>
 
 #include <functional>
 #include <mutex>

--- a/include/derecho/core/detail/replicated_interface.hpp
+++ b/include/derecho/core/detail/replicated_interface.hpp
@@ -1,7 +1,8 @@
 #pragma once
 
-#include "derecho/openssl/signature.hpp"
-#include "derecho/tcp/tcp.hpp"
+#include <derecho/config.h>
+#include <derecho/openssl/signature.hpp>
+#include <derecho/tcp/tcp.hpp>
 #include "derecho_internal.hpp"
 
 #include <optional>

--- a/include/derecho/core/detail/restart_state.hpp
+++ b/include/derecho/core/detail/restart_state.hpp
@@ -1,9 +1,10 @@
 #pragma once
 
+#include <derecho/config.h>
 #include "../subgroup_info.hpp"
 #include "../view.hpp"
 #include "derecho_internal.hpp"
-#include "derecho/mutils-serialization/SerializationSupport.hpp"
+#include <derecho/mutils-serialization/SerializationSupport.hpp>
 
 #include <spdlog/spdlog.h>
 

--- a/include/derecho/core/detail/rpc_manager.hpp
+++ b/include/derecho/core/detail/rpc_manager.hpp
@@ -6,11 +6,12 @@
 
 #pragma once
 
+#include <derecho/config.h>
 #include "../derecho_type_definitions.hpp"
 #include "../view.hpp"
-#include "derecho/mutils-serialization/SerializationSupport.hpp"
-#include "derecho/persistent/Persistent.hpp"
-#include "derecho/utils/logger.hpp"
+#include <derecho/mutils-serialization/SerializationSupport.hpp>
+#include <derecho/persistent/Persistent.hpp>
+#include <derecho/utils/logger.hpp>
 #include "derecho_internal.hpp"
 #include "p2p_connection_manager.hpp"
 #include "remote_invocable.hpp"

--- a/include/derecho/core/detail/rpc_utils.hpp
+++ b/include/derecho/core/detail/rpc_utils.hpp
@@ -6,10 +6,11 @@
 
 #pragma once
 
+#include <derecho/config.h>
 #include "../derecho_exception.hpp"
 #include "../derecho_type_definitions.hpp"
-#include "derecho/mutils-serialization/SerializationSupport.hpp"
-#include "derecho/utils/logger.hpp"
+#include <derecho/mutils-serialization/SerializationSupport.hpp>
+#include <derecho/utils/logger.hpp>
 #include "derecho_internal.hpp"
 
 #include <mutils/macro_utils.hpp>

--- a/include/derecho/core/detail/view_manager.hpp
+++ b/include/derecho/core/detail/view_manager.hpp
@@ -5,10 +5,11 @@
  */
 #pragma once
 
+#include <derecho/config.h>
 #include "../subgroup_info.hpp"
 #include "../view.hpp"
-#include "derecho/conf/conf.hpp"
-#include "derecho/mutils-serialization/SerializationSupport.hpp"
+#include <derecho/conf/conf.hpp>
+#include <derecho/mutils-serialization/SerializationSupport.hpp>
 #include "derecho_internal.hpp"
 #include "locked_reference.hpp"
 #include "multicast_group.hpp"

--- a/include/derecho/core/external_group.hpp
+++ b/include/derecho/core/external_group.hpp
@@ -5,7 +5,8 @@
  * @brief   This file contains the APIs for external clients.
  */
 
-#include "derecho/conf/conf.hpp"
+#include <derecho/config.h>
+#include <derecho/conf/conf.hpp>
 #include "detail/connection_manager.hpp"
 #include "detail/p2p_connection_manager.hpp"
 #include "group.hpp"

--- a/include/derecho/core/group.hpp
+++ b/include/derecho/core/group.hpp
@@ -5,8 +5,9 @@
  * @brief   Declaration of the `Group<>` class template.
  */
 
-#include "derecho/conf/conf.hpp"
-#include "derecho/tcp/tcp.hpp"
+#include <derecho/config.h>
+#include <derecho/conf/conf.hpp>
+#include <derecho/tcp/tcp.hpp>
 #include "derecho_exception.hpp"
 #include "detail/derecho_internal.hpp"
 #include "detail/persistence_manager.hpp"

--- a/include/derecho/core/notification.hpp
+++ b/include/derecho/core/notification.hpp
@@ -5,8 +5,9 @@
  * @brief   This file include the declarations of types for the notification API.
  */
 
-#include "derecho/mutils-serialization/SerializationMacros.hpp"
-#include "derecho/mutils-serialization/SerializationSupport.hpp"
+#include <derecho/config.h>
+#include <derecho/mutils-serialization/SerializationMacros.hpp>
+#include <derecho/mutils-serialization/SerializationSupport.hpp>
 #include "register_rpc_functions.hpp"
 
 #include <functional>

--- a/include/derecho/core/register_rpc_functions.hpp
+++ b/include/derecho/core/register_rpc_functions.hpp
@@ -1,5 +1,6 @@
 #pragma once
-#include "derecho/utils/map_macro.hpp"
+#include <derecho/config.h>
+#include <derecho/utils/map_macro.hpp>
 #include "detail/rpc_utils.hpp"
 
 #define make_p2p_tagger_expr(x) derecho::rpc::tag_p2p<derecho::rpc::hash_cstr(#x)>(&classname::x)

--- a/include/derecho/core/replicated.hpp
+++ b/include/derecho/core/replicated.hpp
@@ -5,8 +5,9 @@
 
 #pragma once
 
-#include "derecho/persistent/Persistent.hpp"
-#include "derecho/tcp/tcp.hpp"
+#include <derecho/config.h>
+#include <derecho/persistent/Persistent.hpp>
+#include <derecho/tcp/tcp.hpp>
 #include "derecho_exception.hpp"
 #include "detail/derecho_internal.hpp"
 #include "detail/remote_invocable.hpp"

--- a/include/derecho/core/subgroup_functions.hpp
+++ b/include/derecho/core/subgroup_functions.hpp
@@ -4,7 +4,8 @@
 
 #pragma once
 
-#include "derecho/utils/logger.hpp"
+#include <derecho/config.h>
+#include <derecho/utils/logger.hpp>
 #include "derecho_exception.hpp"
 #include "derecho_modes.hpp"
 #include "detail/derecho_internal.hpp"

--- a/include/derecho/core/subgroup_info.hpp
+++ b/include/derecho/core/subgroup_info.hpp
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <derecho/config.h>
 #include "derecho_exception.hpp"
 
 #include <cstdint>

--- a/include/derecho/core/view.hpp
+++ b/include/derecho/core/view.hpp
@@ -5,13 +5,14 @@
 
 #pragma once
 
+#include <derecho/config.h>
 #include "derecho_modes.hpp"
 #include "detail/derecho_internal.hpp"
 #include "detail/derecho_sst.hpp"
 #include "detail/multicast_group.hpp"
-#include "derecho/mutils-serialization/SerializationMacros.hpp"
-#include "derecho/mutils-serialization/SerializationSupport.hpp"
-#include "derecho/sst/sst.hpp"
+#include <derecho/mutils-serialization/SerializationMacros.hpp>
+#include <derecho/mutils-serialization/SerializationSupport.hpp>
+#include <derecho/sst/sst.hpp>
 
 #include <cstdint>
 #include <iostream>

--- a/include/derecho/mutils-serialization/Bytes.hpp
+++ b/include/derecho/mutils-serialization/Bytes.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <derecho/config.h>
 #include "SerializationSupport.hpp"
 #include "../mutils-networking/connection.hpp"
 
@@ -9,40 +10,40 @@ namespace mutils{
   must ensure underlying array is not freed while Bytes lives, and is responsible for freeing
   underlying array when Bytes is destroyed.
  */
-	struct Bytes : public ByteRepresentable{
+    struct Bytes : public ByteRepresentable{
 
-		uint8_t const * const bytes;
-		const std::size_t size;
+        uint8_t const * const bytes;
+        const std::size_t size;
 
-		Bytes(decltype(bytes) b, decltype(size) s)
-			:bytes(b),size(s){}
+        Bytes(decltype(bytes) b, decltype(size) s)
+            :bytes(b),size(s){}
 
-		std::size_t to_bytes(uint8_t* v) const{
-			((std::size_t*)(v))[0] = size;
-			memcpy(v + sizeof(size),bytes,size);
-			return size + sizeof(size);
-		}
+        std::size_t to_bytes(uint8_t* v) const{
+            ((std::size_t*)(v))[0] = size;
+            memcpy(v + sizeof(size),bytes,size);
+            return size + sizeof(size);
+        }
 
-		std::size_t bytes_size() const {
-			return size + sizeof(size);
-		}
+        std::size_t bytes_size() const {
+            return size + sizeof(size);
+        }
 
-		void post_object(const std::function<void (uint8_t const * const,std::size_t)>& f) const{
-			f((uint8_t*)&size,sizeof(size));
-			f(bytes,size);
-		}
+        void post_object(const std::function<void (uint8_t const * const,std::size_t)>& f) const{
+            f((uint8_t*)&size,sizeof(size));
+            f(bytes,size);
+        }
 
-		void ensure_registered(DeserializationManager&){}
+        void ensure_registered(DeserializationManager&){}
 
-		//from_bytes is disabled in this implementation, because it's intended only for nocopy-aware scenarios
-		template<typename T, typename V>
-		static std::unique_ptr<Bytes> from_bytes(T*, V*){
-			static_assert(std::is_same<T,V>::value,"Error: from_bytes disabled for mutils::Bytes. See comment in source.");
-		}
+        //from_bytes is disabled in this implementation, because it's intended only for nocopy-aware scenarios
+        template<typename T, typename V>
+        static std::unique_ptr<Bytes> from_bytes(T*, V*){
+            static_assert(std::is_same<T,V>::value,"Error: from_bytes disabled for mutils::Bytes. See comment in source.");
+        }
 
-		static context_ptr<Bytes> from_bytes_noalloc(DeserializationManager *, uint8_t const * const v)  {
-			return context_ptr<Bytes>{new Bytes(v + sizeof(std::size_t),((std::size_t*)(v))[0])};
-		}
+        static context_ptr<Bytes> from_bytes_noalloc(DeserializationManager *, uint8_t const * const v)  {
+            return context_ptr<Bytes>{new Bytes(v + sizeof(std::size_t),((std::size_t*)(v))[0])};
+        }
 
-	};
+    };
 }

--- a/include/derecho/mutils-serialization/SerializationSupport.hpp
+++ b/include/derecho/mutils-serialization/SerializationSupport.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <derecho/config.h>
 #include "SerializationMacros.hpp"
 #include "context_ptr.hpp"
 #include <cstring>

--- a/include/derecho/mutils-serialization/context_ptr.hpp
+++ b/include/derecho/mutils-serialization/context_ptr.hpp
@@ -1,22 +1,24 @@
 #pragma once
+
+#include <derecho/config.h>
 #include <memory>
 #include <type_traits>
 
 namespace mutils{
 
-	template<typename T>
-	struct ContextDeleter : public std::conditional_t<std::is_pod<T>::value,
-													  ContextDeleter<void>,
-													  std::default_delete<T> > {
-	};
+    template<typename T>
+    struct ContextDeleter : public std::conditional_t<std::is_pod<T>::value,
+                                                      ContextDeleter<void>,
+                                                      std::default_delete<T> > {
+    };
 
-	template<>
-	struct ContextDeleter<void> {
-		void operator()(...){}
-	};			   
+    template<>
+    struct ContextDeleter<void> {
+        void operator()(...){}
+    };               
 
-	
-	template<typename T>
-	using context_ptr = std::unique_ptr<T,ContextDeleter<T> >;
+    
+    template<typename T>
+    using context_ptr = std::unique_ptr<T,ContextDeleter<T> >;
 
 }

--- a/include/derecho/openssl/hash.hpp
+++ b/include/derecho/openssl/hash.hpp
@@ -5,6 +5,7 @@
  */
 #pragma once
 
+#include <derecho/config.h>
 #include "openssl_exception.hpp"
 #include "pointers.hpp"
 

--- a/include/derecho/openssl/openssl_exception.hpp
+++ b/include/derecho/openssl/openssl_exception.hpp
@@ -6,6 +6,7 @@
  */
 #pragma once
 
+#include <derecho/config.h>
 #include <exception>
 #include <iostream>
 #include <sstream>

--- a/include/derecho/openssl/pointers.hpp
+++ b/include/derecho/openssl/pointers.hpp
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <derecho/config.h>
 #include <memory>
 #include <openssl/evp.h>
 #include <openssl/bio.h>

--- a/include/derecho/openssl/signature.hpp
+++ b/include/derecho/openssl/signature.hpp
@@ -6,6 +6,7 @@
  */
 
 #pragma once
+#include <derecho/config.h>
 #include "hash.hpp"
 #include "openssl_exception.hpp"
 #include "pointers.hpp"

--- a/include/derecho/persistent/HLC.hpp
+++ b/include/derecho/persistent/HLC.hpp
@@ -1,5 +1,7 @@
+#pragma once
 #ifndef HLC_HPP
 #define HLC_HPP
+#include <derecho/config.h>
 #include <inttypes.h>
 #include <pthread.h>
 #include <sys/types.h>

--- a/include/derecho/persistent/PersistException.hpp
+++ b/include/derecho/persistent/PersistException.hpp
@@ -1,6 +1,8 @@
+#pragma once
 #ifndef PERSISTENT_EXCEPTION_HPP
 #define PERSISTENT_EXCEPTION_HPP
 
+#include <derecho/config.h>
 #include <cstdint>
 #include <cstring>
 #include <stdexcept>

--- a/include/derecho/persistent/PersistNoLog.hpp
+++ b/include/derecho/persistent/PersistNoLog.hpp
@@ -1,3 +1,4 @@
+#pragma once
 #ifndef PERSIST_NO_LOG_HPP
 #define PERSIST_NO_LOG_HPP
 
@@ -5,9 +6,10 @@
 #error PersistLog.hpp only works with clang and gnu compilers
 #endif
 
+#include <derecho/config.h>
 #include "detail/PersistLog.hpp"
 #include "detail/util.hpp"
-#include "derecho/mutils-serialization/SerializationSupport.hpp"
+#include <derecho/mutils-serialization/SerializationSupport.hpp>
 #include <inttypes.h>
 #include <map>
 #include <set>

--- a/include/derecho/persistent/PersistentInterface.hpp
+++ b/include/derecho/persistent/PersistentInterface.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
-#include "../openssl/signature.hpp"
+#include <derecho/config.h>
+#include <derecho/openssl/signature.hpp>
 #include "HLC.hpp"
 
 #include <cstdint>

--- a/include/derecho/persistent/detail/FilePersistLog.hpp
+++ b/include/derecho/persistent/detail/FilePersistLog.hpp
@@ -1,9 +1,11 @@
+#pragma once
 #ifndef FILE_PERSIST_LOG_HPP
 #define FILE_PERSIST_LOG_HPP
 
+#include <derecho/config.h>
 #include "PersistLog.hpp"
 #include "util.hpp"
-#include "derecho/utils/logger.hpp"
+#include <derecho/utils/logger.hpp>
 #include <pthread.h>
 #include <string>
 

--- a/include/derecho/persistent/detail/PersistLog.hpp
+++ b/include/derecho/persistent/detail/PersistLog.hpp
@@ -1,3 +1,4 @@
+#pragma once
 #ifndef PERSIST_LOG_HPP
 #define PERSIST_LOG_HPP
 
@@ -5,6 +6,7 @@
 #error PersistLog.hpp only works with clang and gnu compilers
 #endif
 
+#include <derecho/config.h>
 #include "../HLC.hpp"
 #include "../PersistException.hpp"
 #include "../PersistentInterface.hpp"

--- a/include/derecho/persistent/detail/PersistNoLog_impl.hpp
+++ b/include/derecho/persistent/detail/PersistNoLog_impl.hpp
@@ -1,6 +1,8 @@
+#pragma once
 #ifndef PERSIST_NO_LOG_IMPL_HPP
 #define PERSIST_NO_LOG_IMPL_HPP
 
+#include <derecho/config.h>
 #include "../PersistNoLog.hpp"
 
 #define _NOLOG_OBJECT_DIR_ ((storageType == ST_MEM) ? getPersRamdiskPath().c_str() : getPersFilePath().c_str())

--- a/include/derecho/persistent/detail/Persistent_impl.hpp
+++ b/include/derecho/persistent/detail/Persistent_impl.hpp
@@ -1,9 +1,10 @@
+#pragma once
 #ifndef PERSISTENT_IMPL_HPP
 #define PERSISTENT_IMPL_HPP
 
-#include "derecho/persistent/Persistent.hpp"
-
-#include "derecho/openssl/hash.hpp"
+#include <derecho/config.h>
+#include <derecho/persistent/Persistent.hpp>
+#include <derecho/openssl/hash.hpp>
 
 #include <utility>
 

--- a/include/derecho/persistent/detail/logger.hpp
+++ b/include/derecho/persistent/detail/logger.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
-#include "derecho/utils/logger.hpp"
+#include <derecho/config.h>
+#include <derecho/utils/logger.hpp>
 
 #include <memory>
 #include <atomic>

--- a/include/derecho/persistent/detail/util.hpp
+++ b/include/derecho/persistent/detail/util.hpp
@@ -1,8 +1,10 @@
+#pragma once
 #ifndef PERSISTENT_UTIL_HPP
 #define PERSISTENT_UTIL_HPP
 
+#include <derecho/config.h>
 #include "../PersistException.hpp"
-#include "derecho/conf/conf.hpp"
+#include <derecho/conf/conf.hpp>
 #include <errno.h>
 #include <fcntl.h>
 #include <string>

--- a/include/derecho/rdmc/detail/lf_helper.hpp
+++ b/include/derecho/rdmc/detail/lf_helper.hpp
@@ -1,6 +1,8 @@
+#pragma once
 #ifndef LF_HELPER_HPP
 #define LF_HELPER_HPP
 
+#include <derecho/config.h>
 #include <cstdint>
 #include <functional>
 #include <iostream>

--- a/include/derecho/rdmc/detail/message.hpp
+++ b/include/derecho/rdmc/detail/message.hpp
@@ -1,6 +1,8 @@
+#pragma once
 #ifndef MESSAGE_HPP
 #define MESSAGE_HPP
 
+#include <derecho/config.h>
 #include <cstdint>
 #include <utility>
 

--- a/include/derecho/rdmc/detail/schedule.hpp
+++ b/include/derecho/rdmc/detail/schedule.hpp
@@ -1,6 +1,8 @@
+#pragma once
 #ifndef SCHEDULE_HPP
 #define SCHEDULE_HPP
 
+#include <derecho/config.h>
 #include <cmath>
 #include <cstdint>
 #include <optional>

--- a/include/derecho/rdmc/detail/util.hpp
+++ b/include/derecho/rdmc/detail/util.hpp
@@ -1,6 +1,8 @@
+#pragma once
 #ifndef RDMC_UTIL_HPP
 #define RDMC_UTIL_HPP
 
+#include <derecho/config.h>
 #include <derecho/utils/time.h>
 
 #include <cstdint>

--- a/include/derecho/rdmc/detail/verbs_helper.hpp
+++ b/include/derecho/rdmc/detail/verbs_helper.hpp
@@ -1,6 +1,8 @@
+#pragma once
 #ifndef VERBS_HELPER_HPP
 #define VERBS_HELPER_HPP
 
+#include <derecho/config.h>
 #include <cstdint>
 #include <optional>
 #include <functional>

--- a/include/derecho/rdmc/group_send.hpp
+++ b/include/derecho/rdmc/group_send.hpp
@@ -1,6 +1,8 @@
+#pragma once
 #ifndef GROUP_SEND_HPP
 #define GROUP_SEND_HPP
 
+#include <derecho/config.h>
 #include <derecho/rdmc/rdmc.hpp>
 #include "detail/schedule.hpp"
 

--- a/include/derecho/rdmc/rdmc.hpp
+++ b/include/derecho/rdmc/rdmc.hpp
@@ -1,7 +1,8 @@
-
+#pragma once
 #ifndef RDMC_HPP
 #define RDMC_HPP
 
+#include <derecho/config.h>
 #ifdef USE_VERBS_API
     #include "detail/verbs_helper.hpp"
 #else

--- a/include/derecho/sst/detail/lf.hpp
+++ b/include/derecho/sst/detail/lf.hpp
@@ -6,10 +6,10 @@
  * Contains declarations needed for working with RDMA using LibFabric libraries,
  * including the Resources class and global setup functions.
  */
-
-#include "derecho/core/derecho_type_definitions.hpp"
-#include "derecho/core/detail/connection_manager.hpp"
-#include "derecho/utils/logger.hpp"
+#include <derecho/config.h>
+#include <derecho/core/derecho_type_definitions.hpp>
+#include <derecho/core/detail/connection_manager.hpp>
+#include <derecho/utils/logger.hpp>
 
 #include <iostream>
 #include <map>

--- a/include/derecho/sst/detail/poll_utils.hpp
+++ b/include/derecho/sst/detail/poll_utils.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <derecho/config.h>
 #include <condition_variable>
 #include <optional>
 #include <list>

--- a/include/derecho/sst/detail/sst_impl.hpp
+++ b/include/derecho/sst/detail/sst_impl.hpp
@@ -6,10 +6,11 @@
 
 #pragma once
 
+#include <derecho/config.h>
 #include "../sst.hpp"
 
 #include "../predicates.hpp"
-#include "derecho/utils/time.h"
+#include <derecho/utils/time.h>
 #include "poll_utils.hpp"
 #include <chrono>
 #include <condition_variable>

--- a/include/derecho/sst/detail/verbs.hpp
+++ b/include/derecho/sst/detail/verbs.hpp
@@ -6,8 +6,8 @@
  * Contains declarations needed for working with RDMA using InfiniBand Verbs,
  * including the Resources class and global setup functions.
  */
-
-#include "derecho/core/derecho_type_definitions.hpp"
+#include <derecho/config.h>
+#include <derecho/core/derecho_type_definitions.hpp>
 
 #include <atomic>
 #include <infiniband/verbs.h>

--- a/include/derecho/sst/predicates.hpp
+++ b/include/derecho/sst/predicates.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <derecho/config.h>
 #include <algorithm>
 #include <functional>
 #include <list>

--- a/include/derecho/sst/sst.hpp
+++ b/include/derecho/sst/sst.hpp
@@ -1,7 +1,8 @@
 #pragma once
 
-#include "derecho/conf/conf.hpp"
-#include "derecho/utils/logger.hpp"
+#include <derecho/config.h>
+#include <derecho/conf/conf.hpp>
+#include <derecho/utils/logger.hpp>
 #include "predicates.hpp"
 
 #ifdef USE_VERBS_API

--- a/include/derecho/tcp/tcp.hpp
+++ b/include/derecho/tcp/tcp.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <derecho/config.h>
 #include <functional>
 #include <memory>
 #include <optional>

--- a/include/derecho/utils/container_ostreams.hpp
+++ b/include/derecho/utils/container_ostreams.hpp
@@ -7,6 +7,7 @@
  */
 #pragma once
 
+#include <derecho/config.h>
 #include <map>
 #include <ostream>
 #include <set>

--- a/include/derecho/utils/container_template_functions.hpp
+++ b/include/derecho/utils/container_template_functions.hpp
@@ -6,6 +6,7 @@
  */
 
 #pragma once
+#include <derecho/config.h>
 #include <algorithm>
 #include <list>
 #include <map>

--- a/include/derecho/utils/logger.hpp
+++ b/include/derecho/utils/logger.hpp
@@ -1,6 +1,8 @@
+#pragma once
 #ifndef LOGGER_HPP
 #define LOGGER_HPP
 
+#include <derecho/config.h>
 #include "container_ostreams.hpp"
 
 #include <string>

--- a/include/derecho/utils/time.h
+++ b/include/derecho/utils/time.h
@@ -1,7 +1,9 @@
+#pragma once
 
 #ifndef TIME_TIME_H
 #define TIME_TIME_H
 
+#include <derecho/config.h>
 #include <cstdint>
 #include <sys/resource.h>
 #include <time.h>

--- a/scripts/build/build.sh
+++ b/scripts/build/build.sh
@@ -81,9 +81,9 @@ if [[ $2 == "USE_VERBS_API" ]]; then
 fi
 
 # clear existing installed
-rm -rf ${install_prefix}/lib/libderecho*
-rm -rf ${install_prefix}/lib/cmake/derecho
-rm -rf ${install_prefix}/include/derecho
+# rm -rf ${install_prefix}/lib/libderecho*
+# rm -rf ${install_prefix}/lib/cmake/derecho
+# rm -rf ${install_prefix}/include/derecho
 
 # begin building...
 rm -rf ${build_path} 2>/dev/null

--- a/src/conf/conf.cpp
+++ b/src/conf/conf.cpp
@@ -1,4 +1,4 @@
-#include "derecho/conf/conf.hpp"
+#include <derecho/conf/conf.hpp>
 
 #include <nlohmann/json.hpp>
 

--- a/src/core/bytes_object.cpp
+++ b/src/core/bytes_object.cpp
@@ -1,4 +1,4 @@
-#include "derecho/core/bytes_object.hpp"
+#include <derecho/core/bytes_object.hpp>
 
 #include <cstring>
 

--- a/src/core/connection_manager.cpp
+++ b/src/core/connection_manager.cpp
@@ -1,4 +1,4 @@
-#include "derecho/core/detail/connection_manager.hpp"
+#include <derecho/core/detail/connection_manager.hpp>
 
 #include <cassert>
 #include <iostream>

--- a/src/core/derecho_sst.cpp
+++ b/src/core/derecho_sst.cpp
@@ -1,4 +1,4 @@
-#include "derecho/core/detail/derecho_sst.hpp"
+#include <derecho/core/detail/derecho_sst.hpp>
 
 #include <atomic>
 #include <cstring>

--- a/src/core/git_version.cpp
+++ b/src/core/git_version.cpp
@@ -6,7 +6,7 @@
  * local repository's .git/hooks/ directory.
  */
 
-#include "derecho/core/git_version.hpp"
+#include <derecho/core/git_version.hpp>
 
 namespace derecho {
 

--- a/src/core/multicast_group.cpp
+++ b/src/core/multicast_group.cpp
@@ -1,12 +1,12 @@
-#include "derecho/core/detail/multicast_group.hpp"
+#include <derecho/core/detail/multicast_group.hpp>
 
-#include "derecho/core/detail/derecho_internal.hpp"
-#include "derecho/persistent/Persistent.hpp"
-#include "derecho/persistent/PersistentInterface.hpp"
-#include "derecho/persistent/detail/PersistLog.hpp"
-#include "derecho/rdmc/detail/util.hpp"
-#include "derecho/utils/logger.hpp"
-#include "derecho/utils/time.h"
+#include <derecho/core/detail/derecho_internal.hpp>
+#include <derecho/persistent/Persistent.hpp>
+#include <derecho/persistent/PersistentInterface.hpp>
+#include <derecho/persistent/detail/PersistLog.hpp>
+#include <derecho/rdmc/detail/util.hpp>
+#include <derecho/utils/logger.hpp>
+#include <derecho/utils/time.h>
 
 #include <algorithm>
 #include <atomic>

--- a/src/core/notification.cpp
+++ b/src/core/notification.cpp
@@ -1,4 +1,4 @@
-#include "derecho/core/notification.hpp"
+#include <derecho/core/notification.hpp>
 
 #include <cstring>
 #include <memory>

--- a/src/core/p2p_connection.cpp
+++ b/src/core/p2p_connection.cpp
@@ -1,8 +1,7 @@
-#include "derecho/core/detail/p2p_connection.hpp"
-
-#include "derecho/conf/conf.hpp"
-#include "derecho/core/detail/rpc_utils.hpp"
-#include "derecho/sst/detail/poll_utils.hpp"
+#include <derecho/core/detail/p2p_connection.hpp>
+#include <derecho/conf/conf.hpp>
+#include <derecho/core/detail/rpc_utils.hpp>
+#include <derecho/sst/detail/poll_utils.hpp>
 
 #include <cstring>
 #include <map>

--- a/src/core/p2p_connection_manager.cpp
+++ b/src/core/p2p_connection_manager.cpp
@@ -1,9 +1,9 @@
-#include "derecho/core/detail/p2p_connection_manager.hpp"
+#include <derecho/core/detail/p2p_connection_manager.hpp>
 
-#include "derecho/core/derecho_exception.hpp"
-#include "derecho/conf/conf.hpp"
-#include "derecho/sst/detail/poll_utils.hpp"
-#include "derecho/utils/logger.hpp"
+#include <derecho/core/derecho_exception.hpp>
+#include <derecho/conf/conf.hpp>
+#include <derecho/sst/detail/poll_utils.hpp>
+#include <derecho/utils/logger.hpp>
 
 #include <cassert>
 #include <cstring>

--- a/src/core/persistence_manager.cpp
+++ b/src/core/persistence_manager.cpp
@@ -1,11 +1,11 @@
 /**
  * @date Jun 20, 2017
  */
-#include "derecho/core/detail/persistence_manager.hpp"
+#include <derecho/core/detail/persistence_manager.hpp>
 
-#include "derecho/core/detail/view_manager.hpp"
-#include "derecho/openssl/signature.hpp"
-#include "derecho/persistent/detail/logger.hpp"
+#include <derecho/core/detail/view_manager.hpp>
+#include <derecho/openssl/signature.hpp>
+#include <derecho/persistent/detail/logger.hpp>
 
 #include <map>
 #include <string>

--- a/src/core/public_key_store.cpp
+++ b/src/core/public_key_store.cpp
@@ -1,8 +1,8 @@
 /**
  * @file public_key_store.cpp
  */
-#include "derecho/core/detail/public_key_store.hpp"
-#include "derecho/persistent/detail/util.hpp"
+#include <derecho/core/detail/public_key_store.hpp>
+#include <derecho/persistent/detail/util.hpp>
 
 #include <dirent.h>
 #include <regex>

--- a/src/core/restart_state.cpp
+++ b/src/core/restart_state.cpp
@@ -1,11 +1,11 @@
-#include "derecho/core/detail/restart_state.hpp"
+#include <derecho/core/detail/restart_state.hpp>
 
-#include "derecho/core/detail/version_code.hpp"
-#include "derecho/utils/container_template_functions.hpp"
-#include "derecho/utils/logger.hpp"
+#include <derecho/core/detail/version_code.hpp>
+#include <derecho/utils/container_template_functions.hpp>
+#include <derecho/utils/logger.hpp>
 //This code needs access to ViewManager's static methods
-#include "derecho/core/detail/view_manager.hpp"
-#include "derecho/persistent/Persistent.hpp"
+#include <derecho/core/detail/view_manager.hpp>
+#include <derecho/persistent/Persistent.hpp>
 
 #include <chrono>
 #include <optional>

--- a/src/core/rpc_manager.cpp
+++ b/src/core/rpc_manager.cpp
@@ -4,8 +4,8 @@
  * @date Feb 7, 2017
  */
 
-#include "derecho/core/detail/rpc_manager.hpp"
-#include "derecho/core/detail/view_manager.hpp"
+#include <derecho/core/detail/rpc_manager.hpp>
+#include <derecho/core/detail/view_manager.hpp>
 
 #include <cassert>
 #include <exception>

--- a/src/core/rpc_utils.cpp
+++ b/src/core/rpc_utils.cpp
@@ -1,5 +1,5 @@
-#include "derecho/core/detail/rpc_utils.hpp"
-#include "derecho/utils/logger.hpp"
+#include <derecho/core/detail/rpc_utils.hpp>
+#include <derecho/utils/logger.hpp>
 
 namespace derecho {
 namespace rpc {

--- a/src/core/subgroup_functions.cpp
+++ b/src/core/subgroup_functions.cpp
@@ -2,13 +2,13 @@
  * @file subgroup_functions.cpp
  */
 
-#include "derecho/core/subgroup_functions.hpp"
+#include <derecho/core/subgroup_functions.hpp>
 
-#include "derecho/core/derecho_modes.hpp"
-#include "derecho/core/detail/derecho_internal.hpp"
-#include "derecho/core/view.hpp"
-#include "derecho/utils/container_template_functions.hpp"
-#include "derecho/utils/logger.hpp"
+#include <derecho/core/derecho_modes.hpp>
+#include <derecho/core/detail/derecho_internal.hpp>
+#include <derecho/core/view.hpp>
+#include <derecho/utils/container_template_functions.hpp>
+#include <derecho/utils/logger.hpp>
 
 #include <algorithm>
 #include <iterator>

--- a/src/core/version_code.cpp
+++ b/src/core/version_code.cpp
@@ -1,6 +1,6 @@
-#include "derecho/core/detail/version_code.hpp"
+#include <derecho/core/detail/version_code.hpp>
 
-#include "derecho/core/git_version.hpp"
+#include <derecho/core/git_version.hpp>
 
 #include <cstddef>
 #include <cstdint>

--- a/src/core/view.cpp
+++ b/src/core/view.cpp
@@ -1,5 +1,5 @@
-#include "derecho/core/view.hpp"
-#include "derecho/utils/container_ostreams.hpp"
+#include <derecho/core/view.hpp>
+#include <derecho/utils/container_ostreams.hpp>
 
 #include <algorithm>
 #include <iterator>

--- a/src/core/view_manager.cpp
+++ b/src/core/view_manager.cpp
@@ -2,16 +2,16 @@
  * @date Feb 6, 2017
  */
 
-#include "derecho/core/detail/view_manager.hpp"
+#include <derecho/core/detail/view_manager.hpp>
 
-#include "derecho/core/derecho_exception.hpp"
-#include "derecho/core/detail/public_key_store.hpp"
-#include "derecho/core/detail/version_code.hpp"
-#include "derecho/core/git_version.hpp"
-#include "derecho/core/replicated.hpp"
-#include "derecho/persistent/Persistent.hpp"
-#include "derecho/utils/container_template_functions.hpp"
-#include "derecho/utils/logger.hpp"
+#include <derecho/core/derecho_exception.hpp>
+#include <derecho/core/detail/public_key_store.hpp>
+#include <derecho/core/detail/version_code.hpp>
+#include <derecho/core/git_version.hpp>
+#include <derecho/core/replicated.hpp>
+#include <derecho/persistent/Persistent.hpp>
+#include <derecho/utils/container_template_functions.hpp>
+#include <derecho/utils/logger.hpp>
 
 #include <mutils/macro_utils.hpp>
 

--- a/src/openssl/hash.cpp
+++ b/src/openssl/hash.cpp
@@ -1,6 +1,6 @@
-#include "derecho/openssl/hash.hpp"
+#include <derecho/openssl/hash.hpp>
 
-#include "derecho/openssl/openssl_exception.hpp"
+#include <derecho/openssl/openssl_exception.hpp>
 
 #include <openssl/evp.h>
 

--- a/src/openssl/openssl_exception.cpp
+++ b/src/openssl/openssl_exception.cpp
@@ -3,7 +3,7 @@
  *
  */
 
-#include "derecho/openssl/openssl_exception.hpp"
+#include <derecho/openssl/openssl_exception.hpp>
 
 namespace openssl {
 

--- a/src/openssl/signature.cpp
+++ b/src/openssl/signature.cpp
@@ -1,4 +1,4 @@
-#include "derecho/openssl/signature.hpp"
+#include <derecho/openssl/signature.hpp>
 
 #include <cstdio>
 #include <cstring>

--- a/src/persistent/FilePersistLog.cpp
+++ b/src/persistent/FilePersistLog.cpp
@@ -1,9 +1,9 @@
-#include "derecho/persistent/detail/FilePersistLog.hpp"
+#include <derecho/persistent/detail/FilePersistLog.hpp>
 
-#include "derecho/conf/conf.hpp"
-#include "derecho/persistent/detail/util.hpp"
-#include "derecho/persistent/detail/logger.hpp"
-#include "derecho/persistent/PersistException.hpp"
+#include <derecho/conf/conf.hpp>
+#include <derecho/persistent/detail/util.hpp>
+#include <derecho/persistent/detail/logger.hpp>
+#include <derecho/persistent/PersistException.hpp>
 
 #include <dirent.h>
 #include <errno.h>

--- a/src/persistent/HLC.cpp
+++ b/src/persistent/HLC.cpp
@@ -1,4 +1,4 @@
-#include "derecho/persistent/HLC.hpp"
+#include <derecho/persistent/HLC.hpp>
 
 #include <errno.h>
 #include <time.h>

--- a/src/persistent/PersistLog.cpp
+++ b/src/persistent/PersistLog.cpp
@@ -1,8 +1,8 @@
-#include "derecho/persistent/detail/PersistLog.hpp"
+#include <derecho/persistent/detail/PersistLog.hpp>
 
-#include "derecho/openssl/signature.hpp"
-#include "derecho/persistent/detail/util.hpp"
-#include "derecho/persistent/detail/logger.hpp"
+#include <derecho/openssl/signature.hpp>
+#include <derecho/persistent/detail/util.hpp>
+#include <derecho/persistent/detail/logger.hpp>
 
 namespace persistent {
 

--- a/src/persistent/Persistent.cpp
+++ b/src/persistent/Persistent.cpp
@@ -1,8 +1,8 @@
-#include "derecho/persistent/Persistent.hpp"
+#include <derecho/persistent/Persistent.hpp>
 
-#include "derecho/persistent/detail/logger.hpp"
-#include "derecho/openssl/hash.hpp"
-#include "derecho/openssl/signature.hpp"
+#include <derecho/persistent/detail/logger.hpp>
+#include <derecho/openssl/hash.hpp>
+#include <derecho/openssl/signature.hpp>
 
 #include <functional>
 #include <string>

--- a/src/persistent/logger.cpp
+++ b/src/persistent/logger.cpp
@@ -1,5 +1,5 @@
-#include "derecho/persistent/detail/logger.hpp"
-#include "derecho/conf/conf.hpp"
+#include <derecho/persistent/detail/logger.hpp>
+#include <derecho/conf/conf.hpp>
 
 #include <atomic>
 #include <cstdint>

--- a/src/rdmc/group_send.cpp
+++ b/src/rdmc/group_send.cpp
@@ -1,11 +1,11 @@
-#include "derecho/rdmc/group_send.hpp"
-#include "derecho/rdmc/detail/message.hpp"
-#include "derecho/rdmc/detail/util.hpp"
+#include <derecho/rdmc/group_send.hpp>
+#include <derecho/rdmc/detail/message.hpp>
+#include <derecho/rdmc/detail/util.hpp>
 
 #ifdef USE_VERBS_API
-    #include "derecho/rdmc/detail/verbs_helper.hpp"
+#include <derecho/rdmc/detail/verbs_helper.hpp>
 #else
-    #include "derecho/rdmc/detail/lf_helper.hpp"
+#include <derecho/rdmc/detail/lf_helper.hpp>
 #endif
 
 #include <cassert>

--- a/src/rdmc/lf_helper.cpp
+++ b/src/rdmc/lf_helper.cpp
@@ -1,10 +1,10 @@
-#include "derecho/rdmc/detail/lf_helper.hpp"
+#include <derecho/rdmc/detail/lf_helper.hpp>
 
-#include "derecho/conf/conf.hpp"
-#include "derecho/core/detail/connection_manager.hpp"
-#include "derecho/rdmc/detail/util.hpp"
-#include "derecho/tcp/tcp.hpp"
-#include "derecho/utils/logger.hpp"
+#include <derecho/conf/conf.hpp>
+#include <derecho/core/detail/connection_manager.hpp>
+#include <derecho/rdmc/detail/util.hpp>
+#include <derecho/tcp/tcp.hpp>
+#include <derecho/utils/logger.hpp>
 
 #include <arpa/inet.h>
 #include <atomic>

--- a/src/rdmc/rdmc.cpp
+++ b/src/rdmc/rdmc.cpp
@@ -1,15 +1,15 @@
-#include "derecho/rdmc/rdmc.hpp"
-#include "derecho/rdmc/group_send.hpp"
-#include "derecho/rdmc/detail/message.hpp"
-#include "derecho/rdmc/detail/schedule.hpp"
-#include "derecho/rdmc/detail/util.hpp"
+#include <derecho/rdmc/rdmc.hpp>
+#include <derecho/rdmc/group_send.hpp>
+#include <derecho/rdmc/detail/message.hpp>
+#include <derecho/rdmc/detail/schedule.hpp>
+#include <derecho/rdmc/detail/util.hpp>
 #ifdef USE_VERBS_API
-    #include "derecho/rdmc/detail/verbs_helper.hpp"
+#include <derecho/rdmc/detail/verbs_helper.hpp>
 #else
-    #include "derecho/rdmc/detail/lf_helper.hpp"
+#include <derecho/rdmc/detail/lf_helper.hpp>
 #endif
 
-#include "derecho/core/derecho_type_definitions.hpp"
+#include <derecho/core/derecho_type_definitions.hpp>
 
 #include <atomic>
 #include <cmath>

--- a/src/rdmc/schedule.cpp
+++ b/src/rdmc/schedule.cpp
@@ -1,4 +1,4 @@
-#include "derecho/rdmc/detail/schedule.hpp"
+#include <derecho/rdmc/detail/schedule.hpp>
 
 #include <cassert>
 #include <climits>

--- a/src/rdmc/util.cpp
+++ b/src/rdmc/util.cpp
@@ -1,4 +1,4 @@
-#include "derecho/rdmc/detail/util.hpp"
+#include <derecho/rdmc/detail/util.hpp>
 
 #include <cassert>
 #include <cinttypes>

--- a/src/rdmc/verbs_helper.cpp
+++ b/src/rdmc/verbs_helper.cpp
@@ -1,10 +1,10 @@
-#include "derecho/rdmc/detail/verbs_helper.hpp"
+#include <derecho/rdmc/detail/verbs_helper.hpp>
 
-#include "derecho/conf/conf.hpp"
-#include "derecho/core/detail/connection_manager.hpp"
-#include "derecho/rdmc/detail/util.hpp"
-#include "derecho/tcp/tcp.hpp"
-#include "derecho/utils/logger.hpp"
+#include <derecho/conf/conf.hpp>
+#include <derecho/core/detail/connection_manager.hpp>
+#include <derecho/rdmc/detail/util.hpp>
+#include <derecho/tcp/tcp.hpp>
+#include <derecho/utils/logger.hpp>
 
 #include <atomic>
 #include <cstring>

--- a/src/sst/lf.cpp
+++ b/src/sst/lf.cpp
@@ -4,16 +4,16 @@
  * Implementation of RDMA interface defined in lf.h.
  */
 
-#include "derecho/sst/detail/lf.hpp"
+#include <derecho/sst/detail/lf.hpp>
 
-#include "derecho/conf/conf.hpp"
-#include "derecho/core/detail/connection_manager.hpp"
-#include "derecho/sst/detail/poll_utils.hpp"
-#include "derecho/sst/detail/sst_impl.hpp"
-#include "derecho/tcp/tcp.hpp"
-#include "derecho/utils/logger.hpp"
-#include "derecho/utils/time.h"
-#include "derecho/core/derecho_exception.hpp"
+#include <derecho/conf/conf.hpp>
+#include <derecho/core/detail/connection_manager.hpp>
+#include <derecho/sst/detail/poll_utils.hpp>
+#include <derecho/sst/detail/sst_impl.hpp>
+#include <derecho/tcp/tcp.hpp>
+#include <derecho/utils/logger.hpp>
+#include <derecho/utils/time.h>
+#include <derecho/core/derecho_exception.hpp>
 
 #include <arpa/inet.h>
 #include <byteswap.h>

--- a/src/sst/lf.cpp
+++ b/src/sst/lf.cpp
@@ -123,7 +123,11 @@ static void default_context() {
     memset((void*)&g_ctxt, 0, sizeof(lf_ctxt));
     g_ctxt.hints = crash_if_nullptr("Fail to allocate fi hints", fi_allocinfo);
     //defaults the hints:
+#ifdef  ENABLE_HMEM
     g_ctxt.hints->caps = FI_MSG | FI_RMA | FI_READ | FI_WRITE | FI_REMOTE_READ | FI_REMOTE_WRITE | FI_HMEM;
+#else
+    g_ctxt.hints->caps = FI_MSG | FI_RMA | FI_READ | FI_WRITE | FI_REMOTE_READ | FI_REMOTE_WRITE;
+#endif//ENABLE_HMEM
     g_ctxt.hints->ep_attr->type = FI_EP_MSG;  // use connection based endpoint by default.
     g_ctxt.hints->mode = ~0;                  // all modes
 
@@ -155,7 +159,11 @@ static void load_configuration() {
     if((strcmp(g_ctxt.hints->fabric_attr->prov_name, "sockets") == 0) || (strcmp(g_ctxt.hints->fabric_attr->prov_name, "tcp") == 0)) {
         g_ctxt.hints->domain_attr->mr_mode = FI_MR_BASIC;
     } else {  // default
+#ifdef  ENABLE_HMEM
         g_ctxt.hints->domain_attr->mr_mode = FI_MR_LOCAL | FI_MR_ALLOCATED | FI_MR_PROV_KEY | FI_MR_VIRT_ADDR | FI_MR_HMEM;
+#else
+        g_ctxt.hints->domain_attr->mr_mode = FI_MR_LOCAL | FI_MR_ALLOCATED | FI_MR_PROV_KEY | FI_MR_VIRT_ADDR;
+#endif//ENABLE_HMEM
     }
 
     // scatter/gather batch size

--- a/src/sst/poll_utils.cpp
+++ b/src/sst/poll_utils.cpp
@@ -1,4 +1,4 @@
-#include "derecho/sst/detail/poll_utils.hpp"
+#include <derecho/sst/detail/poll_utils.hpp>
 
 #include <functional>
 #include <iostream>

--- a/src/sst/verbs.cpp
+++ b/src/sst/verbs.cpp
@@ -2,14 +2,14 @@
  * @file verbs.cpp
  * Contains the implementation of the IB Verbs adapter layer of %SST.
  */
-#include "derecho/sst/detail/verbs.hpp"
+#include <derecho/sst/detail/verbs.hpp>
 
-#include "derecho/conf/conf.hpp"
-#include "derecho/core/detail/connection_manager.hpp"
-#include "derecho/sst/detail/poll_utils.hpp"
-#include "derecho/sst/detail/sst_impl.hpp"
-#include "derecho/tcp/tcp.hpp"
-#include "derecho/utils/logger.hpp"
+#include <derecho/conf/conf.hpp>
+#include <derecho/core/detail/connection_manager.hpp>
+#include <derecho/sst/detail/poll_utils.hpp>
+#include <derecho/sst/detail/sst_impl.hpp>
+#include <derecho/tcp/tcp.hpp>
+#include <derecho/utils/logger.hpp>
 
 #include <arpa/inet.h>
 #include <byteswap.h>

--- a/src/tcp/tcp.cpp
+++ b/src/tcp/tcp.cpp
@@ -1,4 +1,4 @@
-#include "derecho/tcp/tcp.hpp"
+#include <derecho/tcp/tcp.hpp>
 
 #include <algorithm>
 #include <arpa/inet.h>

--- a/src/utils/logger.cpp
+++ b/src/utils/logger.cpp
@@ -1,6 +1,6 @@
-#include "derecho/utils/logger.hpp"
+#include <derecho/utils/logger.hpp>
 
-#include "derecho/conf/conf.hpp"
+#include <derecho/conf/conf.hpp>
 
 #include <spdlog/spdlog.h>
 #include <spdlog/async.h>


### PR DESCRIPTION
After a discussion with Edward, we decided to re-issue v2.4.0 with the following changes:
1) Fix the `include` directives (from "" to <>), and
2) Introduce the `config.h.in` so that HMEM feature is controlled and v2.4.0 works for 'tcp' and 'socket' libfabric providers.

TODO: include Edward's changes making USE_VERBS_API compilable (not tested and not recommended as we've developed around libfabric for years.)