### PR TITLE
Update spdlog usage to remain compatible with the latest version

### DIFF
--- a/include/derecho/core/detail/p2p_connection.hpp
+++ b/include/derecho/core/detail/p2p_connection.hpp
@@ -185,3 +185,11 @@ public:
 
 };
 }  // namespace sst
+
+/**
+ * Formatter template specialization specifying that sst::MESSAGE_TYPE should
+ * be converted to a string using its ostream operator. Boilerplate needed by
+ * the spdlog library.
+ */
+template <>
+struct fmt::formatter<sst::MESSAGE_TYPE> : fmt::ostream_formatter {};

--- a/include/derecho/utils/logger.hpp
+++ b/include/derecho/utils/logger.hpp
@@ -10,6 +10,7 @@
 #include <spdlog/spdlog.h>
 #include <spdlog/fmt/ostr.h>
 #include <spdlog/fmt/ranges.h>
+#include <spdlog/fmt/std.h>
 #include <spdlog/sinks/rotating_file_sink.h>
 #include <spdlog/sinks/stdout_color_sinks.h>
 

--- a/src/applications/tests/unit_tests/persistence_notification_test.cpp
+++ b/src/applications/tests/unit_tests/persistence_notification_test.cpp
@@ -86,7 +86,7 @@ void StorageNode::notification_thread_function() {
         for(auto requests_iter = requests_by_version.begin();
             requests_iter != requests_by_version.end();) {
             persistent::version_t requested_version = requests_iter->first;
-            dbg_default_debug("Notification thread checking a notification of type {} for version {}", requests_iter->second.notification_type, requested_version);
+            dbg_default_debug("Notification thread checking a notification of type {} for version {}", static_cast<uint64_t>(requests_iter->second.notification_type), requested_version);
             bool requested_event_happened = false;
             {
                 std::unique_lock<std::mutex> query_results_lock(notification_thread_mutex);

--- a/src/core/git_version.cpp
+++ b/src/core/git_version.cpp
@@ -6,15 +6,15 @@
  * local repository's .git/hooks/ directory.
  */
 
-#include <derecho/core/git_version.hpp>
+#include "derecho/core/git_version.hpp"
 
 namespace derecho {
 
 const int MAJOR_VERSION = 2;
 const int MINOR_VERSION = 4;
 const int PATCH_VERSION = 1;
-const int COMMITS_AHEAD_OF_VERSION = 0;
+const int COMMITS_AHEAD_OF_VERSION = 2;
 const char* VERSION_STRING = "2.4.1";
-const char* VERSION_STRING_PLUS_COMMITS = "2.4.1+0";
+const char* VERSION_STRING_PLUS_COMMITS = "2.4.1+2";
 
 }


### PR DESCRIPTION
The latest version of spdlog (1.15) depends on a newer version of fmt (11.1) that is slightly pickier about how it finds formatters for some data types (like atomics and enums). This change allows Derecho to compile with spdlog 1.15 while preserving backward compatibility with spdlog 1.12.