### PR TITLE
Fix prerequisites installation scripts

### DIFF
--- a/scripts/prerequisites/install-json.sh
+++ b/scripts/prerequisites/install-json.sh
@@ -14,6 +14,6 @@ git clone https://github.com/nlohmann/json.git
 cd json
 git checkout v3.11.3
 cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=${INSTALL_PREFIX} .
-make -j `lscpu | grep "^CPU(" | awk '{print $2}'`
+make -j `nproc`
 make install
 rm -rf ${WORKPATH}

--- a/scripts/prerequisites/install-libfabric.sh
+++ b/scripts/prerequisites/install-libfabric.sh
@@ -20,6 +20,6 @@ git apply ${SCRIPTPATH}/libfabric.patch
 libtoolize
 ./autogen.sh
 ./configure --prefix=${INSTALL_PREFIX} --disable-memhooks-monitor --disable-spinlock
-make -j `lscpu | grep "^CPU(" | awk '{print $2}'`
+make -j `nproc`
 make install
 rm -rf ${WORKPATH}

--- a/scripts/prerequisites/install-mutils-containers.sh
+++ b/scripts/prerequisites/install-mutils-containers.sh
@@ -20,6 +20,6 @@ git checkout e3dd51fdb6dcbe42532250b5d670b3e0f74f015c
 mkdir build
 cd build
 cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=${INSTALL_PREFIX} ..
-make -j `lscpu | grep "^CPU(" | awk '{print $2}'`
+make -j `nproc`
 make install
 rm -rf ${WORKPATH}

--- a/scripts/prerequisites/install-mutils.sh
+++ b/scripts/prerequisites/install-mutils.sh
@@ -19,6 +19,6 @@ git checkout 81e16d898d1f58a2ce4e58253d4b397783866357
 mkdir build
 cd build
 cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=${INSTALL_PREFIX} ..
-make -j `lscpu | grep "^CPU(" | awk '{print $2}'`
+make -j `nproc`
 make install
 rm -rf ${WORKPATH}


### PR DESCRIPTION
Dear Derecho team,

I found the Derecho project quite interesting and powerful. Thank you for the continuous effort on this awesome project! When I was following the instructions to set up the project on the local machine, I found that the installtion scripts didn't work. Basically, `lscpu` outputs a "CPU(s) scaling MHz" line on my machines, which breaked the script. So, I created this pull request to fix the issue by using `nproc` instead.
