### PR TITLE
Minor updates to compile under GCC 15

### DIFF
--- a/include/derecho/tcp/tcp.hpp
+++ b/include/derecho/tcp/tcp.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <derecho/config.h>
+#include <cstdint>
 #include <functional>
 #include <memory>
 #include <optional>

--- a/include/derecho/utils/logger.hpp
+++ b/include/derecho/utils/logger.hpp
@@ -7,6 +7,7 @@
 
 #include <string>
 #include <atomic>
+#include <cstdint>
 #include <spdlog/spdlog.h>
 #include <spdlog/fmt/ostr.h>
 #include <spdlog/fmt/ranges.h>

--- a/src/conf/conf.cpp
+++ b/src/conf/conf.cpp
@@ -123,7 +123,7 @@ void Conf::initialize(int argc, char* argv[], const char* conf_file, const char*
         Conf::singleton->config.try_emplace(LOGGER_PERSISTENCE_LOG_LEVEL, default_log_level);
 
         // 4 - set the flag to initialized
-        Conf::singleton_initialized_flag.store(CONF_INITIALIZED, std::memory_order_acq_rel);
+        Conf::singleton_initialized_flag.store(CONF_INITIALIZED, std::memory_order_release);
 
         // 5 - check the configuration for sanity
         if(hasCustomizedConfKey(LAYOUT_JSON_LAYOUT) && hasCustomizedConfKey(LAYOUT_JSON_LAYOUT_FILE)) {

--- a/src/core/connection_manager.cpp
+++ b/src/core/connection_manager.cpp
@@ -1,5 +1,6 @@
 #include <derecho/core/detail/connection_manager.hpp>
 
+#include <algorithm>
 #include <cassert>
 #include <iostream>
 #include <set>

--- a/src/persistent/logger.cpp
+++ b/src/persistent/logger.cpp
@@ -19,7 +19,7 @@ void PersistLogger::initialize() {
     if(initialize_state.compare_exchange_strong(expected, logger_initializing, std::memory_order_acq_rel)) {
         logger = LoggerFactory::createLogger(LoggerFactory::PERSISTENT_LOGGER_NAME,
                                              derecho::getConfString(derecho::Conf::LOGGER_PERSISTENCE_LOG_LEVEL));
-        initialize_state.store(logger_initialized, std::memory_order_acq_rel);
+        initialize_state.store(logger_initialized, std::memory_order_release);
     }
     while(initialize_state.load(std::memory_order_acquire) != logger_initialized) {
     }

--- a/src/utils/logger.cpp
+++ b/src/utils/logger.cpp
@@ -8,6 +8,7 @@
 #include <spdlog/sinks/stdout_color_sinks.h>
 
 #include <atomic>
+#include <cassert>
 #include <memory>
 
 #define LOGGER_FACTORY_UNINITIALIZED	(0)
@@ -66,7 +67,7 @@ void LoggerFactory::_initialize() {
         _default_logger = _create_logger(default_logger_name,
             spdlog::level::from_str(default_log_level));
         // 3 - change state to initialized
-        _initialize_state.store(LOGGER_FACTORY_INITIALIZED,std::memory_order_acq_rel);
+        _initialize_state.store(LOGGER_FACTORY_INITIALIZED,std::memory_order_release);
         auto start_ms = std::chrono::duration_cast<std::chrono::microseconds>(
             std::chrono::high_resolution_clock::now().time_since_epoch());
         _default_logger->debug("Program start time (microseconds): {}", start_ms.count());


### PR DESCRIPTION
I recently updated to Ubuntu 26.04, which comes with a newer GCC (15.2.0). This version of GCC is more pedantic about the correct usage of `std::memory_order` values and caught a few instances where we used `memory_order_acq_rel` when we should have used `memory_order_release`. It also caught a few missing `#include`s, which I fixed.