### PR TITLE
Added debug log output for derecho.cfg options

### DIFF
--- a/include/derecho/conf/conf.hpp
+++ b/include/derecho/conf/conf.hpp
@@ -27,7 +27,6 @@ public:
     //String constants for config options
     static constexpr const char* DERECHO_CONTACT_IP = "DERECHO/contact_ip";
     static constexpr const char* DERECHO_CONTACT_PORT = "DERECHO/contact_port";
-    static constexpr const char* DERECHO_LEADER_EXTERNAL_PORT = "DERECHO/leader_external_port";
     static constexpr const char* DERECHO_RESTART_LEADERS = "DERECHO/restart_leaders";
     static constexpr const char* DERECHO_RESTART_LEADER_PORTS = "DERECHO/restart_leader_ports";
     static constexpr const char* DERECHO_LOCAL_ID = "DERECHO/local_id";
@@ -85,7 +84,6 @@ private:
             // [DERECHO]
             {DERECHO_CONTACT_IP, "127.0.0.1"},
             {DERECHO_CONTACT_PORT, "23580"},
-            {DERECHO_LEADER_EXTERNAL_PORT, "32645"},
             {DERECHO_RESTART_LEADERS, "127.0.0.1"},
             {DERECHO_RESTART_LEADER_PORTS, "23580"},
             {DERECHO_LOCAL_ID, "0"},
@@ -126,7 +124,7 @@ private:
             {PERS_PRIVATE_KEY_FILE, "private_key.pem"},
             // [LOGGER]
             {LOGGER_DEFAULT_LOG_NAME, "derecho_debug"},
-            {LOGGER_DEFAULT_LOG_LEVEL, "info"},
+            {LOGGER_DEFAULT_LOG_LEVEL, "debug"},
             {LOGGER_LOG_TO_TERMINAL, "true"},
             {LOGGER_LOG_FILE_DEPTH, "3"}};
 
@@ -206,6 +204,8 @@ public:
     const bool hasCustomizedKey(const std::string& key) const {
         return (this->config.find(key) != this->config.end());
     }
+    /** Returns a string representation of all configuration options in the table, for debugging purposes. */
+    std::string getDebugString() const;
     /**
      * Initialize the singleton from the command line and the configuration files.
      * The command line has higher priority than the configuration files, and the

--- a/include/derecho/core/detail/group_impl.hpp
+++ b/include/derecho/core/detail/group_impl.hpp
@@ -10,10 +10,6 @@
 #include "derecho_internal.hpp"
 #include "make_kind_map.hpp"
 
-#include <spdlog/async.h>
-#include <spdlog/sinks/rotating_file_sink.h>
-#include <spdlog/sinks/stdout_color_sinks.h>
-
 namespace derecho {
 
 template <typename SubgroupType>
@@ -28,7 +24,7 @@ template <typename SubgroupType>
 uint32_t _Group::get_subgroup_max_payload_size(uint32_t subgroup_num) {
     if (auto gptr = dynamic_cast<GroupProjection<SubgroupType>*>(this)) {
         return gptr->get_subgroup_max_payload_size(subgroup_num);
-    } else 
+    } else
         throw derecho_exception("Error: this top-level group contains no subgroups for the selected type.");
 }
 
@@ -205,6 +201,7 @@ Group<ReplicatedTypes...>::Group(const UserMessageCallbacks& callbacks,
 #else
           factories(make_kind_map<Factory>(factories...)) {
 #endif
+    dbg_default_debug("Starting with configuration options:\n{}", Conf::get()->getDebugString());
     bool in_total_restart = view_manager.first_init();
     // State transfer must complete before an initial view can commit, and must retry if the view is aborted
     bool initial_view_confirmed = false;

--- a/src/core/git_version.cpp
+++ b/src/core/git_version.cpp
@@ -13,8 +13,8 @@ namespace derecho {
 const int MAJOR_VERSION = 2;
 const int MINOR_VERSION = 4;
 const int PATCH_VERSION = 1;
-const int COMMITS_AHEAD_OF_VERSION = 2;
+const int COMMITS_AHEAD_OF_VERSION = 4;
 const char* VERSION_STRING = "2.4.1";
-const char* VERSION_STRING_PLUS_COMMITS = "2.4.1+2";
+const char* VERSION_STRING_PLUS_COMMITS = "2.4.1+4";
 
 }


### PR DESCRIPTION
It's really hard to notice if Derecho fails to load derecho.cfg because it will silently fall back to all-default values for the config options. To help users debug this, I added a debug-level log statement in the Group constructor that prints out all the actual config options that are in memory, and changed the fallback default log level to "debug" instead of "info" so those value will get printed out even if derecho.cfg fails to load. I also added a console print statement to print a warning if none of derecho.cfg, derecho_node.cfg, or command-line parameters are present; the Conf constructor can't use Logger so console printing is the only way to notify the user that something might be wrong.