### PR TITLE
Updated README and removed an erroneous assert

### DIFF
--- a/src/conf/CMakeLists.txt
+++ b/src/conf/CMakeLists.txt
@@ -11,5 +11,5 @@ target_include_directories(conftst PRIVATE
 )
 target_link_libraries(conftst pthread nlohmann_json::nlohmann_json)
 
-install(FILES derecho-sample.cfg
+install(FILES derecho-sample.cfg derecho_node-sample.cfg
     DESTINATION share/derecho/)

--- a/src/core/persistence_manager.cpp
+++ b/src/core/persistence_manager.cpp
@@ -159,7 +159,6 @@ void PersistenceManager::handle_persist_request(subgroup_id_t subgroup_id, persi
                     persisted_version = search->second->persist();
                     dbg_trace(persistence_logger, "PersistenceManager: Asked Replicated to persist latest version, version actually persisted = {}", persisted_version);
                 }
-                assert(persisted_version >= version);
             }
         }
         // Call the local persistence callbacks before updating the SST
@@ -293,6 +292,7 @@ void PersistenceManager::make_version(const subgroup_id_t& subgroup_id,
                                       const persistent::version_t& version, const HLC& mhlc) {
     auto search = objects_by_subgroup_id.find(subgroup_id);
     if(search != objects_by_subgroup_id.end()) {
+        dbg_debug(persistence_logger, "PersistenceManager: Making version {} in subgroup {}", version, subgroup_id);
         search->second->make_version(version, mhlc);
     }
 }

--- a/src/persistent/Persistent.cpp
+++ b/src/persistent/Persistent.cpp
@@ -27,6 +27,7 @@ PersistentRegistry::~PersistentRegistry() {
 };
 
 void PersistentRegistry::makeVersion(version_t ver, const HLC& mhlc) {
+    dbg_trace(m_logger, "PersistentRegistry: makeVersion({}, hlc({},{}))", ver, mhlc.m_rtc_us, mhlc.m_logic);
     for(auto& entry : m_registry) {
         entry.second->version(ver, mhlc);
     }


### PR DESCRIPTION
The README section on configuration files was out-of-date, and still referred to the old "leader_ip" and "leader_port" options which no longer exist. I fixed it and added an explanation of the new "per-node config" feature (derecho_node.cfg), which was also missing.

Also, I noticed while testing that an assert in persistence_manager could actually fail during correct behavior, because I misunderstood the invariants of persistence requests and persist() calls. It's possible for persisted_version to be less than the parameter version, if the parameter version corresponds to a null message (which does not create a log entry). When a persistence request is posted, the argument version is just the current version at the time the request was posted, not the latest non-null version; thus it's not true that persist() will always persist up to the persistence request's parameter version.