### PR TITLE
+de/serialization support for a set of new STL containers

### DIFF
--- a/include/derecho/mutils-serialization/SerializationMacros.hpp
+++ b/include/derecho/mutils-serialization/SerializationMacros.hpp
@@ -16,7 +16,7 @@
     } \
     void post_object(const std::function<void (uint8_t const * const, std::size_t)>& func ) const { \
         mutils::post_object(func,a); \
-    }
+    } 
 
 #define DEFAULT_SERIALIZE2(a,b) std::size_t to_bytes(uint8_t* ret) const { \
         int bytes_written = mutils::to_bytes(a,ret);  \
@@ -28,7 +28,7 @@
     void post_object(const std::function<void (uint8_t const * const, std::size_t)>& func ) const { \
         mutils::post_object(func,a); \
         mutils::post_object(func,b); \
-    }
+    } 
 
 #define DEFAULT_SERIALIZE3(a,b,c) std::size_t to_bytes(uint8_t* ret) const { \
         int bytes_written = mutils::to_bytes(a,ret);  \
@@ -42,7 +42,7 @@
         mutils::post_object(func,a); \
         mutils::post_object(func,b); \
         mutils::post_object(func,c); \
-    }
+    } 
 
 #define DEFAULT_SERIALIZE4(a,b,c,d) std::size_t to_bytes(uint8_t* ret) const { \
         int bytes_written = mutils::to_bytes(a,ret);  \
@@ -58,7 +58,7 @@
         mutils::post_object(func,b); \
         mutils::post_object(func,c); \
         mutils::post_object(func,d); \
-    }
+    } 
 
 #define DEFAULT_SERIALIZE5(a,b,c,d,e) std::size_t to_bytes(uint8_t* ret) const { \
         int bytes_written = mutils::to_bytes(a,ret);  \
@@ -76,7 +76,7 @@
         mutils::post_object(func,c); \
         mutils::post_object(func,d); \
         mutils::post_object(func,e); \
-    }
+    } 
 
 #define DEFAULT_SERIALIZE6(a,b,c,d,e,f) std::size_t to_bytes(uint8_t* ret) const { \
         int bytes_written = mutils::to_bytes(a,ret);  \
@@ -96,7 +96,7 @@
         mutils::post_object(func,d); \
         mutils::post_object(func,e); \
         mutils::post_object(func,f); \
-    }
+    } 
 
 #define DEFAULT_SERIALIZE7(a,b,c,d,e,f,g) std::size_t to_bytes(uint8_t* ret) const { \
         int bytes_written = mutils::to_bytes(a,ret);  \
@@ -118,7 +118,7 @@
         mutils::post_object(func,e); \
         mutils::post_object(func,f); \
         mutils::post_object(func,g); \
-    }
+    } 
 
 #define DEFAULT_SERIALIZE8(a,b,c,d,e,f,g,h) std::size_t to_bytes(uint8_t* ret) const { \
         int bytes_written = mutils::to_bytes(a,ret);  \
@@ -142,7 +142,7 @@
         mutils::post_object(func,f); \
         mutils::post_object(func,g); \
         mutils::post_object(func,h); \
-    }
+    } 
 
 #define DEFAULT_SERIALIZE9(a,b,c,d,e,f,g,h,i) std::size_t to_bytes(uint8_t* ret) const { \
         int bytes_written = mutils::to_bytes(a,ret);  \
@@ -168,7 +168,7 @@
         mutils::post_object(func,g); \
         mutils::post_object(func,h); \
         mutils::post_object(func,i); \
-    }
+    } 
 
 #define DEFAULT_SERIALIZE10(a,b,c,d,e,f,g,h,i,j) std::size_t to_bytes(uint8_t* ret) const { \
         int bytes_written = mutils::to_bytes(a,ret);  \
@@ -196,7 +196,7 @@
         mutils::post_object(func,h); \
         mutils::post_object(func,i); \
         mutils::post_object(func,j); \
-    }
+    } 
 
 #define DEFAULT_SERIALIZE11(a,b,c,d,e,f,g,h,i,j,k) std::size_t to_bytes(uint8_t* ret) const { \
         int bytes_written = mutils::to_bytes(a,ret);  \
@@ -226,7 +226,7 @@
         mutils::post_object(func,i); \
         mutils::post_object(func,j); \
         mutils::post_object(func,k); \
-    }
+    } 
 
 #define DEFAULT_SERIALIZE12(a,b,c,d,e,f,g,h,i,j,k,l) std::size_t to_bytes(uint8_t* ret) const { \
         int bytes_written = mutils::to_bytes(a,ret);  \
@@ -258,7 +258,7 @@
         mutils::post_object(func,j); \
         mutils::post_object(func,k); \
         mutils::post_object(func,l); \
-    }
+    } 
 
 #define DEFAULT_SERIALIZE13(a,b,c,d,e,f,g,h,i,j,k,l,m) std::size_t to_bytes(uint8_t* ret) const { \
         int bytes_written = mutils::to_bytes(a,ret);  \
@@ -292,7 +292,7 @@
         mutils::post_object(func,k); \
         mutils::post_object(func,l); \
         mutils::post_object(func,m); \
-    }
+    } 
 
 #define DEFAULT_SERIALIZE14(a,b,c,d,e,f,g,h,i,j,k,l,m,n) std::size_t to_bytes(uint8_t* ret) const { \
         int bytes_written = mutils::to_bytes(a,ret);  \
@@ -328,19 +328,607 @@
         mutils::post_object(func,l); \
         mutils::post_object(func,m); \
         mutils::post_object(func,n); \
-    }
+    } 
+
+#define DEFAULT_SERIALIZE15(a,b,c,d,e,f,g,h,i,j,k,l,m,n,o) std::size_t to_bytes(uint8_t* ret) const { \
+        int bytes_written = mutils::to_bytes(a,ret);  \
+        bytes_written += mutils::to_bytes(b,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(c,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(d,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(e,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(f,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(g,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(h,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(i,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(j,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(k,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(l,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(m,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(n,ret + bytes_written); \
+        return bytes_written + mutils::to_bytes(o,ret + bytes_written); \
+    } \
+    std::size_t bytes_size() const { \
+        return mutils::bytes_size(a) + mutils::bytes_size(b) + mutils::bytes_size(c) + mutils::bytes_size(d) + mutils::bytes_size(e) + mutils::bytes_size(f) + mutils::bytes_size(g) + mutils::bytes_size(h) + mutils::bytes_size(i) + mutils::bytes_size(j) + mutils::bytes_size(k) + mutils::bytes_size(l) + mutils::bytes_size(m) + mutils::bytes_size(n) + mutils::bytes_size(o) ; \
+    } \
+    void post_object(const std::function<void (uint8_t const * const, std::size_t)>& func ) const { \
+        mutils::post_object(func,a); \
+        mutils::post_object(func,b); \
+        mutils::post_object(func,c); \
+        mutils::post_object(func,d); \
+        mutils::post_object(func,e); \
+        mutils::post_object(func,f); \
+        mutils::post_object(func,g); \
+        mutils::post_object(func,h); \
+        mutils::post_object(func,i); \
+        mutils::post_object(func,j); \
+        mutils::post_object(func,k); \
+        mutils::post_object(func,l); \
+        mutils::post_object(func,m); \
+        mutils::post_object(func,n); \
+        mutils::post_object(func,o); \
+    } 
+
+#define DEFAULT_SERIALIZE16(a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p) std::size_t to_bytes(uint8_t* ret) const { \
+        int bytes_written = mutils::to_bytes(a,ret);  \
+        bytes_written += mutils::to_bytes(b,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(c,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(d,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(e,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(f,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(g,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(h,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(i,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(j,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(k,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(l,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(m,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(n,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(o,ret + bytes_written); \
+        return bytes_written + mutils::to_bytes(p,ret + bytes_written); \
+    } \
+    std::size_t bytes_size() const { \
+        return mutils::bytes_size(a) + mutils::bytes_size(b) + mutils::bytes_size(c) + mutils::bytes_size(d) + mutils::bytes_size(e) + mutils::bytes_size(f) + mutils::bytes_size(g) + mutils::bytes_size(h) + mutils::bytes_size(i) + mutils::bytes_size(j) + mutils::bytes_size(k) + mutils::bytes_size(l) + mutils::bytes_size(m) + mutils::bytes_size(n) + mutils::bytes_size(o) + mutils::bytes_size(p) ; \
+    } \
+    void post_object(const std::function<void (uint8_t const * const, std::size_t)>& func ) const { \
+        mutils::post_object(func,a); \
+        mutils::post_object(func,b); \
+        mutils::post_object(func,c); \
+        mutils::post_object(func,d); \
+        mutils::post_object(func,e); \
+        mutils::post_object(func,f); \
+        mutils::post_object(func,g); \
+        mutils::post_object(func,h); \
+        mutils::post_object(func,i); \
+        mutils::post_object(func,j); \
+        mutils::post_object(func,k); \
+        mutils::post_object(func,l); \
+        mutils::post_object(func,m); \
+        mutils::post_object(func,n); \
+        mutils::post_object(func,o); \
+        mutils::post_object(func,p); \
+    } 
+
+#define DEFAULT_SERIALIZE17(a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q) std::size_t to_bytes(uint8_t* ret) const { \
+        int bytes_written = mutils::to_bytes(a,ret);  \
+        bytes_written += mutils::to_bytes(b,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(c,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(d,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(e,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(f,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(g,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(h,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(i,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(j,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(k,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(l,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(m,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(n,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(o,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(p,ret + bytes_written); \
+        return bytes_written + mutils::to_bytes(q,ret + bytes_written); \
+    } \
+    std::size_t bytes_size() const { \
+        return mutils::bytes_size(a) + mutils::bytes_size(b) + mutils::bytes_size(c) + mutils::bytes_size(d) + mutils::bytes_size(e) + mutils::bytes_size(f) + mutils::bytes_size(g) + mutils::bytes_size(h) + mutils::bytes_size(i) + mutils::bytes_size(j) + mutils::bytes_size(k) + mutils::bytes_size(l) + mutils::bytes_size(m) + mutils::bytes_size(n) + mutils::bytes_size(o) + mutils::bytes_size(p) + mutils::bytes_size(q) ; \
+    } \
+    void post_object(const std::function<void (uint8_t const * const, std::size_t)>& func ) const { \
+        mutils::post_object(func,a); \
+        mutils::post_object(func,b); \
+        mutils::post_object(func,c); \
+        mutils::post_object(func,d); \
+        mutils::post_object(func,e); \
+        mutils::post_object(func,f); \
+        mutils::post_object(func,g); \
+        mutils::post_object(func,h); \
+        mutils::post_object(func,i); \
+        mutils::post_object(func,j); \
+        mutils::post_object(func,k); \
+        mutils::post_object(func,l); \
+        mutils::post_object(func,m); \
+        mutils::post_object(func,n); \
+        mutils::post_object(func,o); \
+        mutils::post_object(func,p); \
+        mutils::post_object(func,q); \
+    } 
+
+#define DEFAULT_SERIALIZE18(a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r) std::size_t to_bytes(uint8_t* ret) const { \
+        int bytes_written = mutils::to_bytes(a,ret);  \
+        bytes_written += mutils::to_bytes(b,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(c,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(d,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(e,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(f,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(g,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(h,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(i,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(j,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(k,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(l,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(m,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(n,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(o,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(p,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(q,ret + bytes_written); \
+        return bytes_written + mutils::to_bytes(r,ret + bytes_written); \
+    } \
+    std::size_t bytes_size() const { \
+        return mutils::bytes_size(a) + mutils::bytes_size(b) + mutils::bytes_size(c) + mutils::bytes_size(d) + mutils::bytes_size(e) + mutils::bytes_size(f) + mutils::bytes_size(g) + mutils::bytes_size(h) + mutils::bytes_size(i) + mutils::bytes_size(j) + mutils::bytes_size(k) + mutils::bytes_size(l) + mutils::bytes_size(m) + mutils::bytes_size(n) + mutils::bytes_size(o) + mutils::bytes_size(p) + mutils::bytes_size(q) + mutils::bytes_size(r) ; \
+    } \
+    void post_object(const std::function<void (uint8_t const * const, std::size_t)>& func ) const { \
+        mutils::post_object(func,a); \
+        mutils::post_object(func,b); \
+        mutils::post_object(func,c); \
+        mutils::post_object(func,d); \
+        mutils::post_object(func,e); \
+        mutils::post_object(func,f); \
+        mutils::post_object(func,g); \
+        mutils::post_object(func,h); \
+        mutils::post_object(func,i); \
+        mutils::post_object(func,j); \
+        mutils::post_object(func,k); \
+        mutils::post_object(func,l); \
+        mutils::post_object(func,m); \
+        mutils::post_object(func,n); \
+        mutils::post_object(func,o); \
+        mutils::post_object(func,p); \
+        mutils::post_object(func,q); \
+        mutils::post_object(func,r); \
+    } 
+
+#define DEFAULT_SERIALIZE19(a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s) std::size_t to_bytes(uint8_t* ret) const { \
+        int bytes_written = mutils::to_bytes(a,ret);  \
+        bytes_written += mutils::to_bytes(b,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(c,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(d,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(e,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(f,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(g,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(h,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(i,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(j,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(k,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(l,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(m,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(n,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(o,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(p,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(q,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(r,ret + bytes_written); \
+        return bytes_written + mutils::to_bytes(s,ret + bytes_written); \
+    } \
+    std::size_t bytes_size() const { \
+        return mutils::bytes_size(a) + mutils::bytes_size(b) + mutils::bytes_size(c) + mutils::bytes_size(d) + mutils::bytes_size(e) + mutils::bytes_size(f) + mutils::bytes_size(g) + mutils::bytes_size(h) + mutils::bytes_size(i) + mutils::bytes_size(j) + mutils::bytes_size(k) + mutils::bytes_size(l) + mutils::bytes_size(m) + mutils::bytes_size(n) + mutils::bytes_size(o) + mutils::bytes_size(p) + mutils::bytes_size(q) + mutils::bytes_size(r) + mutils::bytes_size(s) ; \
+    } \
+    void post_object(const std::function<void (uint8_t const * const, std::size_t)>& func ) const { \
+        mutils::post_object(func,a); \
+        mutils::post_object(func,b); \
+        mutils::post_object(func,c); \
+        mutils::post_object(func,d); \
+        mutils::post_object(func,e); \
+        mutils::post_object(func,f); \
+        mutils::post_object(func,g); \
+        mutils::post_object(func,h); \
+        mutils::post_object(func,i); \
+        mutils::post_object(func,j); \
+        mutils::post_object(func,k); \
+        mutils::post_object(func,l); \
+        mutils::post_object(func,m); \
+        mutils::post_object(func,n); \
+        mutils::post_object(func,o); \
+        mutils::post_object(func,p); \
+        mutils::post_object(func,q); \
+        mutils::post_object(func,r); \
+        mutils::post_object(func,s); \
+    } 
+
+#define DEFAULT_SERIALIZE20(a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t) std::size_t to_bytes(uint8_t* ret) const { \
+        int bytes_written = mutils::to_bytes(a,ret);  \
+        bytes_written += mutils::to_bytes(b,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(c,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(d,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(e,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(f,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(g,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(h,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(i,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(j,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(k,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(l,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(m,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(n,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(o,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(p,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(q,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(r,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(s,ret + bytes_written); \
+        return bytes_written + mutils::to_bytes(t,ret + bytes_written); \
+    } \
+    std::size_t bytes_size() const { \
+        return mutils::bytes_size(a) + mutils::bytes_size(b) + mutils::bytes_size(c) + mutils::bytes_size(d) + mutils::bytes_size(e) + mutils::bytes_size(f) + mutils::bytes_size(g) + mutils::bytes_size(h) + mutils::bytes_size(i) + mutils::bytes_size(j) + mutils::bytes_size(k) + mutils::bytes_size(l) + mutils::bytes_size(m) + mutils::bytes_size(n) + mutils::bytes_size(o) + mutils::bytes_size(p) + mutils::bytes_size(q) + mutils::bytes_size(r) + mutils::bytes_size(s) + mutils::bytes_size(t) ; \
+    } \
+    void post_object(const std::function<void (uint8_t const * const, std::size_t)>& func ) const { \
+        mutils::post_object(func,a); \
+        mutils::post_object(func,b); \
+        mutils::post_object(func,c); \
+        mutils::post_object(func,d); \
+        mutils::post_object(func,e); \
+        mutils::post_object(func,f); \
+        mutils::post_object(func,g); \
+        mutils::post_object(func,h); \
+        mutils::post_object(func,i); \
+        mutils::post_object(func,j); \
+        mutils::post_object(func,k); \
+        mutils::post_object(func,l); \
+        mutils::post_object(func,m); \
+        mutils::post_object(func,n); \
+        mutils::post_object(func,o); \
+        mutils::post_object(func,p); \
+        mutils::post_object(func,q); \
+        mutils::post_object(func,r); \
+        mutils::post_object(func,s); \
+        mutils::post_object(func,t); \
+    } 
+
+#define DEFAULT_SERIALIZE21(a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t,u) std::size_t to_bytes(uint8_t* ret) const { \
+        int bytes_written = mutils::to_bytes(a,ret);  \
+        bytes_written += mutils::to_bytes(b,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(c,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(d,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(e,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(f,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(g,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(h,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(i,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(j,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(k,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(l,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(m,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(n,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(o,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(p,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(q,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(r,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(s,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(t,ret + bytes_written); \
+        return bytes_written + mutils::to_bytes(u,ret + bytes_written); \
+    } \
+    std::size_t bytes_size() const { \
+        return mutils::bytes_size(a) + mutils::bytes_size(b) + mutils::bytes_size(c) + mutils::bytes_size(d) + mutils::bytes_size(e) + mutils::bytes_size(f) + mutils::bytes_size(g) + mutils::bytes_size(h) + mutils::bytes_size(i) + mutils::bytes_size(j) + mutils::bytes_size(k) + mutils::bytes_size(l) + mutils::bytes_size(m) + mutils::bytes_size(n) + mutils::bytes_size(o) + mutils::bytes_size(p) + mutils::bytes_size(q) + mutils::bytes_size(r) + mutils::bytes_size(s) + mutils::bytes_size(t) + mutils::bytes_size(u) ; \
+    } \
+    void post_object(const std::function<void (uint8_t const * const, std::size_t)>& func ) const { \
+        mutils::post_object(func,a); \
+        mutils::post_object(func,b); \
+        mutils::post_object(func,c); \
+        mutils::post_object(func,d); \
+        mutils::post_object(func,e); \
+        mutils::post_object(func,f); \
+        mutils::post_object(func,g); \
+        mutils::post_object(func,h); \
+        mutils::post_object(func,i); \
+        mutils::post_object(func,j); \
+        mutils::post_object(func,k); \
+        mutils::post_object(func,l); \
+        mutils::post_object(func,m); \
+        mutils::post_object(func,n); \
+        mutils::post_object(func,o); \
+        mutils::post_object(func,p); \
+        mutils::post_object(func,q); \
+        mutils::post_object(func,r); \
+        mutils::post_object(func,s); \
+        mutils::post_object(func,t); \
+        mutils::post_object(func,u); \
+    } 
+
+#define DEFAULT_SERIALIZE22(a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t,u,v) std::size_t to_bytes(uint8_t* ret) const { \
+        int bytes_written = mutils::to_bytes(a,ret);  \
+        bytes_written += mutils::to_bytes(b,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(c,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(d,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(e,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(f,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(g,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(h,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(i,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(j,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(k,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(l,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(m,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(n,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(o,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(p,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(q,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(r,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(s,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(t,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(u,ret + bytes_written); \
+        return bytes_written + mutils::to_bytes(v,ret + bytes_written); \
+    } \
+    std::size_t bytes_size() const { \
+        return mutils::bytes_size(a) + mutils::bytes_size(b) + mutils::bytes_size(c) + mutils::bytes_size(d) + mutils::bytes_size(e) + mutils::bytes_size(f) + mutils::bytes_size(g) + mutils::bytes_size(h) + mutils::bytes_size(i) + mutils::bytes_size(j) + mutils::bytes_size(k) + mutils::bytes_size(l) + mutils::bytes_size(m) + mutils::bytes_size(n) + mutils::bytes_size(o) + mutils::bytes_size(p) + mutils::bytes_size(q) + mutils::bytes_size(r) + mutils::bytes_size(s) + mutils::bytes_size(t) + mutils::bytes_size(u) + mutils::bytes_size(v) ; \
+    } \
+    void post_object(const std::function<void (uint8_t const * const, std::size_t)>& func ) const { \
+        mutils::post_object(func,a); \
+        mutils::post_object(func,b); \
+        mutils::post_object(func,c); \
+        mutils::post_object(func,d); \
+        mutils::post_object(func,e); \
+        mutils::post_object(func,f); \
+        mutils::post_object(func,g); \
+        mutils::post_object(func,h); \
+        mutils::post_object(func,i); \
+        mutils::post_object(func,j); \
+        mutils::post_object(func,k); \
+        mutils::post_object(func,l); \
+        mutils::post_object(func,m); \
+        mutils::post_object(func,n); \
+        mutils::post_object(func,o); \
+        mutils::post_object(func,p); \
+        mutils::post_object(func,q); \
+        mutils::post_object(func,r); \
+        mutils::post_object(func,s); \
+        mutils::post_object(func,t); \
+        mutils::post_object(func,u); \
+        mutils::post_object(func,v); \
+    } 
+
+#define DEFAULT_SERIALIZE23(a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t,u,v,w) std::size_t to_bytes(uint8_t* ret) const { \
+        int bytes_written = mutils::to_bytes(a,ret);  \
+        bytes_written += mutils::to_bytes(b,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(c,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(d,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(e,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(f,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(g,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(h,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(i,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(j,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(k,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(l,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(m,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(n,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(o,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(p,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(q,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(r,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(s,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(t,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(u,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(v,ret + bytes_written); \
+        return bytes_written + mutils::to_bytes(w,ret + bytes_written); \
+    } \
+    std::size_t bytes_size() const { \
+        return mutils::bytes_size(a) + mutils::bytes_size(b) + mutils::bytes_size(c) + mutils::bytes_size(d) + mutils::bytes_size(e) + mutils::bytes_size(f) + mutils::bytes_size(g) + mutils::bytes_size(h) + mutils::bytes_size(i) + mutils::bytes_size(j) + mutils::bytes_size(k) + mutils::bytes_size(l) + mutils::bytes_size(m) + mutils::bytes_size(n) + mutils::bytes_size(o) + mutils::bytes_size(p) + mutils::bytes_size(q) + mutils::bytes_size(r) + mutils::bytes_size(s) + mutils::bytes_size(t) + mutils::bytes_size(u) + mutils::bytes_size(v) + mutils::bytes_size(w) ; \
+    } \
+    void post_object(const std::function<void (uint8_t const * const, std::size_t)>& func ) const { \
+        mutils::post_object(func,a); \
+        mutils::post_object(func,b); \
+        mutils::post_object(func,c); \
+        mutils::post_object(func,d); \
+        mutils::post_object(func,e); \
+        mutils::post_object(func,f); \
+        mutils::post_object(func,g); \
+        mutils::post_object(func,h); \
+        mutils::post_object(func,i); \
+        mutils::post_object(func,j); \
+        mutils::post_object(func,k); \
+        mutils::post_object(func,l); \
+        mutils::post_object(func,m); \
+        mutils::post_object(func,n); \
+        mutils::post_object(func,o); \
+        mutils::post_object(func,p); \
+        mutils::post_object(func,q); \
+        mutils::post_object(func,r); \
+        mutils::post_object(func,s); \
+        mutils::post_object(func,t); \
+        mutils::post_object(func,u); \
+        mutils::post_object(func,v); \
+        mutils::post_object(func,w); \
+    } 
+
+#define DEFAULT_SERIALIZE24(a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t,u,v,w,x) std::size_t to_bytes(uint8_t* ret) const { \
+        int bytes_written = mutils::to_bytes(a,ret);  \
+        bytes_written += mutils::to_bytes(b,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(c,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(d,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(e,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(f,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(g,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(h,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(i,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(j,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(k,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(l,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(m,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(n,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(o,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(p,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(q,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(r,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(s,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(t,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(u,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(v,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(w,ret + bytes_written); \
+        return bytes_written + mutils::to_bytes(x,ret + bytes_written); \
+    } \
+    std::size_t bytes_size() const { \
+        return mutils::bytes_size(a) + mutils::bytes_size(b) + mutils::bytes_size(c) + mutils::bytes_size(d) + mutils::bytes_size(e) + mutils::bytes_size(f) + mutils::bytes_size(g) + mutils::bytes_size(h) + mutils::bytes_size(i) + mutils::bytes_size(j) + mutils::bytes_size(k) + mutils::bytes_size(l) + mutils::bytes_size(m) + mutils::bytes_size(n) + mutils::bytes_size(o) + mutils::bytes_size(p) + mutils::bytes_size(q) + mutils::bytes_size(r) + mutils::bytes_size(s) + mutils::bytes_size(t) + mutils::bytes_size(u) + mutils::bytes_size(v) + mutils::bytes_size(w) + mutils::bytes_size(x) ; \
+    } \
+    void post_object(const std::function<void (uint8_t const * const, std::size_t)>& func ) const { \
+        mutils::post_object(func,a); \
+        mutils::post_object(func,b); \
+        mutils::post_object(func,c); \
+        mutils::post_object(func,d); \
+        mutils::post_object(func,e); \
+        mutils::post_object(func,f); \
+        mutils::post_object(func,g); \
+        mutils::post_object(func,h); \
+        mutils::post_object(func,i); \
+        mutils::post_object(func,j); \
+        mutils::post_object(func,k); \
+        mutils::post_object(func,l); \
+        mutils::post_object(func,m); \
+        mutils::post_object(func,n); \
+        mutils::post_object(func,o); \
+        mutils::post_object(func,p); \
+        mutils::post_object(func,q); \
+        mutils::post_object(func,r); \
+        mutils::post_object(func,s); \
+        mutils::post_object(func,t); \
+        mutils::post_object(func,u); \
+        mutils::post_object(func,v); \
+        mutils::post_object(func,w); \
+        mutils::post_object(func,x); \
+    } 
+
+#define DEFAULT_SERIALIZE25(a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t,u,v,w,x,y) std::size_t to_bytes(uint8_t* ret) const { \
+        int bytes_written = mutils::to_bytes(a,ret);  \
+        bytes_written += mutils::to_bytes(b,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(c,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(d,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(e,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(f,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(g,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(h,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(i,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(j,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(k,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(l,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(m,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(n,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(o,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(p,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(q,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(r,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(s,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(t,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(u,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(v,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(w,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(x,ret + bytes_written); \
+        return bytes_written + mutils::to_bytes(y,ret + bytes_written); \
+    } \
+    std::size_t bytes_size() const { \
+        return mutils::bytes_size(a) + mutils::bytes_size(b) + mutils::bytes_size(c) + mutils::bytes_size(d) + mutils::bytes_size(e) + mutils::bytes_size(f) + mutils::bytes_size(g) + mutils::bytes_size(h) + mutils::bytes_size(i) + mutils::bytes_size(j) + mutils::bytes_size(k) + mutils::bytes_size(l) + mutils::bytes_size(m) + mutils::bytes_size(n) + mutils::bytes_size(o) + mutils::bytes_size(p) + mutils::bytes_size(q) + mutils::bytes_size(r) + mutils::bytes_size(s) + mutils::bytes_size(t) + mutils::bytes_size(u) + mutils::bytes_size(v) + mutils::bytes_size(w) + mutils::bytes_size(x) + mutils::bytes_size(y) ; \
+    } \
+    void post_object(const std::function<void (uint8_t const * const, std::size_t)>& func ) const { \
+        mutils::post_object(func,a); \
+        mutils::post_object(func,b); \
+        mutils::post_object(func,c); \
+        mutils::post_object(func,d); \
+        mutils::post_object(func,e); \
+        mutils::post_object(func,f); \
+        mutils::post_object(func,g); \
+        mutils::post_object(func,h); \
+        mutils::post_object(func,i); \
+        mutils::post_object(func,j); \
+        mutils::post_object(func,k); \
+        mutils::post_object(func,l); \
+        mutils::post_object(func,m); \
+        mutils::post_object(func,n); \
+        mutils::post_object(func,o); \
+        mutils::post_object(func,p); \
+        mutils::post_object(func,q); \
+        mutils::post_object(func,r); \
+        mutils::post_object(func,s); \
+        mutils::post_object(func,t); \
+        mutils::post_object(func,u); \
+        mutils::post_object(func,v); \
+        mutils::post_object(func,w); \
+        mutils::post_object(func,x); \
+        mutils::post_object(func,y); \
+    } 
+
+#define DEFAULT_SERIALIZE26(a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t,u,v,w,x,y,z) std::size_t to_bytes(uint8_t* ret) const { \
+        int bytes_written = mutils::to_bytes(a,ret);  \
+        bytes_written += mutils::to_bytes(b,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(c,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(d,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(e,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(f,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(g,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(h,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(i,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(j,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(k,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(l,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(m,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(n,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(o,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(p,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(q,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(r,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(s,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(t,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(u,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(v,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(w,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(x,ret + bytes_written); \
+        bytes_written += mutils::to_bytes(y,ret + bytes_written); \
+        return bytes_written + mutils::to_bytes(z,ret + bytes_written); \
+    } \
+    std::size_t bytes_size() const { \
+        return mutils::bytes_size(a) + mutils::bytes_size(b) + mutils::bytes_size(c) + mutils::bytes_size(d) + mutils::bytes_size(e) + mutils::bytes_size(f) + mutils::bytes_size(g) + mutils::bytes_size(h) + mutils::bytes_size(i) + mutils::bytes_size(j) + mutils::bytes_size(k) + mutils::bytes_size(l) + mutils::bytes_size(m) + mutils::bytes_size(n) + mutils::bytes_size(o) + mutils::bytes_size(p) + mutils::bytes_size(q) + mutils::bytes_size(r) + mutils::bytes_size(s) + mutils::bytes_size(t) + mutils::bytes_size(u) + mutils::bytes_size(v) + mutils::bytes_size(w) + mutils::bytes_size(x) + mutils::bytes_size(y) + mutils::bytes_size(z) ; \
+    } \
+    void post_object(const std::function<void (uint8_t const * const, std::size_t)>& func ) const { \
+        mutils::post_object(func,a); \
+        mutils::post_object(func,b); \
+        mutils::post_object(func,c); \
+        mutils::post_object(func,d); \
+        mutils::post_object(func,e); \
+        mutils::post_object(func,f); \
+        mutils::post_object(func,g); \
+        mutils::post_object(func,h); \
+        mutils::post_object(func,i); \
+        mutils::post_object(func,j); \
+        mutils::post_object(func,k); \
+        mutils::post_object(func,l); \
+        mutils::post_object(func,m); \
+        mutils::post_object(func,n); \
+        mutils::post_object(func,o); \
+        mutils::post_object(func,p); \
+        mutils::post_object(func,q); \
+        mutils::post_object(func,r); \
+        mutils::post_object(func,s); \
+        mutils::post_object(func,t); \
+        mutils::post_object(func,u); \
+        mutils::post_object(func,v); \
+        mutils::post_object(func,w); \
+        mutils::post_object(func,x); \
+        mutils::post_object(func,y); \
+        mutils::post_object(func,z); \
+    } 
 
 #define DEFAULT_DESERIALIZE2(Name,a) \
     static std::unique_ptr<Name> from_bytes(mutils::DeserializationManager* dsm, uint8_t const * buf){ \
         auto a_obj = mutils::from_bytes<std::decay_t<decltype(a)> >(dsm, buf); \
         return std::make_unique<Name>(*a_obj); \
-    }
+    } 
 
 #define DEFAULT_DESERIALIZE3(Name,a,b) \
     static std::unique_ptr<Name> from_bytes(mutils::DeserializationManager* dsm, uint8_t const * buf){ \
         auto a_obj = mutils::from_bytes<std::decay_t<decltype(a)> >(dsm, buf); \
         return std::make_unique<Name>(*a_obj, *(mutils::from_bytes<std::decay_t<decltype(b)> >(dsm, buf + mutils::bytes_size(*a_obj)))); \
-    }
+    } 
 
 #define DEFAULT_DESERIALIZE4(Name,a,b,c) \
     static std::unique_ptr<Name> from_bytes(mutils::DeserializationManager* dsm, uint8_t const * buf){ \
@@ -348,7 +936,7 @@
         std::size_t bytes_read = mutils::bytes_size(*a_obj); \
         auto b_obj = mutils::from_bytes<std::decay_t<decltype(b)> >(dsm, buf + bytes_read); \
         return std::make_unique<Name>(*a_obj,*b_obj, *(mutils::from_bytes<std::decay_t<decltype(c)> >(dsm, buf + bytes_read + mutils::bytes_size(*b_obj)))); \
-    }
+    } 
 
 #define DEFAULT_DESERIALIZE5(Name,a,b,c,d) \
     static std::unique_ptr<Name> from_bytes(mutils::DeserializationManager* dsm, uint8_t const * buf){ \
@@ -358,7 +946,7 @@
         bytes_read += mutils::bytes_size(*b_obj); \
         auto c_obj = mutils::from_bytes<std::decay_t<decltype(c)> >(dsm, buf + bytes_read); \
         return std::make_unique<Name>(*a_obj,*b_obj,*c_obj, *(mutils::from_bytes<std::decay_t<decltype(d)> >(dsm, buf + bytes_read + mutils::bytes_size(*c_obj)))); \
-    }
+    } 
 
 #define DEFAULT_DESERIALIZE6(Name,a,b,c,d,e) \
     static std::unique_ptr<Name> from_bytes(mutils::DeserializationManager* dsm, uint8_t const * buf){ \
@@ -370,7 +958,7 @@
         bytes_read += mutils::bytes_size(*c_obj); \
         auto d_obj = mutils::from_bytes<std::decay_t<decltype(d)> >(dsm, buf + bytes_read); \
         return std::make_unique<Name>(*a_obj,*b_obj,*c_obj,*d_obj, *(mutils::from_bytes<std::decay_t<decltype(e)> >(dsm, buf + bytes_read + mutils::bytes_size(*d_obj)))); \
-    }
+    } 
 
 #define DEFAULT_DESERIALIZE7(Name,a,b,c,d,e,f) \
     static std::unique_ptr<Name> from_bytes(mutils::DeserializationManager* dsm, uint8_t const * buf){ \
@@ -384,7 +972,7 @@
         bytes_read += mutils::bytes_size(*d_obj); \
         auto e_obj = mutils::from_bytes<std::decay_t<decltype(e)> >(dsm, buf + bytes_read); \
         return std::make_unique<Name>(*a_obj,*b_obj,*c_obj,*d_obj,*e_obj, *(mutils::from_bytes<std::decay_t<decltype(f)> >(dsm, buf + bytes_read + mutils::bytes_size(*e_obj)))); \
-    }
+    } 
 
 #define DEFAULT_DESERIALIZE8(Name,a,b,c,d,e,f,g) \
     static std::unique_ptr<Name> from_bytes(mutils::DeserializationManager* dsm, uint8_t const * buf){ \
@@ -400,7 +988,7 @@
         bytes_read += mutils::bytes_size(*e_obj); \
         auto f_obj = mutils::from_bytes<std::decay_t<decltype(f)> >(dsm, buf + bytes_read); \
         return std::make_unique<Name>(*a_obj,*b_obj,*c_obj,*d_obj,*e_obj,*f_obj, *(mutils::from_bytes<std::decay_t<decltype(g)> >(dsm, buf + bytes_read + mutils::bytes_size(*f_obj)))); \
-    }
+    } 
 
 #define DEFAULT_DESERIALIZE9(Name,a,b,c,d,e,f,g,h) \
     static std::unique_ptr<Name> from_bytes(mutils::DeserializationManager* dsm, uint8_t const * buf){ \
@@ -418,7 +1006,7 @@
         bytes_read += mutils::bytes_size(*f_obj); \
         auto g_obj = mutils::from_bytes<std::decay_t<decltype(g)> >(dsm, buf + bytes_read); \
         return std::make_unique<Name>(*a_obj,*b_obj,*c_obj,*d_obj,*e_obj,*f_obj,*g_obj, *(mutils::from_bytes<std::decay_t<decltype(h)> >(dsm, buf + bytes_read + mutils::bytes_size(*g_obj)))); \
-    }
+    } 
 
 #define DEFAULT_DESERIALIZE10(Name,a,b,c,d,e,f,g,h,i) \
     static std::unique_ptr<Name> from_bytes(mutils::DeserializationManager* dsm, uint8_t const * buf){ \
@@ -438,7 +1026,7 @@
         bytes_read += mutils::bytes_size(*g_obj); \
         auto h_obj = mutils::from_bytes<std::decay_t<decltype(h)> >(dsm, buf + bytes_read); \
         return std::make_unique<Name>(*a_obj,*b_obj,*c_obj,*d_obj,*e_obj,*f_obj,*g_obj,*h_obj, *(mutils::from_bytes<std::decay_t<decltype(i)> >(dsm, buf + bytes_read + mutils::bytes_size(*h_obj)))); \
-    }
+    } 
 
 #define DEFAULT_DESERIALIZE11(Name,a,b,c,d,e,f,g,h,i,j) \
     static std::unique_ptr<Name> from_bytes(mutils::DeserializationManager* dsm, uint8_t const * buf){ \
@@ -460,7 +1048,7 @@
         bytes_read += mutils::bytes_size(*h_obj); \
         auto i_obj = mutils::from_bytes<std::decay_t<decltype(i)> >(dsm, buf + bytes_read); \
         return std::make_unique<Name>(*a_obj,*b_obj,*c_obj,*d_obj,*e_obj,*f_obj,*g_obj,*h_obj,*i_obj, *(mutils::from_bytes<std::decay_t<decltype(j)> >(dsm, buf + bytes_read + mutils::bytes_size(*i_obj)))); \
-    }
+    } 
 
 #define DEFAULT_DESERIALIZE12(Name,a,b,c,d,e,f,g,h,i,j,k) \
     static std::unique_ptr<Name> from_bytes(mutils::DeserializationManager* dsm, uint8_t const * buf){ \
@@ -484,7 +1072,7 @@
         bytes_read += mutils::bytes_size(*i_obj); \
         auto j_obj = mutils::from_bytes<std::decay_t<decltype(j)> >(dsm, buf + bytes_read); \
         return std::make_unique<Name>(*a_obj,*b_obj,*c_obj,*d_obj,*e_obj,*f_obj,*g_obj,*h_obj,*i_obj,*j_obj, *(mutils::from_bytes<std::decay_t<decltype(k)> >(dsm, buf + bytes_read + mutils::bytes_size(*j_obj)))); \
-    }
+    } 
 
 #define DEFAULT_DESERIALIZE13(Name,a,b,c,d,e,f,g,h,i,j,k,l) \
     static std::unique_ptr<Name> from_bytes(mutils::DeserializationManager* dsm, uint8_t const * buf){ \
@@ -510,7 +1098,7 @@
         bytes_read += mutils::bytes_size(*j_obj); \
         auto k_obj = mutils::from_bytes<std::decay_t<decltype(k)> >(dsm, buf + bytes_read); \
         return std::make_unique<Name>(*a_obj,*b_obj,*c_obj,*d_obj,*e_obj,*f_obj,*g_obj,*h_obj,*i_obj,*j_obj,*k_obj, *(mutils::from_bytes<std::decay_t<decltype(l)> >(dsm, buf + bytes_read + mutils::bytes_size(*k_obj)))); \
-    }
+    } 
 
 #define DEFAULT_DESERIALIZE14(Name,a,b,c,d,e,f,g,h,i,j,k,l,m) \
     static std::unique_ptr<Name> from_bytes(mutils::DeserializationManager* dsm, uint8_t const * buf){ \
@@ -538,7 +1126,7 @@
         bytes_read += mutils::bytes_size(*k_obj); \
         auto l_obj = mutils::from_bytes<std::decay_t<decltype(l)> >(dsm, buf + bytes_read); \
         return std::make_unique<Name>(*a_obj,*b_obj,*c_obj,*d_obj,*e_obj,*f_obj,*g_obj,*h_obj,*i_obj,*j_obj,*k_obj,*l_obj, *(mutils::from_bytes<std::decay_t<decltype(m)> >(dsm, buf + bytes_read + mutils::bytes_size(*l_obj)))); \
-    }
+    } 
 
 #define DEFAULT_DESERIALIZE15(Name,a,b,c,d,e,f,g,h,i,j,k,l,m,n) \
     static std::unique_ptr<Name> from_bytes(mutils::DeserializationManager* dsm, uint8_t const * buf){ \
@@ -568,7 +1156,523 @@
         bytes_read += mutils::bytes_size(*l_obj); \
         auto m_obj = mutils::from_bytes<std::decay_t<decltype(m)> >(dsm, buf + bytes_read); \
         return std::make_unique<Name>(*a_obj,*b_obj,*c_obj,*d_obj,*e_obj,*f_obj,*g_obj,*h_obj,*i_obj,*j_obj,*k_obj,*l_obj,*m_obj, *(mutils::from_bytes<std::decay_t<decltype(n)> >(dsm, buf + bytes_read + mutils::bytes_size(*m_obj)))); \
-    }
+    } 
+
+#define DEFAULT_DESERIALIZE16(Name,a,b,c,d,e,f,g,h,i,j,k,l,m,n,o) \
+    static std::unique_ptr<Name> from_bytes(mutils::DeserializationManager* dsm, uint8_t const * buf){ \
+        auto a_obj = mutils::from_bytes<std::decay_t<decltype(a)> >(dsm, buf); \
+        std::size_t bytes_read = mutils::bytes_size(*a_obj); \
+        auto b_obj = mutils::from_bytes<std::decay_t<decltype(b)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*b_obj); \
+        auto c_obj = mutils::from_bytes<std::decay_t<decltype(c)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*c_obj); \
+        auto d_obj = mutils::from_bytes<std::decay_t<decltype(d)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*d_obj); \
+        auto e_obj = mutils::from_bytes<std::decay_t<decltype(e)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*e_obj); \
+        auto f_obj = mutils::from_bytes<std::decay_t<decltype(f)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*f_obj); \
+        auto g_obj = mutils::from_bytes<std::decay_t<decltype(g)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*g_obj); \
+        auto h_obj = mutils::from_bytes<std::decay_t<decltype(h)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*h_obj); \
+        auto i_obj = mutils::from_bytes<std::decay_t<decltype(i)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*i_obj); \
+        auto j_obj = mutils::from_bytes<std::decay_t<decltype(j)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*j_obj); \
+        auto k_obj = mutils::from_bytes<std::decay_t<decltype(k)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*k_obj); \
+        auto l_obj = mutils::from_bytes<std::decay_t<decltype(l)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*l_obj); \
+        auto m_obj = mutils::from_bytes<std::decay_t<decltype(m)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*m_obj); \
+        auto n_obj = mutils::from_bytes<std::decay_t<decltype(n)> >(dsm, buf + bytes_read); \
+        return std::make_unique<Name>(*a_obj,*b_obj,*c_obj,*d_obj,*e_obj,*f_obj,*g_obj,*h_obj,*i_obj,*j_obj,*k_obj,*l_obj,*m_obj,*n_obj, *(mutils::from_bytes<std::decay_t<decltype(o)> >(dsm, buf + bytes_read + mutils::bytes_size(*n_obj)))); \
+    } 
+
+#define DEFAULT_DESERIALIZE17(Name,a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p) \
+    static std::unique_ptr<Name> from_bytes(mutils::DeserializationManager* dsm, uint8_t const * buf){ \
+        auto a_obj = mutils::from_bytes<std::decay_t<decltype(a)> >(dsm, buf); \
+        std::size_t bytes_read = mutils::bytes_size(*a_obj); \
+        auto b_obj = mutils::from_bytes<std::decay_t<decltype(b)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*b_obj); \
+        auto c_obj = mutils::from_bytes<std::decay_t<decltype(c)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*c_obj); \
+        auto d_obj = mutils::from_bytes<std::decay_t<decltype(d)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*d_obj); \
+        auto e_obj = mutils::from_bytes<std::decay_t<decltype(e)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*e_obj); \
+        auto f_obj = mutils::from_bytes<std::decay_t<decltype(f)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*f_obj); \
+        auto g_obj = mutils::from_bytes<std::decay_t<decltype(g)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*g_obj); \
+        auto h_obj = mutils::from_bytes<std::decay_t<decltype(h)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*h_obj); \
+        auto i_obj = mutils::from_bytes<std::decay_t<decltype(i)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*i_obj); \
+        auto j_obj = mutils::from_bytes<std::decay_t<decltype(j)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*j_obj); \
+        auto k_obj = mutils::from_bytes<std::decay_t<decltype(k)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*k_obj); \
+        auto l_obj = mutils::from_bytes<std::decay_t<decltype(l)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*l_obj); \
+        auto m_obj = mutils::from_bytes<std::decay_t<decltype(m)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*m_obj); \
+        auto n_obj = mutils::from_bytes<std::decay_t<decltype(n)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*n_obj); \
+        auto o_obj = mutils::from_bytes<std::decay_t<decltype(o)> >(dsm, buf + bytes_read); \
+        return std::make_unique<Name>(*a_obj,*b_obj,*c_obj,*d_obj,*e_obj,*f_obj,*g_obj,*h_obj,*i_obj,*j_obj,*k_obj,*l_obj,*m_obj,*n_obj,*o_obj, *(mutils::from_bytes<std::decay_t<decltype(p)> >(dsm, buf + bytes_read + mutils::bytes_size(*o_obj)))); \
+    } 
+
+#define DEFAULT_DESERIALIZE18(Name,a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q) \
+    static std::unique_ptr<Name> from_bytes(mutils::DeserializationManager* dsm, uint8_t const * buf){ \
+        auto a_obj = mutils::from_bytes<std::decay_t<decltype(a)> >(dsm, buf); \
+        std::size_t bytes_read = mutils::bytes_size(*a_obj); \
+        auto b_obj = mutils::from_bytes<std::decay_t<decltype(b)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*b_obj); \
+        auto c_obj = mutils::from_bytes<std::decay_t<decltype(c)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*c_obj); \
+        auto d_obj = mutils::from_bytes<std::decay_t<decltype(d)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*d_obj); \
+        auto e_obj = mutils::from_bytes<std::decay_t<decltype(e)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*e_obj); \
+        auto f_obj = mutils::from_bytes<std::decay_t<decltype(f)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*f_obj); \
+        auto g_obj = mutils::from_bytes<std::decay_t<decltype(g)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*g_obj); \
+        auto h_obj = mutils::from_bytes<std::decay_t<decltype(h)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*h_obj); \
+        auto i_obj = mutils::from_bytes<std::decay_t<decltype(i)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*i_obj); \
+        auto j_obj = mutils::from_bytes<std::decay_t<decltype(j)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*j_obj); \
+        auto k_obj = mutils::from_bytes<std::decay_t<decltype(k)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*k_obj); \
+        auto l_obj = mutils::from_bytes<std::decay_t<decltype(l)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*l_obj); \
+        auto m_obj = mutils::from_bytes<std::decay_t<decltype(m)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*m_obj); \
+        auto n_obj = mutils::from_bytes<std::decay_t<decltype(n)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*n_obj); \
+        auto o_obj = mutils::from_bytes<std::decay_t<decltype(o)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*o_obj); \
+        auto p_obj = mutils::from_bytes<std::decay_t<decltype(p)> >(dsm, buf + bytes_read); \
+        return std::make_unique<Name>(*a_obj,*b_obj,*c_obj,*d_obj,*e_obj,*f_obj,*g_obj,*h_obj,*i_obj,*j_obj,*k_obj,*l_obj,*m_obj,*n_obj,*o_obj,*p_obj, *(mutils::from_bytes<std::decay_t<decltype(q)> >(dsm, buf + bytes_read + mutils::bytes_size(*p_obj)))); \
+    } 
+
+#define DEFAULT_DESERIALIZE19(Name,a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r) \
+    static std::unique_ptr<Name> from_bytes(mutils::DeserializationManager* dsm, uint8_t const * buf){ \
+        auto a_obj = mutils::from_bytes<std::decay_t<decltype(a)> >(dsm, buf); \
+        std::size_t bytes_read = mutils::bytes_size(*a_obj); \
+        auto b_obj = mutils::from_bytes<std::decay_t<decltype(b)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*b_obj); \
+        auto c_obj = mutils::from_bytes<std::decay_t<decltype(c)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*c_obj); \
+        auto d_obj = mutils::from_bytes<std::decay_t<decltype(d)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*d_obj); \
+        auto e_obj = mutils::from_bytes<std::decay_t<decltype(e)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*e_obj); \
+        auto f_obj = mutils::from_bytes<std::decay_t<decltype(f)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*f_obj); \
+        auto g_obj = mutils::from_bytes<std::decay_t<decltype(g)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*g_obj); \
+        auto h_obj = mutils::from_bytes<std::decay_t<decltype(h)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*h_obj); \
+        auto i_obj = mutils::from_bytes<std::decay_t<decltype(i)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*i_obj); \
+        auto j_obj = mutils::from_bytes<std::decay_t<decltype(j)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*j_obj); \
+        auto k_obj = mutils::from_bytes<std::decay_t<decltype(k)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*k_obj); \
+        auto l_obj = mutils::from_bytes<std::decay_t<decltype(l)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*l_obj); \
+        auto m_obj = mutils::from_bytes<std::decay_t<decltype(m)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*m_obj); \
+        auto n_obj = mutils::from_bytes<std::decay_t<decltype(n)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*n_obj); \
+        auto o_obj = mutils::from_bytes<std::decay_t<decltype(o)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*o_obj); \
+        auto p_obj = mutils::from_bytes<std::decay_t<decltype(p)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*p_obj); \
+        auto q_obj = mutils::from_bytes<std::decay_t<decltype(q)> >(dsm, buf + bytes_read); \
+        return std::make_unique<Name>(*a_obj,*b_obj,*c_obj,*d_obj,*e_obj,*f_obj,*g_obj,*h_obj,*i_obj,*j_obj,*k_obj,*l_obj,*m_obj,*n_obj,*o_obj,*p_obj,*q_obj, *(mutils::from_bytes<std::decay_t<decltype(r)> >(dsm, buf + bytes_read + mutils::bytes_size(*q_obj)))); \
+    } 
+
+#define DEFAULT_DESERIALIZE20(Name,a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s) \
+    static std::unique_ptr<Name> from_bytes(mutils::DeserializationManager* dsm, uint8_t const * buf){ \
+        auto a_obj = mutils::from_bytes<std::decay_t<decltype(a)> >(dsm, buf); \
+        std::size_t bytes_read = mutils::bytes_size(*a_obj); \
+        auto b_obj = mutils::from_bytes<std::decay_t<decltype(b)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*b_obj); \
+        auto c_obj = mutils::from_bytes<std::decay_t<decltype(c)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*c_obj); \
+        auto d_obj = mutils::from_bytes<std::decay_t<decltype(d)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*d_obj); \
+        auto e_obj = mutils::from_bytes<std::decay_t<decltype(e)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*e_obj); \
+        auto f_obj = mutils::from_bytes<std::decay_t<decltype(f)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*f_obj); \
+        auto g_obj = mutils::from_bytes<std::decay_t<decltype(g)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*g_obj); \
+        auto h_obj = mutils::from_bytes<std::decay_t<decltype(h)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*h_obj); \
+        auto i_obj = mutils::from_bytes<std::decay_t<decltype(i)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*i_obj); \
+        auto j_obj = mutils::from_bytes<std::decay_t<decltype(j)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*j_obj); \
+        auto k_obj = mutils::from_bytes<std::decay_t<decltype(k)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*k_obj); \
+        auto l_obj = mutils::from_bytes<std::decay_t<decltype(l)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*l_obj); \
+        auto m_obj = mutils::from_bytes<std::decay_t<decltype(m)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*m_obj); \
+        auto n_obj = mutils::from_bytes<std::decay_t<decltype(n)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*n_obj); \
+        auto o_obj = mutils::from_bytes<std::decay_t<decltype(o)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*o_obj); \
+        auto p_obj = mutils::from_bytes<std::decay_t<decltype(p)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*p_obj); \
+        auto q_obj = mutils::from_bytes<std::decay_t<decltype(q)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*q_obj); \
+        auto r_obj = mutils::from_bytes<std::decay_t<decltype(r)> >(dsm, buf + bytes_read); \
+        return std::make_unique<Name>(*a_obj,*b_obj,*c_obj,*d_obj,*e_obj,*f_obj,*g_obj,*h_obj,*i_obj,*j_obj,*k_obj,*l_obj,*m_obj,*n_obj,*o_obj,*p_obj,*q_obj,*r_obj, *(mutils::from_bytes<std::decay_t<decltype(s)> >(dsm, buf + bytes_read + mutils::bytes_size(*r_obj)))); \
+    } 
+
+#define DEFAULT_DESERIALIZE21(Name,a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t) \
+    static std::unique_ptr<Name> from_bytes(mutils::DeserializationManager* dsm, uint8_t const * buf){ \
+        auto a_obj = mutils::from_bytes<std::decay_t<decltype(a)> >(dsm, buf); \
+        std::size_t bytes_read = mutils::bytes_size(*a_obj); \
+        auto b_obj = mutils::from_bytes<std::decay_t<decltype(b)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*b_obj); \
+        auto c_obj = mutils::from_bytes<std::decay_t<decltype(c)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*c_obj); \
+        auto d_obj = mutils::from_bytes<std::decay_t<decltype(d)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*d_obj); \
+        auto e_obj = mutils::from_bytes<std::decay_t<decltype(e)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*e_obj); \
+        auto f_obj = mutils::from_bytes<std::decay_t<decltype(f)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*f_obj); \
+        auto g_obj = mutils::from_bytes<std::decay_t<decltype(g)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*g_obj); \
+        auto h_obj = mutils::from_bytes<std::decay_t<decltype(h)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*h_obj); \
+        auto i_obj = mutils::from_bytes<std::decay_t<decltype(i)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*i_obj); \
+        auto j_obj = mutils::from_bytes<std::decay_t<decltype(j)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*j_obj); \
+        auto k_obj = mutils::from_bytes<std::decay_t<decltype(k)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*k_obj); \
+        auto l_obj = mutils::from_bytes<std::decay_t<decltype(l)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*l_obj); \
+        auto m_obj = mutils::from_bytes<std::decay_t<decltype(m)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*m_obj); \
+        auto n_obj = mutils::from_bytes<std::decay_t<decltype(n)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*n_obj); \
+        auto o_obj = mutils::from_bytes<std::decay_t<decltype(o)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*o_obj); \
+        auto p_obj = mutils::from_bytes<std::decay_t<decltype(p)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*p_obj); \
+        auto q_obj = mutils::from_bytes<std::decay_t<decltype(q)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*q_obj); \
+        auto r_obj = mutils::from_bytes<std::decay_t<decltype(r)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*r_obj); \
+        auto s_obj = mutils::from_bytes<std::decay_t<decltype(s)> >(dsm, buf + bytes_read); \
+        return std::make_unique<Name>(*a_obj,*b_obj,*c_obj,*d_obj,*e_obj,*f_obj,*g_obj,*h_obj,*i_obj,*j_obj,*k_obj,*l_obj,*m_obj,*n_obj,*o_obj,*p_obj,*q_obj,*r_obj,*s_obj, *(mutils::from_bytes<std::decay_t<decltype(t)> >(dsm, buf + bytes_read + mutils::bytes_size(*s_obj)))); \
+    } 
+
+#define DEFAULT_DESERIALIZE22(Name,a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t,u) \
+    static std::unique_ptr<Name> from_bytes(mutils::DeserializationManager* dsm, uint8_t const * buf){ \
+        auto a_obj = mutils::from_bytes<std::decay_t<decltype(a)> >(dsm, buf); \
+        std::size_t bytes_read = mutils::bytes_size(*a_obj); \
+        auto b_obj = mutils::from_bytes<std::decay_t<decltype(b)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*b_obj); \
+        auto c_obj = mutils::from_bytes<std::decay_t<decltype(c)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*c_obj); \
+        auto d_obj = mutils::from_bytes<std::decay_t<decltype(d)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*d_obj); \
+        auto e_obj = mutils::from_bytes<std::decay_t<decltype(e)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*e_obj); \
+        auto f_obj = mutils::from_bytes<std::decay_t<decltype(f)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*f_obj); \
+        auto g_obj = mutils::from_bytes<std::decay_t<decltype(g)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*g_obj); \
+        auto h_obj = mutils::from_bytes<std::decay_t<decltype(h)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*h_obj); \
+        auto i_obj = mutils::from_bytes<std::decay_t<decltype(i)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*i_obj); \
+        auto j_obj = mutils::from_bytes<std::decay_t<decltype(j)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*j_obj); \
+        auto k_obj = mutils::from_bytes<std::decay_t<decltype(k)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*k_obj); \
+        auto l_obj = mutils::from_bytes<std::decay_t<decltype(l)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*l_obj); \
+        auto m_obj = mutils::from_bytes<std::decay_t<decltype(m)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*m_obj); \
+        auto n_obj = mutils::from_bytes<std::decay_t<decltype(n)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*n_obj); \
+        auto o_obj = mutils::from_bytes<std::decay_t<decltype(o)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*o_obj); \
+        auto p_obj = mutils::from_bytes<std::decay_t<decltype(p)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*p_obj); \
+        auto q_obj = mutils::from_bytes<std::decay_t<decltype(q)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*q_obj); \
+        auto r_obj = mutils::from_bytes<std::decay_t<decltype(r)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*r_obj); \
+        auto s_obj = mutils::from_bytes<std::decay_t<decltype(s)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*s_obj); \
+        auto t_obj = mutils::from_bytes<std::decay_t<decltype(t)> >(dsm, buf + bytes_read); \
+        return std::make_unique<Name>(*a_obj,*b_obj,*c_obj,*d_obj,*e_obj,*f_obj,*g_obj,*h_obj,*i_obj,*j_obj,*k_obj,*l_obj,*m_obj,*n_obj,*o_obj,*p_obj,*q_obj,*r_obj,*s_obj,*t_obj, *(mutils::from_bytes<std::decay_t<decltype(u)> >(dsm, buf + bytes_read + mutils::bytes_size(*t_obj)))); \
+    } 
+
+#define DEFAULT_DESERIALIZE23(Name,a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t,u,v) \
+    static std::unique_ptr<Name> from_bytes(mutils::DeserializationManager* dsm, uint8_t const * buf){ \
+        auto a_obj = mutils::from_bytes<std::decay_t<decltype(a)> >(dsm, buf); \
+        std::size_t bytes_read = mutils::bytes_size(*a_obj); \
+        auto b_obj = mutils::from_bytes<std::decay_t<decltype(b)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*b_obj); \
+        auto c_obj = mutils::from_bytes<std::decay_t<decltype(c)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*c_obj); \
+        auto d_obj = mutils::from_bytes<std::decay_t<decltype(d)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*d_obj); \
+        auto e_obj = mutils::from_bytes<std::decay_t<decltype(e)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*e_obj); \
+        auto f_obj = mutils::from_bytes<std::decay_t<decltype(f)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*f_obj); \
+        auto g_obj = mutils::from_bytes<std::decay_t<decltype(g)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*g_obj); \
+        auto h_obj = mutils::from_bytes<std::decay_t<decltype(h)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*h_obj); \
+        auto i_obj = mutils::from_bytes<std::decay_t<decltype(i)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*i_obj); \
+        auto j_obj = mutils::from_bytes<std::decay_t<decltype(j)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*j_obj); \
+        auto k_obj = mutils::from_bytes<std::decay_t<decltype(k)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*k_obj); \
+        auto l_obj = mutils::from_bytes<std::decay_t<decltype(l)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*l_obj); \
+        auto m_obj = mutils::from_bytes<std::decay_t<decltype(m)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*m_obj); \
+        auto n_obj = mutils::from_bytes<std::decay_t<decltype(n)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*n_obj); \
+        auto o_obj = mutils::from_bytes<std::decay_t<decltype(o)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*o_obj); \
+        auto p_obj = mutils::from_bytes<std::decay_t<decltype(p)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*p_obj); \
+        auto q_obj = mutils::from_bytes<std::decay_t<decltype(q)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*q_obj); \
+        auto r_obj = mutils::from_bytes<std::decay_t<decltype(r)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*r_obj); \
+        auto s_obj = mutils::from_bytes<std::decay_t<decltype(s)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*s_obj); \
+        auto t_obj = mutils::from_bytes<std::decay_t<decltype(t)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*t_obj); \
+        auto u_obj = mutils::from_bytes<std::decay_t<decltype(u)> >(dsm, buf + bytes_read); \
+        return std::make_unique<Name>(*a_obj,*b_obj,*c_obj,*d_obj,*e_obj,*f_obj,*g_obj,*h_obj,*i_obj,*j_obj,*k_obj,*l_obj,*m_obj,*n_obj,*o_obj,*p_obj,*q_obj,*r_obj,*s_obj,*t_obj,*u_obj, *(mutils::from_bytes<std::decay_t<decltype(v)> >(dsm, buf + bytes_read + mutils::bytes_size(*u_obj)))); \
+    } 
+
+#define DEFAULT_DESERIALIZE24(Name,a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t,u,v,w) \
+    static std::unique_ptr<Name> from_bytes(mutils::DeserializationManager* dsm, uint8_t const * buf){ \
+        auto a_obj = mutils::from_bytes<std::decay_t<decltype(a)> >(dsm, buf); \
+        std::size_t bytes_read = mutils::bytes_size(*a_obj); \
+        auto b_obj = mutils::from_bytes<std::decay_t<decltype(b)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*b_obj); \
+        auto c_obj = mutils::from_bytes<std::decay_t<decltype(c)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*c_obj); \
+        auto d_obj = mutils::from_bytes<std::decay_t<decltype(d)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*d_obj); \
+        auto e_obj = mutils::from_bytes<std::decay_t<decltype(e)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*e_obj); \
+        auto f_obj = mutils::from_bytes<std::decay_t<decltype(f)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*f_obj); \
+        auto g_obj = mutils::from_bytes<std::decay_t<decltype(g)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*g_obj); \
+        auto h_obj = mutils::from_bytes<std::decay_t<decltype(h)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*h_obj); \
+        auto i_obj = mutils::from_bytes<std::decay_t<decltype(i)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*i_obj); \
+        auto j_obj = mutils::from_bytes<std::decay_t<decltype(j)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*j_obj); \
+        auto k_obj = mutils::from_bytes<std::decay_t<decltype(k)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*k_obj); \
+        auto l_obj = mutils::from_bytes<std::decay_t<decltype(l)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*l_obj); \
+        auto m_obj = mutils::from_bytes<std::decay_t<decltype(m)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*m_obj); \
+        auto n_obj = mutils::from_bytes<std::decay_t<decltype(n)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*n_obj); \
+        auto o_obj = mutils::from_bytes<std::decay_t<decltype(o)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*o_obj); \
+        auto p_obj = mutils::from_bytes<std::decay_t<decltype(p)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*p_obj); \
+        auto q_obj = mutils::from_bytes<std::decay_t<decltype(q)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*q_obj); \
+        auto r_obj = mutils::from_bytes<std::decay_t<decltype(r)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*r_obj); \
+        auto s_obj = mutils::from_bytes<std::decay_t<decltype(s)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*s_obj); \
+        auto t_obj = mutils::from_bytes<std::decay_t<decltype(t)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*t_obj); \
+        auto u_obj = mutils::from_bytes<std::decay_t<decltype(u)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*u_obj); \
+        auto v_obj = mutils::from_bytes<std::decay_t<decltype(v)> >(dsm, buf + bytes_read); \
+        return std::make_unique<Name>(*a_obj,*b_obj,*c_obj,*d_obj,*e_obj,*f_obj,*g_obj,*h_obj,*i_obj,*j_obj,*k_obj,*l_obj,*m_obj,*n_obj,*o_obj,*p_obj,*q_obj,*r_obj,*s_obj,*t_obj,*u_obj,*v_obj, *(mutils::from_bytes<std::decay_t<decltype(w)> >(dsm, buf + bytes_read + mutils::bytes_size(*v_obj)))); \
+    } 
+
+#define DEFAULT_DESERIALIZE25(Name,a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t,u,v,w,x) \
+    static std::unique_ptr<Name> from_bytes(mutils::DeserializationManager* dsm, uint8_t const * buf){ \
+        auto a_obj = mutils::from_bytes<std::decay_t<decltype(a)> >(dsm, buf); \
+        std::size_t bytes_read = mutils::bytes_size(*a_obj); \
+        auto b_obj = mutils::from_bytes<std::decay_t<decltype(b)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*b_obj); \
+        auto c_obj = mutils::from_bytes<std::decay_t<decltype(c)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*c_obj); \
+        auto d_obj = mutils::from_bytes<std::decay_t<decltype(d)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*d_obj); \
+        auto e_obj = mutils::from_bytes<std::decay_t<decltype(e)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*e_obj); \
+        auto f_obj = mutils::from_bytes<std::decay_t<decltype(f)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*f_obj); \
+        auto g_obj = mutils::from_bytes<std::decay_t<decltype(g)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*g_obj); \
+        auto h_obj = mutils::from_bytes<std::decay_t<decltype(h)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*h_obj); \
+        auto i_obj = mutils::from_bytes<std::decay_t<decltype(i)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*i_obj); \
+        auto j_obj = mutils::from_bytes<std::decay_t<decltype(j)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*j_obj); \
+        auto k_obj = mutils::from_bytes<std::decay_t<decltype(k)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*k_obj); \
+        auto l_obj = mutils::from_bytes<std::decay_t<decltype(l)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*l_obj); \
+        auto m_obj = mutils::from_bytes<std::decay_t<decltype(m)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*m_obj); \
+        auto n_obj = mutils::from_bytes<std::decay_t<decltype(n)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*n_obj); \
+        auto o_obj = mutils::from_bytes<std::decay_t<decltype(o)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*o_obj); \
+        auto p_obj = mutils::from_bytes<std::decay_t<decltype(p)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*p_obj); \
+        auto q_obj = mutils::from_bytes<std::decay_t<decltype(q)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*q_obj); \
+        auto r_obj = mutils::from_bytes<std::decay_t<decltype(r)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*r_obj); \
+        auto s_obj = mutils::from_bytes<std::decay_t<decltype(s)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*s_obj); \
+        auto t_obj = mutils::from_bytes<std::decay_t<decltype(t)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*t_obj); \
+        auto u_obj = mutils::from_bytes<std::decay_t<decltype(u)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*u_obj); \
+        auto v_obj = mutils::from_bytes<std::decay_t<decltype(v)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*v_obj); \
+        auto w_obj = mutils::from_bytes<std::decay_t<decltype(w)> >(dsm, buf + bytes_read); \
+        return std::make_unique<Name>(*a_obj,*b_obj,*c_obj,*d_obj,*e_obj,*f_obj,*g_obj,*h_obj,*i_obj,*j_obj,*k_obj,*l_obj,*m_obj,*n_obj,*o_obj,*p_obj,*q_obj,*r_obj,*s_obj,*t_obj,*u_obj,*v_obj,*w_obj, *(mutils::from_bytes<std::decay_t<decltype(x)> >(dsm, buf + bytes_read + mutils::bytes_size(*w_obj)))); \
+    } 
+
+#define DEFAULT_DESERIALIZE26(Name,a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t,u,v,w,x,y) \
+    static std::unique_ptr<Name> from_bytes(mutils::DeserializationManager* dsm, uint8_t const * buf){ \
+        auto a_obj = mutils::from_bytes<std::decay_t<decltype(a)> >(dsm, buf); \
+        std::size_t bytes_read = mutils::bytes_size(*a_obj); \
+        auto b_obj = mutils::from_bytes<std::decay_t<decltype(b)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*b_obj); \
+        auto c_obj = mutils::from_bytes<std::decay_t<decltype(c)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*c_obj); \
+        auto d_obj = mutils::from_bytes<std::decay_t<decltype(d)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*d_obj); \
+        auto e_obj = mutils::from_bytes<std::decay_t<decltype(e)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*e_obj); \
+        auto f_obj = mutils::from_bytes<std::decay_t<decltype(f)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*f_obj); \
+        auto g_obj = mutils::from_bytes<std::decay_t<decltype(g)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*g_obj); \
+        auto h_obj = mutils::from_bytes<std::decay_t<decltype(h)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*h_obj); \
+        auto i_obj = mutils::from_bytes<std::decay_t<decltype(i)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*i_obj); \
+        auto j_obj = mutils::from_bytes<std::decay_t<decltype(j)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*j_obj); \
+        auto k_obj = mutils::from_bytes<std::decay_t<decltype(k)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*k_obj); \
+        auto l_obj = mutils::from_bytes<std::decay_t<decltype(l)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*l_obj); \
+        auto m_obj = mutils::from_bytes<std::decay_t<decltype(m)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*m_obj); \
+        auto n_obj = mutils::from_bytes<std::decay_t<decltype(n)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*n_obj); \
+        auto o_obj = mutils::from_bytes<std::decay_t<decltype(o)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*o_obj); \
+        auto p_obj = mutils::from_bytes<std::decay_t<decltype(p)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*p_obj); \
+        auto q_obj = mutils::from_bytes<std::decay_t<decltype(q)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*q_obj); \
+        auto r_obj = mutils::from_bytes<std::decay_t<decltype(r)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*r_obj); \
+        auto s_obj = mutils::from_bytes<std::decay_t<decltype(s)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*s_obj); \
+        auto t_obj = mutils::from_bytes<std::decay_t<decltype(t)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*t_obj); \
+        auto u_obj = mutils::from_bytes<std::decay_t<decltype(u)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*u_obj); \
+        auto v_obj = mutils::from_bytes<std::decay_t<decltype(v)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*v_obj); \
+        auto w_obj = mutils::from_bytes<std::decay_t<decltype(w)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*w_obj); \
+        auto x_obj = mutils::from_bytes<std::decay_t<decltype(x)> >(dsm, buf + bytes_read); \
+        return std::make_unique<Name>(*a_obj,*b_obj,*c_obj,*d_obj,*e_obj,*f_obj,*g_obj,*h_obj,*i_obj,*j_obj,*k_obj,*l_obj,*m_obj,*n_obj,*o_obj,*p_obj,*q_obj,*r_obj,*s_obj,*t_obj,*u_obj,*v_obj,*w_obj,*x_obj, *(mutils::from_bytes<std::decay_t<decltype(y)> >(dsm, buf + bytes_read + mutils::bytes_size(*x_obj)))); \
+    } 
+
+#define DEFAULT_DESERIALIZE27(Name,a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t,u,v,w,x,y,z) \
+    static std::unique_ptr<Name> from_bytes(mutils::DeserializationManager* dsm, uint8_t const * buf){ \
+        auto a_obj = mutils::from_bytes<std::decay_t<decltype(a)> >(dsm, buf); \
+        std::size_t bytes_read = mutils::bytes_size(*a_obj); \
+        auto b_obj = mutils::from_bytes<std::decay_t<decltype(b)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*b_obj); \
+        auto c_obj = mutils::from_bytes<std::decay_t<decltype(c)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*c_obj); \
+        auto d_obj = mutils::from_bytes<std::decay_t<decltype(d)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*d_obj); \
+        auto e_obj = mutils::from_bytes<std::decay_t<decltype(e)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*e_obj); \
+        auto f_obj = mutils::from_bytes<std::decay_t<decltype(f)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*f_obj); \
+        auto g_obj = mutils::from_bytes<std::decay_t<decltype(g)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*g_obj); \
+        auto h_obj = mutils::from_bytes<std::decay_t<decltype(h)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*h_obj); \
+        auto i_obj = mutils::from_bytes<std::decay_t<decltype(i)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*i_obj); \
+        auto j_obj = mutils::from_bytes<std::decay_t<decltype(j)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*j_obj); \
+        auto k_obj = mutils::from_bytes<std::decay_t<decltype(k)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*k_obj); \
+        auto l_obj = mutils::from_bytes<std::decay_t<decltype(l)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*l_obj); \
+        auto m_obj = mutils::from_bytes<std::decay_t<decltype(m)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*m_obj); \
+        auto n_obj = mutils::from_bytes<std::decay_t<decltype(n)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*n_obj); \
+        auto o_obj = mutils::from_bytes<std::decay_t<decltype(o)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*o_obj); \
+        auto p_obj = mutils::from_bytes<std::decay_t<decltype(p)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*p_obj); \
+        auto q_obj = mutils::from_bytes<std::decay_t<decltype(q)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*q_obj); \
+        auto r_obj = mutils::from_bytes<std::decay_t<decltype(r)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*r_obj); \
+        auto s_obj = mutils::from_bytes<std::decay_t<decltype(s)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*s_obj); \
+        auto t_obj = mutils::from_bytes<std::decay_t<decltype(t)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*t_obj); \
+        auto u_obj = mutils::from_bytes<std::decay_t<decltype(u)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*u_obj); \
+        auto v_obj = mutils::from_bytes<std::decay_t<decltype(v)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*v_obj); \
+        auto w_obj = mutils::from_bytes<std::decay_t<decltype(w)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*w_obj); \
+        auto x_obj = mutils::from_bytes<std::decay_t<decltype(x)> >(dsm, buf + bytes_read); \
+        bytes_read += mutils::bytes_size(*x_obj); \
+        auto y_obj = mutils::from_bytes<std::decay_t<decltype(y)> >(dsm, buf + bytes_read); \
+        return std::make_unique<Name>(*a_obj,*b_obj,*c_obj,*d_obj,*e_obj,*f_obj,*g_obj,*h_obj,*i_obj,*j_obj,*k_obj,*l_obj,*m_obj,*n_obj,*o_obj,*p_obj,*q_obj,*r_obj,*s_obj,*t_obj,*u_obj,*v_obj,*w_obj,*x_obj,*y_obj, *(mutils::from_bytes<std::decay_t<decltype(z)> >(dsm, buf + bytes_read + mutils::bytes_size(*y_obj)))); \
+    } 
 
 
 #define DEFAULT_SERIALIZE_IMPL2(count, ...) DEFAULT_SERIALIZE ## count (__VA_ARGS__)

--- a/include/derecho/mutils-serialization/SerializationSupport.hpp
+++ b/include/derecho/mutils-serialization/SerializationSupport.hpp
@@ -9,6 +9,10 @@
 #include <mutils/type_utils.hpp>
 #include <tuple>
 #include <vector>
+#include <set>
+#include <unordered_set>
+#include <map>
+#include <unordered_map>
 
 // BEGIN DECLARATIONS AND USAGE INFORMATION
 
@@ -274,6 +278,42 @@ std::size_t bytes_size(const std::set<T>& s) {
 }
 
 /**
+ * All the elements of the hashset, plus one int for the number of elements.
+ */
+template <typename T>
+std::size_t bytes_size(const std::unordered_set<T>& s) {
+    int size = sizeof(int);
+    for(auto& a : s) {
+        size += bytes_size(a);
+    }
+    return size;
+}
+
+/**
+ * All the elements of the hashset, plus one int for the number of elements.
+ */
+template <typename T>
+std::size_t bytes_size(const std::multiset<T>& s) {
+    int size = sizeof(int);
+    for(auto& a : s) {
+        size += bytes_size(a);
+    }
+    return size;
+}
+
+/**
+ * All the elements of the hashset, plus one int for the number of elements.
+ */
+template <typename T>
+std::size_t bytes_size(const std::unordered_multiset<T>& s) {
+    int size = sizeof(int);
+    for(auto& a : s) {
+        size += bytes_size(a);
+    }
+    return size;
+}
+
+/**
  * Sums the size of each key and value in the map, plus one int for the
  * number of entries
  */
@@ -293,6 +333,34 @@ std::size_t bytes_size(const std::map<K, V>& m) {
  */
 template <typename K, typename V>
 std::size_t bytes_size(const std::unordered_map<K, V>& m) {
+    int size = sizeof(int);
+    for(const auto& p : m) {
+        size += bytes_size(p.first);
+        size += bytes_size(p.second);
+    }
+    return size;
+}
+
+/**
+ * Sums the size of each key and value in the multimap, plus one int for the
+ * number of entries
+ */
+template <typename K, typename V>
+std::size_t bytes_size(const std::multimap<K, V>& m) {
+    int size = sizeof(int);
+    for(const auto& p : m) {
+        size += bytes_size(p.first);
+        size += bytes_size(p.second);
+    }
+    return size;
+}
+
+/**
+ * Sums the size of each key and value in the multimap, plus one int for the
+ * number of entries
+ */
+template <typename K, typename V>
+std::size_t bytes_size(const std::unordered_multimap<K, V>& m) {
     int size = sizeof(int);
     for(const auto& p : m) {
         size += bytes_size(p.first);
@@ -510,6 +578,15 @@ struct is_list<std::list<T>> : std::true_type {};
 template <typename T>
 struct is_list<const std::list<T>> : std::true_type {};
 
+template <typename T>
+struct is_set<std::unordered_set<T>> : std::true_type {};
+
+template <typename T>
+struct is_set<std::multiset<T>> : std::true_type {};
+
+template <typename T>
+struct is_set<std::unordered_multiset<T>> : std::true_type {};
+
 template <typename>
 struct is_map : std::false_type {};
 
@@ -519,6 +596,12 @@ struct is_map<std::map<K, V>> : std::true_type {};
 template <typename K, typename V>
 struct is_map<const std::map<K, V>> : std::true_type {};
 
+template <typename K, typename V>
+struct is_map<std::multimap<K, V>> : std::true_type {};
+
+template <typename K, typename V>
+struct is_map<const std::multimap<K, V>> : std::true_type {};
+
 template <typename>
 struct is_unordered_map : std::false_type {};
 
@@ -527,6 +610,12 @@ struct is_unordered_map<std::unordered_map<K, V>> : std::true_type {};
 
 template <typename K, typename V>
 struct is_unordered_map<const std::unordered_map<K, V>> : std::true_type {};
+
+template <typename K, typename V>
+struct is_unordered_map<std::unordered_multimap<K, V>> : std::true_type {};
+
+template <typename K, typename V>
+struct is_unordered_map<const std::unordered_multimap<K, V>> : std::true_type {};
 
 template <typename>
 struct is_string : std::false_type {};
@@ -578,13 +667,33 @@ template <typename T>
 void post_object(const std::function<void(uint8_t const* const, std::size_t)>& consumer,
                  const std::set<T>& s);
 
+template <typename T>
+void post_object(const std::function<void(uint8_t const* const, std::size_t)>& consumer,
+                 const std::unordered_set<T>& s);
+
+template <typename T>
+void post_object(const std::function<void(uint8_t const* const, std::size_t)>& consumer,
+                 const std::multiset<T>& s);
+
+template <typename T>
+void post_object(const std::function<void(uint8_t const* const, std::size_t)>& consumer,
+                 const std::unordered_multiset<T>& s);
+
 template <typename K, typename V>
 void post_object(const std::function<void(uint8_t const* const, std::size_t)>& consumer,
                  const std::map<K, V>& map);
 
 template <typename K, typename V>
 void post_object(const std::function<void(uint8_t const* const, std::size_t)>& consumer,
+                 const std::multimap<K, V>& map);
+
+template <typename K, typename V>
+void post_object(const std::function<void(uint8_t const* const, std::size_t)>& consumer,
                  const std::unordered_map<K, V>& map);
+
+template <typename K, typename V>
+void post_object(const std::function<void(uint8_t const* const, std::size_t)>& consumer,
+                 const std::unordered_multimap<K, V>& map);
 
 // Forward declarations of to_bytes functions for STL types
 
@@ -608,11 +717,26 @@ std::size_t to_bytes(const std::tuple<T...>& tuple, uint8_t* buffer);
 template <typename T>
 std::size_t to_bytes(const std::set<T>& s, uint8_t* buffer);
 
+template <typename T>
+std::size_t to_bytes(const std::unordered_set<T>& s, uint8_t* buffer);
+
+template <typename T>
+std::size_t to_bytes(const std::multiset<T>& s, uint8_t* buffer);
+
+template <typename T>
+std::size_t to_bytes(const std::unordered_multiset<T>& s, uint8_t* buffer);
+
 template <typename K, typename V>
 std::size_t to_bytes(const std::map<K, V>& m, uint8_t* buffer);
 
 template <typename K, typename V>
+std::size_t to_bytes(const std::multimap<K, V>& m, uint8_t* buffer);
+
+template <typename K, typename V>
 std::size_t to_bytes(const std::unordered_map<K, V>& m, uint8_t* buffer);
+
+template <typename K, typename V>
+std::size_t to_bytes(const std::unordered_multimap<K, V>& m, uint8_t* buffer);
 
 // Forward declarations of from_bytes functions for STL types
 
@@ -778,6 +902,36 @@ void post_object(const std::function<void(uint8_t const* const, std::size_t)>& c
     }
 }
 
+template <typename T>
+void post_object(const std::function<void(uint8_t const* const, std::size_t)>& consumer,
+                 const std::unordered_set<T>& s) {
+    int size = s.size();
+    consumer((uint8_t*)&size, sizeof(size));
+    for(const auto& a : s) {
+        post_object(consumer, a);
+    }
+}
+
+template <typename T>
+void post_object(const std::function<void(uint8_t const* const, std::size_t)>& consumer,
+                 const std::multiset<T>& s) {
+    int size = s.size();
+    consumer((uint8_t*)&size, sizeof(size));
+    for(const auto& a : s) {
+        post_object(consumer, a);
+    }
+}
+
+template <typename T>
+void post_object(const std::function<void(uint8_t const* const, std::size_t)>& consumer,
+                 const std::unordered_multiset<T>& s) {
+    int size = s.size();
+    consumer((uint8_t*)&size, sizeof(size));
+    for(const auto& a : s) {
+        post_object(consumer, a);
+    }
+}
+
 template <typename K, typename V>
 void post_object(const std::function<void(uint8_t const* const, std::size_t)>& consumer,
                  const std::map<K, V>& map) {
@@ -791,7 +945,29 @@ void post_object(const std::function<void(uint8_t const* const, std::size_t)>& c
 
 template <typename K, typename V>
 void post_object(const std::function<void(uint8_t const* const, std::size_t)>& consumer,
+                 const std::multimap<K, V>& map) {
+    int size = map.size();
+    consumer((uint8_t*)&size, sizeof(size));
+    for(const auto& pair : map) {
+        post_object(consumer, pair.first);
+        post_object(consumer, pair.second);
+    }
+}
+
+template <typename K, typename V>
+void post_object(const std::function<void(uint8_t const* const, std::size_t)>& consumer,
                  const std::unordered_map<K, V>& map) {
+    int size = map.size();
+    consumer((uint8_t*)&size, sizeof(size));
+    for(const auto& pair : map) {
+        post_object(consumer, pair.first);
+        post_object(consumer, pair.second);
+    }
+}
+
+template <typename K, typename V>
+void post_object(const std::function<void(uint8_t const* const, std::size_t)>& consumer,
+                 const std::unordered_multimap<K, V>& map) {
     int size = map.size();
     consumer((uint8_t*)&size, sizeof(size));
     for(const auto& pair : map) {
@@ -881,6 +1057,36 @@ std::size_t to_bytes(const std::set<T>& s, uint8_t* buffer) {
     return bsize;
 }
 
+template <typename T>
+std::size_t to_bytes(const std::unordered_set<T>& s, uint8_t* buffer) {
+    int set_size = s.size();
+    std::size_t bsize = to_bytes(set_size,buffer);
+    for (const auto& e: s) {
+        bsize += to_bytes(e, buffer+bsize);
+    }
+    return bsize;
+}
+
+template <typename T>
+std::size_t to_bytes(const std::multiset<T>& s, uint8_t* buffer) {
+    int set_size = s.size();
+    std::size_t bsize = to_bytes(set_size,buffer);
+    for (const auto& e: s) {
+        bsize += to_bytes(e, buffer+bsize);
+    }
+    return bsize;
+}
+
+template <typename T>
+std::size_t to_bytes(const std::unordered_multiset<T>& s, uint8_t* buffer) {
+    int set_size = s.size();
+    std::size_t bsize = to_bytes(set_size,buffer);
+    for (const auto& e: s) {
+        bsize += to_bytes(e, buffer+bsize);
+    }
+    return bsize;
+}
+
 template <typename K, typename V>
 std::size_t to_bytes(const std::map<K, V>& m, uint8_t* buffer) {
     int map_size = m.size();
@@ -893,7 +1099,29 @@ std::size_t to_bytes(const std::map<K, V>& m, uint8_t* buffer) {
 }
 
 template <typename K, typename V>
+std::size_t to_bytes(const std::multimap<K, V>& m, uint8_t* buffer) {
+    int map_size = m.size();
+    std::size_t bsize = to_bytes(map_size,buffer);
+    for (const auto& e: m) {
+        bsize += to_bytes(e.first,buffer+bsize);
+        bsize += to_bytes(e.second,buffer+bsize);
+    }
+    return bsize;
+}
+
+template <typename K, typename V>
 std::size_t to_bytes(const std::unordered_map<K, V>& m, uint8_t* buffer) {
+    int map_size = m.size();
+    std::size_t bsize = to_bytes(map_size,buffer);
+    for (const auto& e: m) {
+        bsize += to_bytes(e.first,buffer+bsize);
+        bsize += to_bytes(e.second,buffer+bsize);
+    }
+    return bsize;
+}
+
+template <typename K, typename V>
+std::size_t to_bytes(const std::unordered_multimap<K, V>& m, uint8_t* buffer) {
     int map_size = m.size();
     std::size_t bsize = to_bytes(map_size,buffer);
     for (const auto& e: m) {
@@ -929,6 +1157,24 @@ void ensure_registered(const std::pair<L, R>& v, DeserializationManager& dm) {
 
 template <typename T>
 void ensure_registered(const std::set<T>& v, DeserializationManager& dm) {
+    for(auto& e : v)
+        ensure_registered(e, dm);
+}
+
+template <typename T>
+void ensure_registered(const std::unordered_set<T>& v, DeserializationManager& dm) {
+    for(auto& e : v)
+        ensure_registered(e, dm);
+}
+
+template <typename T>
+void ensure_registered(const std::multiset<T>& v, DeserializationManager& dm) {
+    for(auto& e : v)
+        ensure_registered(e, dm);
+}
+
+template <typename T>
+void ensure_registered(const std::unordered_multiset<T>& v, DeserializationManager& dm) {
     for(auto& e : v)
         ensure_registered(e, dm);
 }
@@ -1030,7 +1276,7 @@ std::enable_if_t<is_set<std::remove_cv_t<T>>::value, std::unique_ptr<T>>
 from_bytes(DeserializationManager* ctx, const uint8_t* _buffer) {
     int size = ((int*)_buffer)[0];
     const uint8_t* buffer = _buffer + sizeof(int);
-    auto r = std::make_unique<std::set<typename T::key_type>>();
+    auto r = std::make_unique<std::remove_cv_t<T>>();
     for(int i = 0; i < size; ++i) {
         auto e = from_bytes<typename T::key_type>(ctx, buffer);
         buffer += bytes_size(*e);

--- a/include/derecho/mutils-serialization/generate_macros.py
+++ b/include/derecho/mutils-serialization/generate_macros.py
@@ -96,7 +96,7 @@ args = argparser.parse_args()
 
 with open(OUTPUT_FILENAME, 'w') as output:
     output.write(pragma_once)
-    output.write(include_header.format(path='"../mutils/macro_utils.hpp"'))
+    output.write(include_header.format(path='<mutils/macro_utils.hpp>'))
     output.write(header_comments)
     # First, generate the serializers
     for curr_num_fields in range(1,args.num_fields+1):

--- a/src/mutils-serialization/serialization-test.cpp
+++ b/src/mutils-serialization/serialization-test.cpp
@@ -10,6 +10,7 @@
 #include <string>
 #include <tuple>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 /**
  * @cond DoxygenSuppressed
@@ -26,31 +27,51 @@ struct TestObject : public mutils::ByteRepresentable {
     std::pair<std::uint32_t, std::uint64_t> test_pair;
     std::tuple<int, std::string, std::uint64_t> test_tuple;
     std::set<int> test_set;
+    std::unordered_set<int> test_hashset;
+    std::multiset<int> test_multiset;
+    std::unordered_multiset<int> test_hashmultiset;
     std::list<int> test_list;
     std::vector<int> test_vector;
     std::map<int, std::string> test_map;
+    std::multimap<int, std::string> test_multimap;
     std::unordered_map<int, std::string> test_hashmap;
+    std::unordered_multimap<int, std::string> test_hashmultimap;
     PODStruct test_pod;
     TestObject(int i, const std::string& str, const std::pair<std::uint32_t, std::uint64_t> p,
                const std::tuple<int, std::string, std::uint64_t>& t, const std::set<int>& s,
+               const std::unordered_set<int>& hs,
+               const std::multiset<int>& ms,
+               const std::unordered_multiset<int>& hms,
                const std::list<int>& l, const std::vector<int>& v, const std::map<int, std::string>& m,
-               const std::unordered_map<int, std::string>& u, const PODStruct& pod)
+               const std::multimap<int, std::string>& mm,
+               const std::unordered_map<int, std::string>& u, 
+               const std::unordered_multimap<int, std::string>& hmm,
+               const PODStruct& pod)
         : test_int(i),
           test_string(str),
           test_pair(p),
           test_tuple(t),
           test_set(s),
+          test_hashset(hs),
+          test_multiset(ms),
+          test_hashmultiset(hms),
           test_list(l),
           test_vector(v),
           test_map(m),
+          test_multimap(mm),
           test_hashmap(u),
+          test_hashmultimap(hmm),
           test_pod(pod) {}
 
     // Mostly use DEFAULT_SERIALIZATION_SUPPORT, but don't use the default from_bytes_noalloc
     DEFAULT_SERIALIZE(test_int, test_string, test_pair, test_tuple,
-                      test_set, test_list, test_vector, test_map, test_hashmap, test_pod);
+                      test_set, test_hashset, test_multiset, test_hashmultiset,
+                      test_list, test_vector, test_map, test_multimap, test_hashmap,
+                      test_hashmultimap, test_pod);
     DEFAULT_DESERIALIZE(TestObject, test_int, test_string, test_pair, test_tuple,
-                        test_set, test_list, test_vector, test_map, test_hashmap, test_pod);
+                        test_set, test_hashset, test_multiset, test_hashmultiset,
+                        test_list, test_vector, test_map, test_multimap, test_hashmap,
+                        test_hashmultimap, test_pod);
     // Provide a from_bytes_noalloc that recursively calls from_bytes_noalloc so we actually test from_bytes_noalloc
     static mutils::context_ptr<TestObject> from_bytes_noalloc(mutils::DeserializationManager* dsm, uint8_t const* buf) {
         auto int_ptr = mutils::from_bytes_noalloc<int>(dsm, buf);
@@ -63,18 +84,30 @@ struct TestObject : public mutils::ByteRepresentable {
         bytes_read += mutils::bytes_size(*tuple_ptr);
         auto set_ptr = mutils::from_bytes_noalloc<std::set<int>>(dsm, buf + bytes_read);
         bytes_read += mutils::bytes_size(*set_ptr);
+        auto hashset_ptr = mutils::from_bytes_noalloc<std::unordered_set<int>>(dsm, buf + bytes_read);
+        bytes_read += mutils::bytes_size(*hashset_ptr);
+        auto multiset_ptr = mutils::from_bytes_noalloc<std::multiset<int>>(dsm, buf + bytes_read);
+        bytes_read += mutils::bytes_size(*multiset_ptr);
+        auto hashmultiset_ptr = mutils::from_bytes_noalloc<std::unordered_multiset<int>>(dsm, buf + bytes_read);
+        bytes_read += mutils::bytes_size(*hashmultiset_ptr);
         auto list_ptr = mutils::from_bytes_noalloc<std::list<int>>(dsm, buf + bytes_read);
         bytes_read += mutils::bytes_size(*list_ptr);
         auto vec_ptr = mutils::from_bytes_noalloc<std::vector<int>>(dsm, buf + bytes_read);
         bytes_read += mutils::bytes_size(*vec_ptr);
         auto map_ptr = mutils::from_bytes_noalloc<std::map<int, std::string>>(dsm, buf + bytes_read);
         bytes_read += mutils::bytes_size(*map_ptr);
+        auto multimap_ptr = mutils::from_bytes_noalloc<std::multimap<int, std::string>>(dsm, buf + bytes_read);
+        bytes_read += mutils::bytes_size(*multimap_ptr);
         auto hashmap_ptr = mutils::from_bytes_noalloc<std::unordered_map<int, std::string>>(dsm, buf + bytes_read);
         bytes_read += mutils::bytes_size(*hashmap_ptr);
+        auto hashmultimap_ptr = mutils::from_bytes_noalloc<std::unordered_multimap<int, std::string>>(dsm, buf + bytes_read);
+        bytes_read += mutils::bytes_size(*hashmultimap_ptr);
         auto pod_ptr = mutils::from_bytes_noalloc<PODStruct>(dsm, buf + bytes_read);
         bytes_read += mutils::bytes_size(*pod_ptr);
         return mutils::context_ptr<TestObject>(new TestObject(*int_ptr, *string_ptr, *pair_ptr, *tuple_ptr, *set_ptr,
-                                                              *list_ptr, *vec_ptr, *map_ptr, *hashmap_ptr, *pod_ptr));
+                                                              *hashset_ptr, *multiset_ptr, *hashmultiset_ptr,
+                                                              *list_ptr, *vec_ptr, *map_ptr, *multimap_ptr, *hashmap_ptr,
+                                                              *hashmultimap_ptr, *pod_ptr));
     };
     static mutils::context_ptr<const TestObject> from_bytes_noalloc_const(mutils::DeserializationManager* dsm, uint8_t const* buf) {
         auto int_ptr = mutils::from_bytes_noalloc<const int>(dsm, buf);
@@ -87,18 +120,30 @@ struct TestObject : public mutils::ByteRepresentable {
         bytes_read += mutils::bytes_size(*tuple_ptr);
         auto set_ptr = mutils::from_bytes_noalloc<const std::set<int>>(dsm, buf + bytes_read);
         bytes_read += mutils::bytes_size(*set_ptr);
+        auto hashset_ptr = mutils::from_bytes_noalloc<std::unordered_set<int>>(dsm, buf + bytes_read);
+        bytes_read += mutils::bytes_size(*hashset_ptr);
+        auto multiset_ptr = mutils::from_bytes_noalloc<std::multiset<int>>(dsm, buf + bytes_read);
+        bytes_read += mutils::bytes_size(*multiset_ptr);
+        auto hashmultiset_ptr = mutils::from_bytes_noalloc<std::unordered_multiset<int>>(dsm, buf + bytes_read);
+        bytes_read += mutils::bytes_size(*hashmultiset_ptr);
         auto list_ptr = mutils::from_bytes_noalloc<const std::list<int>>(dsm, buf + bytes_read);
         bytes_read += mutils::bytes_size(*list_ptr);
         auto vec_ptr = mutils::from_bytes_noalloc<const std::vector<int>>(dsm, buf + bytes_read);
         bytes_read += mutils::bytes_size(*vec_ptr);
         auto map_ptr = mutils::from_bytes_noalloc<const std::map<int, std::string>>(dsm, buf + bytes_read);
         bytes_read += mutils::bytes_size(*map_ptr);
+        auto multimap_ptr = mutils::from_bytes_noalloc<std::multimap<int, std::string>>(dsm, buf + bytes_read);
+        bytes_read += mutils::bytes_size(*multimap_ptr);
         auto hashmap_ptr = mutils::from_bytes_noalloc<const std::unordered_map<int, std::string>>(dsm, buf + bytes_read);
         bytes_read += mutils::bytes_size(*hashmap_ptr);
+        auto hashmultimap_ptr = mutils::from_bytes_noalloc<std::unordered_multimap<int, std::string>>(dsm, buf + bytes_read);
+        bytes_read += mutils::bytes_size(*hashmultimap_ptr);
         auto pod_ptr = mutils::from_bytes_noalloc<const PODStruct>(dsm, buf + bytes_read);
         bytes_read += mutils::bytes_size(*pod_ptr);
         return mutils::context_ptr<const TestObject>(new TestObject(*int_ptr, *string_ptr, *pair_ptr, *tuple_ptr, *set_ptr,
-                                                                    *list_ptr, *vec_ptr, *map_ptr, *hashmap_ptr, *pod_ptr));
+                                                                    *hashset_ptr, *multiset_ptr, *hashmultiset_ptr,
+                                                                    *list_ptr, *vec_ptr, *map_ptr, *multimap_ptr, *hashmap_ptr,
+                                                                    *hashmultimap_ptr, *pod_ptr));
     }
 
     void ensure_registered(mutils::DeserializationManager&){};
@@ -110,10 +155,15 @@ bool operator==(const TestObject& lhs, const TestObject& rhs) {
            lhs.test_pair == rhs.test_pair &&
            lhs.test_tuple == rhs.test_tuple &&
            lhs.test_set == rhs.test_set &&
+           lhs.test_hashset == rhs.test_hashset &&
+           lhs.test_multiset == rhs.test_multiset &&
+           lhs.test_hashmultiset == rhs.test_hashmultiset &&
            lhs.test_list == rhs.test_list &&
            lhs.test_vector == rhs.test_vector &&
            lhs.test_map == rhs.test_map &&
+           lhs.test_multimap == rhs.test_multimap &&
            lhs.test_hashmap == rhs.test_hashmap &&
+           lhs.test_hashmultimap == rhs.test_hashmultimap &&
            lhs.test_pod.field_one == rhs.test_pod.field_one &&
            lhs.test_pod.field_two == rhs.test_pod.field_two &&
            lhs.test_pod.a_bool == rhs.test_pod.a_bool;
@@ -129,6 +179,18 @@ int test_object_function(const TestObject& arg) {
         std::cout << i << ",";
     }
     std::cout << "}, {";
+    for(const auto& i : arg.test_hashset) {
+        std::cout << i << ",";
+    }
+    std::cout << "}, {";
+    for(const auto& i : arg.test_multiset) {
+        std::cout << i << ",";
+    }
+    std::cout << "}, {";
+    for(const auto& i : arg.test_hashmultiset) {
+        std::cout << i << ",";
+    }
+    std::cout << "}, {";
     for(const auto& i : arg.test_list) {
         std::cout << i << ",";
     }
@@ -141,7 +203,15 @@ int test_object_function(const TestObject& arg) {
         std::cout << "{" << entry.first << " => " << entry.second << "}, ";
     }
     std::cout << "}, {";
+    for(const auto& entry : arg.test_multimap) {
+        std::cout << "{" << entry.first << " => " << entry.second << "}, ";
+    }
+    std::cout << "}, {";
     for(const auto& entry : arg.test_hashmap) {
+        std::cout << "{" << entry.first << " => " << entry.second << "}, ";
+    }
+    std::cout << "}, {";
+    for(const auto& entry : arg.test_hashmultimap) {
         std::cout << "{" << entry.first << " => " << entry.second << "}, ";
     }
     std::cout << "}, PODStruct{" << arg.test_pod.field_one << ", " << arg.test_pod.field_two << ", " << arg.test_pod.a_bool << "} }" << std::endl;
@@ -152,9 +222,12 @@ int main(int argc, char** argv) {
     mutils::DeserializationManager dsm{{}};
     TestObject obj(123456789, "Foo", {666666, 88888888},
                    {-987654321, "Bar", 12345678909876543210ull},
-                   {5, 6, 7, 8}, {1, 2, 3, 4}, {9, 9, 9, 9, 9},
+                   {5, 6, 7, 8}, {9, 10, 11, 12}, {5, 5, 6, 6}, {7, 7, 8, 8},
+                   {1, 2, 3, 4}, {9, 9, 9, 9, 9},
                    {{1, "One"}, {2, "Two"}, {3, "Three"}},
+                   {{10,"TEN"}, {10,"Ten"}, {10, "ten"}},
                    {{4, "Four"}, {5, "Five"}, {6, "Six"}, {7, "Seven"}},
+                   {{11,"ELEVEN"},{11,"Eleven"},{11,"eleven"}},
                    PODStruct{-1, -2, false});
     std::unique_ptr<TestObject> deserialized_obj;
     std::size_t buffer_size = mutils::bytes_size(obj);


### PR DESCRIPTION
The new supported STL containers include the following:
- unordered_set
- multiset
- unordered_multiset
- multimap
- unordered_multimap

This pull request has been unit-tested.