### PR TITLE
Upgrade spdlog dependency to 1.12

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,7 @@ find_package(mutils REQUIRED)
 find_package(mutils-containers REQUIRED)
 
 # Target: spdlog::spdlog
-find_package(spdlog 1.3.1...1.9.2 REQUIRED)
+find_package(spdlog 1.12.0 REQUIRED)
 
 # Target: OpenSSL::Crypto and OpenSSL::ssl
 find_package(OpenSSL 1.1.1 REQUIRED)

--- a/derechoConfig.cmake
+++ b/derechoConfig.cmake
@@ -5,7 +5,7 @@ include(CMakeFindDependencyMacro)
 # we need to ensure these targets are forwarded to downstream projects that depend on Derecho
 find_dependency(mutils)
 find_dependency(mutils-containers)
-find_dependency(spdlog 1.3.1)
+find_dependency(spdlog 1.12.0)
 find_dependency(OpenSSL 1.1.1)
 find_dependency(nlohmann_json 3.9.0)
 

--- a/include/derecho/utils/logger.hpp
+++ b/include/derecho/utils/logger.hpp
@@ -9,6 +9,7 @@
 #include <atomic>
 #include <spdlog/spdlog.h>
 #include <spdlog/fmt/ostr.h>
+#include <spdlog/fmt/ranges.h>
 #include <spdlog/sinks/rotating_file_sink.h>
 #include <spdlog/sinks/stdout_color_sinks.h>
 

--- a/src/applications/tests/unit_tests/client_callback_mockup.hpp
+++ b/src/applications/tests/unit_tests/client_callback_mockup.hpp
@@ -76,6 +76,9 @@ enum class ClientCallbackType {
 
 std::ostream& operator<<(std::ostream& os, const ClientCallbackType& cb_type);
 
+template <>
+struct fmt::formatter<ClientCallbackType> : fmt::ostream_formatter {};
+
 /**
  * Structure used by StorageNode to pass callback requests from the
  * register_callback RPC function to the callback-sending thread.


### PR DESCRIPTION
The spdlog library introduced some non-backward-compatible changes between version 1.9.2 (packaged with Ubuntu 22.04) and version 1.12 (packaged with Ubuntu 24.04). Specifically, standard library containers are only log-printable if the new header `<spdlog/fmt/ranges.h>` is included, and user-defined types are only log-printable if they explicitly specialize `fmt::formatter<T>`  -- including `<spdlog/fmt/ostr.h>` and defining an `operator<<` for your type, as done in spdlog 1.9.2, is no longer sufficient.

I updated the code to compile against spdlog 1.12, and updated CMakeLists to specify spdlog 1.12 as the new minimum required version, because the header `<spdlog/fmt/ranges.h>` doesn't exist in spdlog 1.9.2. Since this changes Derecho's required dependencies, it should go into a new version of Derecho, hopefully 2.4.1.