### PR TITLE
Fix compile errors in the Verbs API

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,7 +395,7 @@ Here is an example of a JSON layout string that uses "reserved_node_ids_by_shard
             if(curr_view.num_members < 3) {
                 throw derecho::subgroup_provisioning_exception();
             }
-            std::vector<node_id_t> first_3_nodes(&curr_view.members[0], &curr_view.members[0] + 3);
+            std::vector<derecho::node_id_t> first_3_nodes(&curr_view.members[0], &curr_view.members[0] + 3);
             //Put the desired SubView at subgroup_layout[0][0] since there's one subgroup with one shard
             subgroup_layout[0].emplace_back(curr_view.make_subview(first_3_nodes));
             //Advance next_unassigned_rank by 3, unless it was already beyond 3, since we assigned the first 3 nodes
@@ -405,7 +405,7 @@ Here is an example of a JSON layout string that uses "reserved_node_ids_by_shard
             if(curr_view.num_members < 6) {
                 throw derecho::subgroup_provisioning_exception();
             }
-            std::vector<node_id_t> next_3_nodes(&curr_view.members[3], &curr_view.members[3] + 3);
+            std::vector<derecho::node_id_t> next_3_nodes(&curr_view.members[3], &curr_view.members[3] + 3);
             subgroup_layout[0].emplace_back(curr_view.make_subview(next_3_nodes));
             curr_view.next_unassigned_rank += 3;
         }
@@ -453,7 +453,7 @@ PeerCaller<Cache>& p2p_cache_handle = group->get_nonmember_subgroup<Cache>(1);
 When invoking a P2P send, the caller must specify, as the first argument, the ID of the node to communicate with. The caller must ensure that this node is actually a member of the subgroup that the PeerCaller targets (though it can be in any shard of that subgroup). Nodes can find out the current membership of a subgroup by calling the `get_subgroup_members` method on the Group, which uses the same template parameter and argument as `get_subgroup` to select a subgroup by type and index. For example, assuming Cache subgroups are not sharded, this is how a non-member process could make a call to `get`, targeting the first node in the second subgroup of type Cache:
 
 ```cpp
-std::vector<node_id_t> cache_members = group.get_subgroup_members<Cache>(1)[0];
+std::vector<derecho::node_id_t> cache_members = group.get_subgroup_members<Cache>(1)[0];
 derecho::rpc::QueryResults<std::string> results = p2p_cache_handle.p2p_send<RPC_NAME(get)>(cache_members[0], "Foo");
 ```
 

--- a/include/derecho/core/detail/connection_manager.hpp
+++ b/include/derecho/core/detail/connection_manager.hpp
@@ -9,10 +9,10 @@
 #include <map>
 #include <mutex>
 
-using node_id_t = derecho::node_id_t;
 
 namespace tcp {
 
+using node_id_t = derecho::node_id_t;
 using ip_addr_t = derecho::ip_addr_t;
 
 class tcp_connections {

--- a/include/derecho/core/detail/p2p_connection.hpp
+++ b/include/derecho/core/detail/p2p_connection.hpp
@@ -6,7 +6,7 @@
 #else
 #include <derecho/sst/detail/lf.hpp>
 #endif
-#include "derecho/utils/logger.hpp"
+#include <derecho/utils/logger.hpp>
 
 #include <atomic>
 #include <iostream>

--- a/include/derecho/core/detail/p2p_connection.hpp
+++ b/include/derecho/core/detail/p2p_connection.hpp
@@ -6,6 +6,7 @@
 #else
 #include <derecho/sst/detail/lf.hpp>
 #endif
+#include "derecho/utils/logger.hpp"
 
 #include <atomic>
 #include <iostream>

--- a/include/derecho/rdmc/detail/lf_helper.hpp
+++ b/include/derecho/rdmc/detail/lf_helper.hpp
@@ -34,6 +34,7 @@ struct fid_cq;
  */
 namespace rdma {
 using ip_addr_t = derecho::ip_addr_t;
+using node_id_t = derecho::node_id_t;
 
 class exception {};
 class invalid_args : public exception {};

--- a/include/derecho/rdmc/detail/verbs_helper.hpp
+++ b/include/derecho/rdmc/detail/verbs_helper.hpp
@@ -24,6 +24,9 @@ struct ibv_cq;
  * to the IB Verbs library.
  */
 namespace rdma {
+using ip_addr_t = derecho::ip_addr_t;
+using node_id_t = derecho::node_id_t;
+
 // Various classes of exceptions
 class exception {};
 class invalid_args : public exception {};

--- a/include/derecho/sst/detail/lf.hpp
+++ b/include/derecho/sst/detail/lf.hpp
@@ -30,6 +30,7 @@ namespace sst {
 
 using memory_attribute_t    =   derecho::memory_attribute_t;
 using ip_addr_t             =   derecho::ip_addr_t;
+using node_id_t             =   derecho::node_id_t;
 
 class lf_completion_entry_ctxt {
 private:

--- a/include/derecho/sst/detail/verbs.hpp
+++ b/include/derecho/sst/detail/verbs.hpp
@@ -12,8 +12,19 @@
 #include <atomic>
 #include <infiniband/verbs.h>
 #include <map>
+#include <stdexcept>
+#include <sys/uio.h>
+#include <vector>
 
 namespace sst {
+
+using memory_attribute_t    =   derecho::memory_attribute_t;
+using ip_addr_t             =   derecho::ip_addr_t;
+using node_id_t             =   derecho::node_id_t;
+
+struct unsupported_operation_exception : public std::logic_error {
+    unsupported_operation_exception(const std::string& message) : logic_error(message) {}
+};
 
 /** Structure to exchange the data needed to connect the Queue Pairs */
 struct cm_con_data_t {
@@ -81,8 +92,8 @@ protected:
     int post_remote_send(verbs_sender_ctxt* sctxt, const long long int offset, const long long int size, const int op, const bool completion);
 
 public:
-    /** Index of the remote node. */
-    int remote_index;
+    /** ID of the remote node. */
+    int remote_id;
     /** Handle for the IB Verbs Queue Pair object. */
     struct ibv_qp* qp;
     /** Memory Region handle for the write buffer. */
@@ -107,15 +118,131 @@ public:
 
     /** Constructor; initializes Queue Pair, Memory Regions, and `remote_props`.
      */
-    _resources(int r_index, uint8_t* write_addr, uint8_t* read_addr, int size_w,
+    _resources(int r_id, uint8_t* write_addr, uint8_t* read_addr, int size_w,
                int size_r);
     /** Destroys the resources. */
     virtual ~_resources();
+    /**
+     * Out-of-Band memory and send management
+     * These are not currently supported when using the Verbs interface, but are
+     * declared here to allow compilation to succeed. Attempting to use any of
+     * them will throw an exception.
+     */
+
+    /**
+     * get the descriptor of the corresponding oob memory region
+     * Important: it assumes shared lock on oob_mrs_mutex.
+     * If iov does not fall into an oob memory region, it fails with nullptr.
+     *
+     * @param addr
+     *
+     * @return the descriptor of type void*, or nullptr in case of failure.
+     * @throw   derecho::derecho_exception if not found.
+     */
+    static void* get_oob_mr_desc(void* addr);
+
+    /**
+     * Get the key of the corresponding oob memory region for remote access.
+     *
+     * @param addr      The address of registered oob memory
+     *
+     * @return  the remote access key,
+     * @throw   derecho::derecho_exception if not found.
+     */
+    static uint64_t get_oob_mr_key(void* addr);
+
+    /**
+     * Register oob memory
+     * @param addr  the address of the OOB memory
+     * @param size  the size of the OOB memory
+     * @param attr  the memory attribute
+     *
+     * @throws derecho_exception on failure.
+     */
+    static void register_oob_memory_ex(void* addr, size_t size, const memory_attribute_t& attr);
+
+    /**
+     * Deregister oob memory
+     * @param addr the address of OOB memory
+     *
+     * @throws derecho_exception on failure.
+     */
+    static void deregister_oob_memory(void* addr);
+
+    /**
+     * Wait for a completion entries
+     * @param num_entries   The number of entries to wait for
+     * @param timeout_us    The number of microseconds to wait before throwing timeout
+     *
+     * @throws derecho_exception on failure.
+     */
+    void wait_for_thread_local_completion_entries(size_t num_entries, uint64_t timeout_us);
+
+    /*
+     * oob write
+     * @param iov               The gather memory vector, the total size of the source should not go beyond 'size'.
+     * @param iovcnt            The length of the vector.
+     * @param remote_dest_addr  The remote address for receiving this message
+     * @param rkey              The access key for the remote memory.
+     * @param size              The size of the remote buffer
+     *
+     * @throws derecho_exception at failure.
+     */
+    void oob_remote_write(const struct iovec* iov, int iovcnt,
+                          void* remote_dest_addr, uint64_t rkey, size_t size);
+
+    /*
+     * oob read
+     * @param iov               The scatter memory vector, the total size of the source should not go beyond 'size'.
+     * @param iovcnt            The length of the vector.
+     * @param remote_src_addr   The remote address for receiving this message
+     * @param rkey              The access key for the remote memory.
+     * @param size              The size of the remote buffer
+     *
+     * @throws derecho_exception at failure.
+     */
+    void oob_remote_read(const struct iovec* iov, int iovcnt,
+                         void* remote_src_addr, uint64_t rkey, size_t size);
+
+    /*
+     * oob send
+     * @param iov               The gather memory vector.
+     * @param iovcnt            The length of the vector.
+     *
+     * @throws derecho_exception at failure.
+     */
+    void oob_send(const struct iovec* iov, int iovcnt);
+
+    /*
+     * oob recv
+     * @param iov               The gather memory vector.
+     * @param iovcnt            The length of the vector.
+     *
+     * @throws derecho_exception at failure.
+     */
+    void oob_recv(const struct iovec* iov, int iovcnt);
+
+#define OOB_OP_READ     0x0
+#define OOB_OP_WRITE    0x1
+#define OOB_OP_SEND     0x2
+#define OOB_OP_RECV     0x3
+    /*
+     * Public callable wrapper around wait_for_thread_local_completion_entries()
+     * @param op                The OOB operations, one of the following:
+     *                          - OOB_OP_READ
+     *                          - OOB_OP_WRITE
+     *                          - OOB_OP_SEND
+     *                          - OOB_OP_RECV
+     *                          For most of the cases, we wait for only one completion. To allow an operation like
+     *                          "exchange", which is to be implemented, we might need to write for two completions.
+     * @param timeout_us        Timeout settings in microseconds.
+     */
+    void wait_for_oob_op(uint32_t op, uint64_t timeout_us);
 };
 
 class resources : public _resources {
 public:
-    resources(int r_index, uint8_t* write_addr, uint8_t* read_addr, int size_w,
+    resources(int r_id, uint8_t* write_addr, uint8_t* read_addr, int size_w,
               int size_r);
     /**
      * Report that the remote node this object is connected to has failed.
@@ -144,7 +271,7 @@ class resources_two_sided : public _resources {
     int post_receive(verbs_sender_ctxt* ce_ctxt, const long long int offset, const long long int size);
 
 public:
-    resources_two_sided(int r_index, uint8_t* write_addr, uint8_t* read_addr, int size_w,
+    resources_two_sided(int r_id, uint8_t* write_addr, uint8_t* read_addr, int size_w,
                         int size_r);
     /**
      * Report that the remote node this object is connected to has failed.
@@ -181,7 +308,7 @@ bool sync(uint32_t r_index);
  * @param live_nodes_list A list of node IDs whose connections should be retained;
  *        all other connections will be deleted.
  */
-void filter_external_to(const std::vector<node_id_t>& live_nodes_list);
+void filter_external_to(const std::vector<derecho::node_id_t>& live_nodes_list);
 
 /** Initializes the global verbs resources. */
 void verbs_initialize(const std::map<uint32_t, std::pair<ip_addr_t, uint16_t>>& ip_addrs_and_sst_ports,

--- a/src/applications/archive/custom_subgroup_profiles_test.cpp
+++ b/src/applications/archive/custom_subgroup_profiles_test.cpp
@@ -12,6 +12,7 @@
 
 using derecho::PeerCaller;
 using derecho::Replicated;
+using derecho::node_id_t;
 using std::cout;
 using std::endl;
 using namespace persistent;

--- a/src/applications/archive/external_client_perf_test.cpp
+++ b/src/applications/archive/external_client_perf_test.cpp
@@ -8,6 +8,7 @@
 
 using derecho::ExternalClientCaller;
 using derecho::Replicated;
+using derecho::node_id_t;
 using std::cout;
 using std::endl;
 using derecho::Bytes;

--- a/src/applications/archive/long_subgroup_test.cpp
+++ b/src/applications/archive/long_subgroup_test.cpp
@@ -7,6 +7,7 @@
 
 using derecho::PeerCaller;
 using derecho::Replicated;
+using derecho::node_id_t;
 using std::cout;
 using std::endl;
 using namespace persistent;

--- a/src/applications/archive/notification_test.cpp
+++ b/src/applications/archive/notification_test.cpp
@@ -7,6 +7,7 @@
 #include <derecho/persistent/Persistent.hpp>
 
 using derecho::ExternalClientCaller;
+using derecho::node_id_t;
 using std::cout;
 using std::endl;
 

--- a/src/applications/archive/scaling_subgroup_test.cpp
+++ b/src/applications/archive/scaling_subgroup_test.cpp
@@ -9,6 +9,7 @@
 
 using derecho::PeerCaller;
 using derecho::Replicated;
+using derecho::node_id_t;
 using std::cout;
 using std::endl;
 using namespace persistent;

--- a/src/applications/archive/smart_membership_function_test.cpp
+++ b/src/applications/archive/smart_membership_function_test.cpp
@@ -21,6 +21,8 @@
 #define RPC_NAME(...) 0ULL
 #endif
 
+using derecho::node_id_t;
+
 class Cache : public mutils::ByteRepresentable {
     std::map<std::string, std::string> cache_map;
 

--- a/src/applications/archive/subgroup_test.cpp
+++ b/src/applications/archive/subgroup_test.cpp
@@ -10,6 +10,7 @@
 #include <derecho/core/derecho.hpp>
 
 using derecho::RawObject;
+using derecho::node_id_t;
 using std::cin;
 using std::cout;
 using std::endl;

--- a/src/applications/archive/typed_subgroup_test.cpp
+++ b/src/applications/archive/typed_subgroup_test.cpp
@@ -12,6 +12,7 @@
 
 using derecho::PeerCaller;
 using derecho::Replicated;
+using derecho::node_id_t;
 using std::cout;
 using std::endl;
 using namespace persistent;

--- a/src/applications/demos/overlapping_replicated_objects.cpp
+++ b/src/applications/demos/overlapping_replicated_objects.cpp
@@ -22,6 +22,7 @@
 
 using derecho::PeerCaller;
 using derecho::Replicated;
+using derecho::node_id_t;
 using std::cout;
 using std::endl;
 

--- a/src/applications/demos/signed_store_mockup.cpp
+++ b/src/applications/demos/signed_store_mockup.cpp
@@ -110,13 +110,13 @@ ClientTier::ClientTier(){};
 std::tuple<persistent::version_t, uint64_t, std::vector<uint8_t>> ClientTier::submit_update(const Blob& data) const {
     derecho::PeerCaller<ObjectStore>& storage_subgroup = group->template get_nonmember_subgroup<ObjectStore>();
     derecho::PeerCaller<SignatureStore>& signature_subgroup = group->template get_nonmember_subgroup<SignatureStore>();
-    std::vector<std::vector<node_id_t>> storage_members = group->get_subgroup_members<ObjectStore>();
-    std::vector<std::vector<node_id_t>> signature_members = group->get_subgroup_members<SignatureStore>();
+    std::vector<std::vector<derecho::node_id_t>> storage_members = group->get_subgroup_members<ObjectStore>();
+    std::vector<std::vector<derecho::node_id_t>> signature_members = group->get_subgroup_members<SignatureStore>();
     std::uniform_int_distribution<> storage_distribution(0, storage_members[0].size() - 1);
     std::uniform_int_distribution<> signature_distribution(0, signature_members[0].size() - 1);
     //Choose a random member of each subgroup to contact with the P2P message
-    const node_id_t storage_member_to_contact = storage_members[0][storage_distribution(random_engine)];
-    const node_id_t signature_member_to_contact = signature_members[0][signature_distribution(random_engine)];
+    const derecho::node_id_t storage_member_to_contact = storage_members[0][storage_distribution(random_engine)];
+    const derecho::node_id_t signature_member_to_contact = signature_members[0][signature_distribution(random_engine)];
     //Send the new data to the storage subgroup
     dbg_default_debug("Sending update data to node {}", storage_member_to_contact);
     auto storage_query_results = storage_subgroup.p2p_send<RPC_NAME(update)>(storage_member_to_contact, data);
@@ -213,7 +213,7 @@ Blob ObjectStore::get_latest() const {
 /* -------------------------------------------------------------------- */
 
 //Determines whether a node ID is a member of any shard in a list of shards
-bool member_of_shards(node_id_t node_id, const std::vector<std::vector<node_id_t>>& shard_member_lists) {
+bool member_of_shards(derecho::node_id_t node_id, const std::vector<std::vector<derecho::node_id_t>>& shard_member_lists) {
     for(const auto& shard_members : shard_member_lists) {
         if(std::find(shard_members.begin(), shard_members.end(), node_id) != shard_members.end()) {
             return true;

--- a/src/applications/demos/simple_replicated_objects.cpp
+++ b/src/applications/demos/simple_replicated_objects.cpp
@@ -22,6 +22,7 @@
 
 using derecho::PeerCaller;
 using derecho::Replicated;
+using derecho::node_id_t;
 using std::cout;
 using std::endl;
 

--- a/src/applications/demos/simple_replicated_objects_json.cpp
+++ b/src/applications/demos/simple_replicated_objects_json.cpp
@@ -23,6 +23,7 @@
 
 using derecho::PeerCaller;
 using derecho::Replicated;
+using derecho::node_id_t;
 using std::cout;
 using std::endl;
 using json = nlohmann::json;

--- a/src/applications/demos/simple_replicated_objects_overlap.cpp
+++ b/src/applications/demos/simple_replicated_objects_overlap.cpp
@@ -13,6 +13,7 @@
 
 using derecho::PeerCaller;
 using derecho::Replicated;
+using derecho::node_id_t;
 using std::cout;
 using std::endl;
 

--- a/src/applications/tests/performance_tests/oob_perf.cpp
+++ b/src/applications/tests/performance_tests/oob_perf.cpp
@@ -155,7 +155,7 @@ bool OOBRDMA::get(const uint64_t& callee_addr, const uint64_t& caller_addr, cons
 template <typename P2PCaller>
 void perf_test (
         P2PCaller& p2p_caller,
-        node_id_t nid,
+        derecho::node_id_t nid,
         uint64_t rkey,
         void* put_buffer_laddr,
         void* get_buffer_laddr,

--- a/src/applications/tests/performance_tests/p2p_bw_test.cpp
+++ b/src/applications/tests/performance_tests/p2p_bw_test.cpp
@@ -15,6 +15,7 @@
 using std::endl;
 using test::Bytes;
 using namespace std::chrono;
+using derecho::node_id_t;
 
 /**
  * RPC Object with a single function that returns a byte array over P2P

--- a/src/applications/tests/performance_tests/p2p_latency_test.cpp
+++ b/src/applications/tests/performance_tests/p2p_latency_test.cpp
@@ -9,6 +9,7 @@ using std::cout;
 using std::endl;
 using std::string;
 using std::chrono::duration_cast;
+using derecho::node_id_t;
 
 class TestObject : public mutils::ByteRepresentable {
     int state;

--- a/src/applications/tests/unit_tests/client_callback_mockup.hpp
+++ b/src/applications/tests/unit_tests/client_callback_mockup.hpp
@@ -82,7 +82,7 @@ std::ostream& operator<<(std::ostream& os, const ClientCallbackType& cb_type);
  */
 struct CallbackRequest {
     ClientCallbackType callback_type;
-    node_id_t client;
+    derecho::node_id_t client;
     persistent::version_t version;
 };
 
@@ -110,7 +110,7 @@ public:
      * P2P-callable function that creates a new log entry with the provided data.
      * @return The version assigned to the new log entry, and the timestamp assigned to the new log entry
     */
-    std::pair<persistent::version_t, uint64_t> update(node_id_t sender_id,
+    std::pair<persistent::version_t, uint64_t> update(derecho::node_id_t sender_id,
                                                       uint32_t update_counter,
                                                       const Blob& new_data) const;
 
@@ -126,7 +126,7 @@ public:
      * update (identified by its version) has reached a particular state (locally/globally
      * persisted, signed)
      */
-    void register_callback(node_id_t client_node_id, const ClientCallbackType& callback_type, persistent::version_t version) const;
+    void register_callback(derecho::node_id_t client_node_id, const ClientCallbackType& callback_type, persistent::version_t version) const;
     /**
      * Function that implements the callback-checking thread. This thread waits for
      * updates to finish persisting and then sends callbacks to clients who requested

--- a/src/applications/tests/unit_tests/external_notification_test.cpp
+++ b/src/applications/tests/unit_tests/external_notification_test.cpp
@@ -8,6 +8,7 @@
 
 using derecho::ExternalClientCaller;
 using derecho::Replicated;
+using derecho::node_id_t;
 using std::cout;
 using std::endl;
 

--- a/src/applications/tests/unit_tests/persistence_notification_test.cpp
+++ b/src/applications/tests/unit_tests/persistence_notification_test.cpp
@@ -46,7 +46,7 @@ derecho::Bytes StorageNode::get(const persistent::version_t& version) const {
     return *object_log[version];
 }
 
-void StorageNode::request_notification(node_id_t client_node_id,
+void StorageNode::request_notification(derecho::node_id_t client_node_id,
                                        NotificationMessageType notification_type,
                                        persistent::version_t version) const {
     dbg_default_debug("Received a call to request_notification from node {} for version {}", client_node_id, version);
@@ -208,7 +208,7 @@ int main(int argc, char** argv) {
                                         + derecho::remote_invocation_utilities::header_space();
     //An update plus the two other parameters must fit in the available payload size
     const std::size_t update_size = derecho::getConfUInt64(derecho::Conf::SUBGROUP_DEFAULT_MAX_PAYLOAD_SIZE)
-                                    - rpc_header_size - sizeof(node_id_t) - sizeof(uint32_t);
+                                    - rpc_header_size - sizeof(derecho::node_id_t) - sizeof(uint32_t);
     //For generating random updates
     const std::string characters("abcdefghijklmnopqrstuvwxyz");
     std::mt19937 random_generator(getpid());
@@ -255,12 +255,12 @@ int main(int argc, char** argv) {
         derecho::ExternalGroupClient<StorageNode> client(dummy_storage_factory);
         derecho::ExternalClientCaller<StorageNode, decltype(client)>& storage_caller = client.get_subgroup_caller<StorageNode>(0);
         //Since we know there is only 1 subgroup and 1 shard of StorageNode, getting the node IDs is easy
-        std::vector<node_id_t> storage_node_ids = client.get_shard_members<StorageNode>(0, 0);
+        std::vector<derecho::node_id_t> storage_node_ids = client.get_shard_members<StorageNode>(0, 0);
         //Pick a node to contact to send updates
-        node_id_t update_node = storage_node_ids[0];
+        derecho::node_id_t update_node = storage_node_ids[0];
         //Right now, we must request notifications from that same node, because only the P2P
         //update method can record QueryResults; other replicas have no way of tracking their updates
-        node_id_t notification_node = update_node;
+        derecho::node_id_t notification_node = update_node;
         //Register the client callback handler
         storage_caller.add_p2p_connection(notification_node);
         storage_caller.register_notification_handler(client_callback_function);

--- a/src/applications/tests/unit_tests/persistence_notification_test.hpp
+++ b/src/applications/tests/unit_tests/persistence_notification_test.hpp
@@ -16,7 +16,7 @@ enum NotificationMessageType : uint64_t {
 
 struct NotificationRequest {
     NotificationMessageType notification_type;
-    node_id_t client_id;
+    derecho::node_id_t client_id;
     persistent::version_t version;
 };
 
@@ -67,7 +67,7 @@ public:
      * update (identified by its version) has reached a particular state (locally/globally
      * persisted, signed)
      */
-    void request_notification(node_id_t client_node_id, NotificationMessageType notification_type,
+    void request_notification(derecho::node_id_t client_node_id, NotificationMessageType notification_type,
                               persistent::version_t version) const;
     /**
      * Function that implements the notification-checking thread. This thread waits for

--- a/src/applications/tests/unit_tests/rpc_function_types.cpp
+++ b/src/applications/tests/unit_tests/rpc_function_types.cpp
@@ -73,6 +73,7 @@ public:
 
 using derecho::flexible_even_shards;
 using derecho::one_subgroup_policy;
+using derecho::node_id_t;
 
 int main(int argc, char** argv) {
     // Read configurations from the command line options as well as the default config file

--- a/src/applications/tests/unit_tests/rpc_reply_maps.cpp
+++ b/src/applications/tests/unit_tests/rpc_reply_maps.cpp
@@ -15,6 +15,8 @@
 #define RPC_NAME(...) 0ULL
 #endif
 
+using derecho::node_id_t;
+
 class StringObject : public mutils::ByteRepresentable {
     std::string log;
 

--- a/src/applications/tests/unit_tests/subgroup_function_tester.cpp
+++ b/src/applications/tests/unit_tests/subgroup_function_tester.cpp
@@ -25,6 +25,7 @@ void test_fixed_allocation_functions() {
     using derecho::CrossProductPolicy;
     using derecho::DefaultSubgroupAllocator;
     using derecho::SubgroupAllocationPolicy;
+    using derecho::node_id_t;
     //Reduce the verbosity of specifying "ordered" for three custom subgroups
     std::vector<derecho::Mode> three_ordered(3, derecho::Mode::ORDERED);
     std::vector<std::string> three_default_profiles(3, "default");
@@ -106,6 +107,7 @@ void test_fixed_allocation_functions() {
 void test_flexible_allocation_functions() {
     using derecho::DefaultSubgroupAllocator;
     using derecho::SubgroupAllocationPolicy;
+    using derecho::node_id_t;
 
     //Reduce the verbosity of specifying "ordered" for three custom subgroups
     std::vector<derecho::Mode> three_ordered(3, derecho::Mode::ORDERED);
@@ -164,6 +166,8 @@ void test_flexible_allocation_functions() {
 }
 
 void test_json_layout() {
+    using derecho::node_id_t;
+
     const char* json_layout_string =
             R"|([
     {

--- a/src/core/git_version.cpp
+++ b/src/core/git_version.cpp
@@ -13,8 +13,8 @@ namespace derecho {
 const int MAJOR_VERSION = 2;
 const int MINOR_VERSION = 4;
 const int PATCH_VERSION = 0;
-const int COMMITS_AHEAD_OF_VERSION = 1;
+const int COMMITS_AHEAD_OF_VERSION = 2;
 const char* VERSION_STRING = "2.4.0";
-const char* VERSION_STRING_PLUS_COMMITS = "2.4.0+1";
+const char* VERSION_STRING_PLUS_COMMITS = "2.4.0+2";
 
 }

--- a/src/core/git_version.cpp
+++ b/src/core/git_version.cpp
@@ -13,8 +13,8 @@ namespace derecho {
 const int MAJOR_VERSION = 2;
 const int MINOR_VERSION = 4;
 const int PATCH_VERSION = 0;
-const int COMMITS_AHEAD_OF_VERSION = 0;
+const int COMMITS_AHEAD_OF_VERSION = 1;
 const char* VERSION_STRING = "2.4.0";
-const char* VERSION_STRING_PLUS_COMMITS = "2.4.0+0";
+const char* VERSION_STRING_PLUS_COMMITS = "2.4.0+1";
 
 }


### PR DESCRIPTION
Since we haven't used the Verbs version of SST and RDMC in a while, there were a bunch of compile errors if you actually used the -DUSE_VERBS_API flag. I fixed them so that Derecho can at least compile when you use this flag. This does not mean the Verbs API has been tested, though, and it definitely won't work with the new OOB memory buffer commands.